### PR TITLE
fix-release-gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ bin/*
 *.test
 
 # Release binary output directory
-# pkg
+/pkg/*
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out


### PR DESCRIPTION
ignore top level pkg directory created by release automation, but include internal/pkg