### PR TITLE
Fix Render rebase mistake

### DIFF
--- a/cli/render.go
+++ b/cli/render.go
@@ -35,6 +35,8 @@ func (c *RenderCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.packConfig.Name = c.args[0]
+
 	// Set defaults and initialize the error context.
 	errorContext := initPackCommand(c.packConfig)
 


### PR DESCRIPTION
Add back the pack name set logic that got erroneously removed during rebase.

Closes #95 