### PR TITLE
variable: use dot for namespace rather than forward-slash.

### DIFF
--- a/internal/pkg/variable/cli.go
+++ b/internal/pkg/variable/cli.go
@@ -12,7 +12,7 @@ import (
 func (p *Parser) parseCLIVariable(name string, rawVal string) hcl.Diagnostics {
 	// Split the name to see if we have a namespace CLI variable for a child
 	// pack and set the default packVarName.
-	splitName := strings.Split(name, "/")
+	splitName := strings.SplitN(name, ".", 2)
 	packVarName := []string{p.cfg.ParentName, name}
 
 	switch len(splitName) {
@@ -69,9 +69,10 @@ func (p *Parser) parseCLIVariable(name string, rawVal string) hcl.Diagnostics {
 
 	// We have a verified override variable.
 	v := Variable{
-		Name:  packVarName[1],
-		Type:  val.Type(),
-		Value: val,
+		Name:      packVarName[1],
+		Type:      val.Type(),
+		Value:     val,
+		DeclRange: fakeRange,
 	}
 	p.cliOverrideVars[packVarName[0]] = append(p.cliOverrideVars[packVarName[0]], &v)
 

--- a/internal/pkg/variable/cli_test.go
+++ b/internal/pkg/variable/cli_test.go
@@ -1,0 +1,131 @@
+package variable
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestParser_parseCLIVariable(t *testing.T) {
+	testCases := []struct {
+		inputParser     *Parser
+		inputName       string
+		inputRawVal     string
+		expectedError   bool
+		expectedCLIVars map[string][]*Variable
+		name            string
+	}{
+		{
+			inputParser: &Parser{
+				fs:  afero.Afero{Fs: afero.OsFs{}},
+				cfg: &ParserConfig{ParentName: "example"},
+				rootVars: map[string]map[string]*Variable{
+					"example": {
+						"region": &Variable{
+							Name:      "region",
+							Type:      cty.String,
+							Value:     cty.StringVal("vlc"),
+							DeclRange: hcl.Range{Filename: "<value for var.region from arguments>"},
+						},
+					},
+				},
+				cliOverrideVars: make(map[string][]*Variable),
+			},
+			inputName:     "region",
+			inputRawVal:   "vlc",
+			expectedError: false,
+			expectedCLIVars: map[string][]*Variable{
+				"example": {
+					{
+						Name:      "region",
+						Type:      cty.String,
+						Value:     cty.StringVal("vlc"),
+						DeclRange: hcl.Range{Filename: "<value for var.region from arguments>"},
+					},
+				},
+			},
+			name: "non-namespaced variable",
+		},
+		{
+			inputParser: &Parser{
+				fs:  afero.Afero{Fs: afero.OsFs{}},
+				cfg: &ParserConfig{ParentName: "example"},
+				rootVars: map[string]map[string]*Variable{
+					"example": {
+						"region": &Variable{
+							Name:      "region",
+							Type:      cty.String,
+							Value:     cty.StringVal("vlc"),
+							DeclRange: hcl.Range{Filename: "<value for var.region from arguments>"},
+						},
+					},
+				},
+				cliOverrideVars: make(map[string][]*Variable),
+			},
+			inputName:     "example.region",
+			inputRawVal:   "vlc",
+			expectedError: false,
+			expectedCLIVars: map[string][]*Variable{
+				"example": {
+					{
+						Name:      "region",
+						Type:      cty.String,
+						Value:     cty.StringVal("vlc"),
+						DeclRange: hcl.Range{Filename: "<value for var.example.region from arguments>"},
+					},
+				},
+			},
+			name: "namespaced variable",
+		},
+		{
+			inputParser: &Parser{
+				fs:              afero.Afero{Fs: afero.OsFs{}},
+				cfg:             &ParserConfig{ParentName: "example"},
+				rootVars:        map[string]map[string]*Variable{},
+				cliOverrideVars: make(map[string][]*Variable),
+			},
+			inputName:       "example.region",
+			inputRawVal:     "vlc",
+			expectedError:   true,
+			expectedCLIVars: map[string][]*Variable{},
+			name:            "root variable absent",
+		},
+		{
+			inputParser: &Parser{
+				fs:  afero.Afero{Fs: afero.OsFs{}},
+				cfg: &ParserConfig{ParentName: "example"},
+				rootVars: map[string]map[string]*Variable{
+					"example": {
+						"region": &Variable{
+							Name: "region",
+							Type: cty.DynamicPseudoType,
+							Value: cty.MapVal(map[string]cty.Value{
+								"region": cty.StringVal("dc1"),
+							}),
+							DeclRange: hcl.Range{Filename: "<value for var.region from arguments>"},
+						},
+					},
+				},
+				cliOverrideVars: make(map[string][]*Variable),
+			},
+			inputName:       "example.region",
+			inputRawVal:     "vlc",
+			expectedError:   true,
+			expectedCLIVars: map[string][]*Variable{},
+			name:            "unconvertable variable",
+		},
+	}
+
+	for _, tc := range testCases {
+		actualErr := tc.inputParser.parseCLIVariable(tc.inputName, tc.inputRawVal)
+		if tc.expectedError {
+			assert.NotNil(t, actualErr, tc.name)
+		} else {
+			assert.Nil(t, actualErr, tc.name)
+			assert.Equal(t, tc.expectedCLIVars, tc.inputParser.cliOverrideVars, tc.name)
+		}
+	}
+}


### PR DESCRIPTION
Added some tests 🥳 