### PR TITLE
cli: standardize arg/flag parsing error message

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"runtime"
 
@@ -252,6 +253,15 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 	return set
 }
 
+// Returns minimal help usage message
+// Used on flag/arg parse error in c.Init method
+func (c *baseCommand) helpUsageMessage() string {
+	if c.cmdKey == "" {
+		return `See "nomad-pack --help"`
+	}
+	return fmt.Sprintf(`See "nomad-pack %s --help"`, c.cmdKey)
+}
+
 // flagSetBit is used with baseCommand.flagSet
 type flagSetBit uint
 
@@ -263,6 +273,10 @@ const (
 var (
 	// ErrSentinel is a sentinel value that we can return from Init to force an exit.
 	ErrSentinel = errors.New("error sentinel")
+
+	// ErrParsingArgsOrFlags should be used in the Init method of a CLI command
+	// if it returns an error.
+	ErrParsingArgsOrFlags = "error parsing args or flags"
 )
 
 func Humanize(err error) string {

--- a/cli/info.go
+++ b/cli/info.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 
+	flag "github.com/hashicorp/nomad-pack/flag"
 	"github.com/hashicorp/nomad-pack/internal/pkg/errors"
 	"github.com/hashicorp/nomad-pack/internal/pkg/loader"
 	"github.com/hashicorp/nomad-pack/internal/pkg/variable"
@@ -17,12 +18,15 @@ type InfoCommand struct {
 }
 
 func (c *InfoCommand) Run(args []string) int {
-	c.cmdKey = "info" // Add cmd key here so help text is available in Init
+	c.cmdKey = "info" // Add cmdKey here to print out helpUsageMessage on Init error
 	// Initialize. If we fail, we just exit since Init handles the UI.
 	if err := c.Init(
 		WithExactArgs(1, args),
+		WithFlags(c.Flags()),
 		WithNoConfig(),
 	); err != nil {
+		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		c.ui.Info(c.helpUsageMessage())
 		return 1
 	}
 
@@ -121,6 +125,10 @@ func (c *InfoCommand) Run(args []string) int {
 
 	doc.RenderFrame()
 	return 0
+}
+
+func (c *InfoCommand) Flags() *flag.Sets {
+	return c.flagSet(0, nil)
 }
 
 func (c *InfoCommand) Help() string {

--- a/cli/init.go
+++ b/cli/init.go
@@ -17,13 +17,15 @@ type InitCommand struct {
 }
 
 func (c *InitCommand) Run(args []string) int {
-	c.cmdKey = "init" // Add cmd key here so help text is available in Init
+	c.cmdKey = "init" // Add cmdKey here to print out helpUsageMessage on Init error
 	// Initialize. If we fail, we just exit since Init handles the UI.
 	if err := c.Init(
-		WithExactArgs(0, args),
+		WithNoArgs(args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
 	); err != nil {
+		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		c.ui.Info(c.helpUsageMessage())
 		return 1
 	}
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -33,6 +33,7 @@ var (
 		"run",
 		"destroy",
 		"info",
+		"status",
 		"registry add",
 		"registry delete",
 		"registry list",

--- a/cli/plan.go
+++ b/cli/plan.go
@@ -23,14 +23,15 @@ type PlanCommand struct {
 
 func (c *PlanCommand) Run(args []string) int {
 	var err error
-	c.cmdKey = "plan"
+	c.cmdKey = "plan" // Add cmdKey here to print out helpUsageMessage on Init error
 	// Initialize. If we fail, we just exit since Init handles the UI.
 	if err := c.Init(
 		WithExactArgs(1, args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
 	); err != nil {
-		c.ui.ErrorWithContext(err, "error parsing args or flags")
+		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		c.ui.Info(c.helpUsageMessage())
 		return 255
 	}
 

--- a/cli/render.go
+++ b/cli/render.go
@@ -21,10 +21,11 @@ type RenderCommand struct {
 
 // Run satisfies the Run function of the cli.Command interface.
 func (r *RenderCommand) Run(args []string) int {
-
-	r.cmdKey = "render"
+	r.cmdKey = "render" // Add cmdKey here to print out helpUsageMessage on Init error
 
 	if err := r.Init(WithExactArgs(1, args), WithFlags(r.Flags()), WithNoConfig()); err != nil {
+		r.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		r.ui.Info(r.helpUsageMessage())
 		return 1
 	}
 

--- a/cli/run.go
+++ b/cli/run.go
@@ -24,13 +24,15 @@ type RunCommand struct {
 
 func (c *RunCommand) Run(args []string) int {
 	var err error
-	c.cmdKey = "run" // Add cmd key here so help text is available in Init
+	c.cmdKey = "run" // Add cmdKey here to print out helpUsageMessage on Init error
 	// Initialize. If we fail, we just exit since Init handles the UI.
 	if err := c.Init(
 		WithExactArgs(1, args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
 	); err != nil {
+		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		c.ui.Info(c.helpUsageMessage())
 		return 1
 	}
 

--- a/cli/status.go
+++ b/cli/status.go
@@ -17,14 +17,15 @@ type StatusCommand struct {
 }
 
 func (c *StatusCommand) Run(args []string) int {
-	c.cmdKey = "status"
+	c.cmdKey = "status" // Add cmdKey here to print out helpUsageMessage on Init error
 	// Initialize. If we fail, we just exit since Init handles the UI.
 	if err := c.Init(
 		WithCustomArgs(args, validateStatusArgs),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
 	); err != nil {
-		c.ui.ErrorWithContext(err, "error parsing args or flags")
+		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		c.ui.Info(c.helpUsageMessage())
 		return 1
 	}
 

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -25,13 +25,15 @@ type StopCommand struct {
 
 func (c *StopCommand) Run(args []string) int {
 	var err error
-	c.cmdKey = "stop" // Add cmd key here so help text is available in Init
+	c.cmdKey = "stop" // Add cmdKey here to print out helpUsageMessage on Init error
 	// Initialize. If we fail, we just exit since Init handles the UI.
 	if err = c.Init(
 		WithExactArgs(1, args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),
 	); err != nil {
+		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		c.ui.Info(c.helpUsageMessage())
 		return 1
 	}
 

--- a/cli/version.go
+++ b/cli/version.go
@@ -15,7 +15,9 @@ func (c *VersionCommand) Run(args []string) int {
 	flagSet := c.Flags()
 
 	// Initialize. If we fail, we just exit since Init handles the UI.
-	if err := c.Init(WithArgs(args), WithFlags(flagSet), WithNoConfig(), WithClient(false)); err != nil {
+	if err := c.Init(WithNoArgs(args), WithFlags(flagSet), WithNoConfig(), WithClient(false)); err != nil {
+		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		c.ui.Info(c.helpUsageMessage())
 		return 1
 	}
 


### PR DESCRIPTION
As discussed, this opts for the docker approach of directing the user towards printing help instead of printing out the entire usage, which in the case of run and other flag-heavy commands, would push the error off the screen.

The only commands I didn't touch were list and repo since those are getting modified/deleted in the registry PR.

Some of our commands were returning the error using ErrorContext, some
of them were swallowing the error. This opts for using ErrorContext and
a standard parsing error message, along with minimal instructions on
using the help flag.