### PR TITLE
pack: perform more validation on pack before processing.

### DIFF
--- a/internal/pkg/manager/manager.go
+++ b/internal/pkg/manager/manager.go
@@ -114,8 +114,8 @@ func (pm *PackManager) loadAndValidatePacks() (*pack.Pack, error) {
 		return nil, fmt.Errorf("failed to load pack: %v", err)
 	}
 
-	if err := parentPack.Metadata.Validate(); err != nil {
-		return nil, fmt.Errorf("failed to validate pack metadata: %v", err)
+	if err := parentPack.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate pack: %v", err)
 	}
 
 	// Using the input path to the parent pack, define the path where
@@ -146,8 +146,8 @@ func (pm *PackManager) loadAndValidatePack(cur *pack.Pack, depsPath string) erro
 			return fmt.Errorf("failed to load dependent pack: %v", err)
 		}
 
-		if err := dependentPack.Metadata.Validate(); err != nil {
-			return fmt.Errorf("failed to validate dependent pack metadata: %v", err)
+		if err := dependentPack.Validate(); err != nil {
+			return fmt.Errorf("failed to validate dependent pack: %v", err)
 		}
 
 		// Add the dependency to the current pack.

--- a/pkg/pack/pack.go
+++ b/pkg/pack/pack.go
@@ -1,5 +1,7 @@
 package pack
 
+import "errors"
+
 // File is an individual file component of a Pack.
 type File struct {
 
@@ -82,4 +84,20 @@ func (p *Pack) RootVariableFiles() map[string]*File {
 	}
 
 	return out
+}
+
+// Validate the pack for terminal problems that can easily be detected at this
+// stage. Anything that has potential to cause a panic should ideally be caught
+// here.
+func (p *Pack) Validate() error {
+
+	if p.RootVariableFile == nil {
+		return errors.New("root variable file is required")
+	}
+
+	if err := p.Metadata.Validate(); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
When a pack has been loaded it can go through validation to ensure
it meets basic requirement. Until now that only included metadata
validation. In situations where the root variable file was missing,
the processor would panic as the file is nil. This is now checked
in the pack validator, fixing this, and also creating a func to
continue to expand as needed.

closes #114 