### PR TITLE
Ensure variable files exist before parsing.

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -175,7 +175,6 @@ func (c *baseCommand) Init(opts ...Option) error {
 	return nil
 }
 
-
 func (c *baseCommand) ensureCache() error {
 	// Creates global cache
 	globalCache, err := cache.NewCache(&cache.CacheConfig{
@@ -187,7 +186,7 @@ func (c *baseCommand) ensureCache() error {
 	}
 
 	// Check if default registry exists
-	_, err = os.Stat(path.Join(cache.DefaultCachePath(),cache.DefaultRegistryName))
+	_, err = os.Stat(path.Join(cache.DefaultCachePath(), cache.DefaultRegistryName))
 	// If it does not error, then the registry already exists
 	if err == nil {
 		return nil
@@ -203,7 +202,6 @@ func (c *baseCommand) ensureCache() error {
 	}
 	return nil
 }
-
 
 // flagSet creates the flags for this command. The callback should be used
 // to configure the set with your own custom options.

--- a/cli/helpers.go
+++ b/cli/helpers.go
@@ -46,7 +46,6 @@ func initPackCommand(cfg *cache.PackConfig) *errors.UIErrorContext {
 	return errorContext
 }
 
-
 // TODO: Needs code review. This seems like it should get moved to the registry
 // package, in which case all of the dependent functions likely need to get moved.
 // get the global cache directory

--- a/internal/pkg/variable/parser.go
+++ b/internal/pkg/variable/parser.go
@@ -66,7 +66,7 @@ func NewParser(cfg *ParserConfig) (*Parser, error) {
 	for _, file := range cfg.FileOverrides {
 		_, err := os.Stat(file)
 		if err != nil {
-			return nil, errors.New(fmt.Sprintf("Variable file `%s` not found", file))
+			return nil, fmt.Errorf("variable file %q not found", file)
 		}
 	}
 

--- a/internal/pkg/variable/parser.go
+++ b/internal/pkg/variable/parser.go
@@ -3,6 +3,7 @@ package variable
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -62,6 +63,12 @@ func NewParser(cfg *ParserConfig) (*Parser, error) {
 	// Sort the file overrides to ensure variable merging is consistent on
 	// multiple passes.
 	sort.Strings(cfg.FileOverrides)
+	for _, file := range cfg.FileOverrides {
+		_, err := os.Stat(file)
+		if err != nil {
+			return nil, errors.New(fmt.Sprintf("Variable file `%s` not found", file))
+		}
+	}
 
 	return &Parser{
 		fs: afero.Afero{

--- a/internal/runner/job/error.go
+++ b/internal/runner/job/error.go
@@ -50,8 +50,8 @@ func generateRegisterError(err error, errCtx *errors.UIErrorContext, jobName str
 
 	// Create our base error.
 	deployErr := errors.WrappedUIContext{
-		Err:      err,
-		Subject:  "failed to register job",
+		Err:     err,
+		Subject: "failed to register job",
 		Context: registerErr,
 	}
 


### PR DESCRIPTION
- Check that variable files passed in with the `--var-file` option exists
before attempting to parse.
- Fixes #112