### PR TITLE
manager: return array of errors for better UI output.

### DIFF
--- a/cli/helpers.go
+++ b/cli/helpers.go
@@ -344,13 +344,16 @@ func generatePackManager(c *baseCommand, client *v1.Client, registryName, pack s
 	return manager.NewPackManager(&cfg, client)
 }
 
-// Uses the pack manager to parse the templates, override template variables with var files
-// and cli vars as applicable
+// renderPack uses the pack manager to parse the templates, override template
+// variables with var files and cli vars as applicable
 func renderPack(manager *manager.PackManager, ui terminal.UI, errCtx *errors.UIErrorContext) (*renderer.Rendered, error) {
 	r, err := manager.ProcessTemplates()
 	if err != nil {
-		ui.ErrorWithContext(err, "failed to process pack ", errCtx.GetAll()...)
-		return nil, err
+		for i := range err {
+			err[i].Context.Append(errCtx)
+			ui.ErrorWithContext(err[i].Err, "failed to process pack", err[i].Context.GetAll()...)
+		}
+		return nil, stdErrors.New("failed to render")
 	}
 	return r, nil
 }


### PR DESCRIPTION
Old Output:
```
! Failed To Process Pack

	Error:   <value for var.regions from arguments>:0,0-0: Missing base variable declaration to override; There is no variable named "regions". An override file can only override a variable that was already declared in a
primary configuration file.
	Type:    hcl.Diagnostics
	Context:
	         - Pack Name: hello_world@latest
	         - Registry Name: community
	         - Registry Path: /Users/jrasell/.nomad/packs/community
	         - Pack Path: /Users/jrasell/.nomad/packs/community
```

New Output:
```
! Failed To Process Pack

	Error:   There is no variable named "regions". An override file can only override a variable that was already declared in a primary configuration file.
	Type:    *errors.errorString
	Context:
	         - HCL Range: <value for var.regions from arguments>:0,0-0
	         - Pack Name: hello_world@latest
	         - Registry Name: community
	         - Registry Path: /Users/jrasell/.nomad/packs/community
	         - Pack Path: /Users/jrasell/.nomad/packs/community
```

closes #67 