### PR TITLE
Use consistent variables for pack deployment name

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -290,7 +290,7 @@ func TestJobStop(t *testing.T) {
 	require.Equal(t, 0, exitCode)
 
 	d := &StopCommand{baseCommand: baseCommand}
-	exitCode = d.Run([]string{runCommand.packName, "--purge=true"})
+	exitCode = d.Run([]string{runCommand.packConfig.Name, "--purge=true"})
 	require.Equal(t, 0, exitCode)
 
 	os.Setenv("NOMAD_ADDR", nomadAddr)
@@ -429,11 +429,11 @@ func TestJobDestroyWithOverrides(t *testing.T) {
 
 	// Stop nonexistent job
 	d := &DestroyCommand{StopCommand: &StopCommand{baseCommand: baseCommand}}
-	exitCode := d.Run([]string{r.packName, deployName, "--var=job_name=baz"})
+	exitCode := d.Run([]string{r.packConfig.Name, deployName, "--var=job_name=baz"})
 	require.Equal(t, 1, exitCode)
 
 	// Stop job with var override
-	exitCode = d.Run([]string{r.packName, deployName, "--var=job_name=foo"})
+	exitCode = d.Run([]string{r.packConfig.Name, deployName, "--var=job_name=foo"})
 	require.Equal(t, 0, exitCode)
 
 	// Assert job "bar" still exists
@@ -444,7 +444,7 @@ func TestJobDestroyWithOverrides(t *testing.T) {
 	require.NoError(t, err)
 
 	// Stop job with no overrides passed
-	exitCode = d.Run([]string{r.packName, deployName})
+	exitCode = d.Run([]string{r.packConfig.Name, deployName})
 	require.Equal(t, 0, exitCode)
 
 	// Assert job bar is gone

--- a/cli/helpers.go
+++ b/cli/helpers.go
@@ -303,7 +303,7 @@ func getPackJobsByDeploy(jobsApi *v1.Jobs, cfg *cache.PackConfig, deploymentName
 
 		if nomadJob.Meta != nil {
 			jobMeta := *nomadJob.Meta
-			jobDeploymentName, ok := jobMeta[packDeploymentNameKey]
+			jobDeploymentName, ok := jobMeta[job.PackDeploymentNameKey]
 
 			if ok {
 				if jobDeploymentName == deploymentName {
@@ -485,7 +485,7 @@ func getDeployedPackJobs(jobsApi *v1.Jobs, cfg *cache.PackConfig, deploymentName
 			if ok && jobPackName == cfg.Name {
 				// Filter by deployment name if specified
 				if deploymentName != "" {
-					jobDeployName, deployOk := jobMeta[packDeploymentNameKey]
+					jobDeployName, deployOk := jobMeta[job.PackDeploymentNameKey]
 					if deployOk && jobDeployName != deploymentName {
 						continue
 					}
@@ -493,7 +493,7 @@ func getDeployedPackJobs(jobsApi *v1.Jobs, cfg *cache.PackConfig, deploymentName
 				packJobs = append(packJobs, JobStatusInfo{
 					packName:       cfg.Name,
 					registryName:   cfg.Registry,
-					deploymentName: jobMeta[packDeploymentNameKey],
+					deploymentName: jobMeta[job.PackDeploymentNameKey],
 					jobID:          *nomadJob.ID,
 					status:         *nomadJob.Status,
 				})

--- a/cli/run.go
+++ b/cli/run.go
@@ -295,7 +295,3 @@ func (c *RunCommand) Help() string {
 func (c *RunCommand) Synopsis() string {
 	return "Run a new pack or update an existing pack"
 }
-
-var (
-	packDeploymentNameKey = "pack_deployment_name"
-)


### PR DESCRIPTION
There was a random custom variable that was being used instead of the standard package keys, two helper functions, that resulted in no jobs being found for the pack. The variable was deleted and the functions were updated to use the package keys.