### PR TITLE
errors: add wrapped context error for use across all CLI returns.

### DIFF
--- a/internal/pkg/errors/ui_context.go
+++ b/internal/pkg/errors/ui_context.go
@@ -1,6 +1,9 @@
 package errors
 
-import stdErrors "errors"
+import (
+	stdErrors "errors"
+	"strings"
+)
 
 // ErrNoTemplatesRendered is an error to be used when the CLI runs a render
 // process that doesn't result in parent templates. This helps provide a clear
@@ -20,6 +23,7 @@ const (
 	UIContextPrefixJobName        = "Job Name: "
 	UIContextPrefixDeploymentName = "Deployment Name: "
 	UIContextPrefixRegion         = "Region: "
+	UIContextPrefixHCLRange       = "HCL Range: "
 )
 
 // UIErrorContext is used to store and manipulate error context strings used
@@ -41,3 +45,6 @@ func (u *UIErrorContext) Copy() *UIErrorContext { return &UIErrorContext{context
 
 // GetAll returns all the stored context strings.
 func (u *UIErrorContext) GetAll() []string { return u.contexts }
+
+// String returns the stored contexts as a minimally formatted string.
+func (u *UIErrorContext) String() string { return strings.Join(u.contexts, "\n") }

--- a/internal/pkg/errors/wrapped_context.go
+++ b/internal/pkg/errors/wrapped_context.go
@@ -1,0 +1,49 @@
+package errors
+
+import (
+	stdErrors "errors"
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+)
+
+// WrappedUIContext encapsulates an error, subject, and context that can be
+// used to provide detail error outputs to the console. It is suggested that
+// any function returning an error to the CLI use this instead of a standard
+// error.
+type WrappedUIContext struct {
+
+	// Err is the full error message to store.
+	Err error
+
+	// Subject is a short, high-level summary of the error. It should avoid
+	// including complex formatting to include file names for example. These
+	// items should be added to the Context instead.
+	Subject string
+
+	// Context contains all the context required to fully understand the error
+	// and helps troubleshooting.
+	Context *UIErrorContext
+}
+
+// Error is used to satisfy to builtin.Error interface. This allows us to use
+// WrappedUIContext as an error if needed, although we should prefer to return
+// the strong type.
+func (w *WrappedUIContext) Error() string {
+	return fmt.Sprintf("%s: %v: \n%s", w.Subject, w.Err, w.Context.String())
+}
+
+// HCLDiagsToWrappedUIContext converts HCL specific hcl.Diagnostics into an
+// array of WrappedUIContext.
+func HCLDiagsToWrappedUIContext(diags hcl.Diagnostics) []*WrappedUIContext {
+	wrapped := make([]*WrappedUIContext, len(diags))
+	for i, diag := range diags {
+		wrapped[i] = &WrappedUIContext{
+			Err:     stdErrors.New(diag.Detail),
+			Subject: diag.Summary,
+			Context: NewUIErrorContext(),
+		}
+		wrapped[i].Context.Add(UIContextPrefixHCLRange, diag.Subject.String())
+	}
+	return wrapped
+}

--- a/internal/pkg/errors/wrapped_context_test.go
+++ b/internal/pkg/errors/wrapped_context_test.go
@@ -1,0 +1,65 @@
+package errors
+
+import (
+	stdErrors "errors"
+	"github.com/hashicorp/hcl/v2"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrappedUIContext_Error(t *testing.T) {
+	testCases := []struct {
+		inputWrappedUIContext *WrappedUIContext
+		expectedOutput        string
+		name                  string
+	}{
+		{
+			inputWrappedUIContext: &WrappedUIContext{
+				Err:     stdErrors.New("tis but a scratch"),
+				Subject: "the cause of camalot",
+				Context: &UIErrorContext{contexts: []string{"King: Arthur"}},
+			},
+			expectedOutput: "the cause of camalot: tis but a scratch: \nKing: Arthur",
+			name:           "basic test 1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, tc.inputWrappedUIContext.Error(), tc.name)
+		})
+	}
+}
+
+func TestWrappedUIContext_HCLDiagsToWrappedUIContext(t *testing.T) {
+	testCases := []struct {
+		inputDiags     hcl.Diagnostics
+		expectedOutput []*WrappedUIContext
+		name           string
+	}{
+		{
+			inputDiags: hcl.Diagnostics{
+				{
+					Summary: "some poor diag detail",
+					Detail:  "this is the longer detail and is the real error",
+					Subject: &hcl.Range{Filename: "test.hcl"},
+				},
+			},
+			expectedOutput: []*WrappedUIContext{
+				{
+					Err:     stdErrors.New("this is the longer detail and is the real error"),
+					Subject: "some poor diag detail",
+					Context: &UIErrorContext{contexts: []string{"HCL Range: test.hcl:0,0-0"}},
+				},
+			},
+			name: "basic test 1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tc.expectedOutput, HCLDiagsToWrappedUIContext(tc.inputDiags), tc.name)
+		})
+	}
+}


### PR DESCRIPTION
This will be used by the Deployer once added as well as the Pack Manager. It aims to provide a single, consistent way for internal processes to return complex errors to the CLI.