### PR TITLE
cli: getRegistryPath should always return an error to CLI exits.

### DIFF
--- a/cli/plan.go
+++ b/cli/plan.go
@@ -71,7 +71,6 @@ func (c *PlanCommand) Run(args []string) int {
 
 	registryPath, err := getRegistryPath(c.registryName, c.ui, errorContext)
 	if err != nil {
-		c.ui.ErrorWithContext(err, "failed to identify repository path")
 		return 255
 	}
 

--- a/cli/render.go
+++ b/cli/render.go
@@ -44,7 +44,6 @@ func (r *RenderCommand) Run(args []string) int {
 	// TODO: Refactor to context.nomad file in next phase.
 	registryPath, err := getRegistryPath(repo, r.ui, errorContext)
 	if err != nil {
-		r.ui.ErrorWithContext(err, "failed to identify repository path", errorContext.GetAll()...)
 		return 1
 	}
 

--- a/internal/pkg/errors/ui_context.go
+++ b/internal/pkg/errors/ui_context.go
@@ -24,6 +24,7 @@ const (
 	UIContextPrefixRegion         = "Region: "
 	UIContextPrefixHCLRange       = "HCL Range: "
 	UIContextPrefixRegistryName   = "Registry Name: "
+	UIContextPrefixRegistryPath   = "Registry Path: "
 )
 
 // UIErrorContext is used to store and manipulate error context strings used


### PR DESCRIPTION
This change fixes the getRegistryPath call so that all errors are
returned to the caller. This allows the CLI to correctly exit when
needed.

The change also ensures the function is soley responsible for
outputting UI errors so we do not get duplicate error messages.