### PR TITLE
makefile: add sdk isolation check and fix failure.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ api:
 	go get github.com/hashicorp/nomad-openapi/v1
 
 .PHONY: check
-check: check-mod
+check: check-mod check-sdk
 
 .PHONY: check-mod
 check-mod: ## Checks the Go mod is tidy
@@ -35,5 +35,13 @@ check-mod: ## Checks the Go mod is tidy
 		echo tools go.mod or go.sum needs updating; \
 		git --no-pager diff go.mod; \
 		git --no-pager diff go.sum; \
+		exit 1; fi
+	@echo "==> Done"
+
+.PHONY: check-sdk
+check-sdk: ## Checks the SDK is isolated
+	@echo "==> Checking SDK package is isolated..."
+	@if go list --test -f '{{ join .Deps "\n" }}' ./sdk/* | grep github.com/hashicorp/nomad-pack/ | grep -v -e /nomad-pack/sdk/ -e nomad-pack/sdk.test; \
+		then echo " /sdk package depends the ^^ above internal packages. Remove such dependency"; \
 		exit 1; fi
 	@echo "==> Done"

--- a/internal/pkg/helper/ptr/ptr.go
+++ b/internal/pkg/helper/ptr/ptr.go
@@ -1,4 +1,0 @@
-package ptr
-
-// Bool returns a pointer to the input boolean value.
-func Bool(i bool) *bool { return &i }

--- a/sdk/helper/ptr.go
+++ b/sdk/helper/ptr.go
@@ -1,0 +1,4 @@
+package helper
+
+// BoolToPtr returns a pointer to the input boolean value.
+func BoolToPtr(i bool) *bool { return &i }

--- a/sdk/pack/dependency.go
+++ b/sdk/pack/dependency.go
@@ -1,6 +1,6 @@
 package pack
 
-import "github.com/hashicorp/nomad-pack/internal/pkg/helper/ptr"
+import "github.com/hashicorp/nomad-pack/sdk/helper"
 
 // Dependency is a single dependency of a pack. A pack can have multiple and
 // each dependency represents an individual pack. A pack can be used as a
@@ -32,7 +32,7 @@ func (d *Dependency) validate() error {
 	}
 
 	if d.Enabled == nil {
-		d.Enabled = ptr.Bool(true)
+		d.Enabled = helper.BoolToPtr(true)
 	}
 	return nil
 }

--- a/sdk/pack/dependency_test.go
+++ b/sdk/pack/dependency_test.go
@@ -3,7 +3,7 @@ package pack
 import (
 	"testing"
 
-	"github.com/hashicorp/nomad-pack/internal/pkg/helper/ptr"
+	"github.com/hashicorp/nomad-pack/sdk/helper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +22,7 @@ func TestDependency_Validate(t *testing.T) {
 			expectedOutputDependency: &Dependency{
 				Name:    "example",
 				Source:  "git://example.com/example",
-				Enabled: ptr.Bool(true),
+				Enabled: helper.BoolToPtr(true),
 			},
 			name: "nil enabled input",
 		},
@@ -30,12 +30,12 @@ func TestDependency_Validate(t *testing.T) {
 			inputDependency: &Dependency{
 				Name:    "example",
 				Source:  "git://example.com/example",
-				Enabled: ptr.Bool(false),
+				Enabled: helper.BoolToPtr(false),
 			},
 			expectedOutputDependency: &Dependency{
 				Name:    "example",
 				Source:  "git://example.com/example",
-				Enabled: ptr.Bool(false),
+				Enabled: helper.BoolToPtr(false),
 			},
 			name: "false enabled input",
 		},
@@ -43,12 +43,12 @@ func TestDependency_Validate(t *testing.T) {
 			inputDependency: &Dependency{
 				Name:    "example",
 				Source:  "git://example.com/example",
-				Enabled: ptr.Bool(true),
+				Enabled: helper.BoolToPtr(true),
 			},
 			expectedOutputDependency: &Dependency{
 				Name:    "example",
 				Source:  "git://example.com/example",
-				Enabled: ptr.Bool(true),
+				Enabled: helper.BoolToPtr(true),
 			},
 			name: "false enabled input",
 		},


### PR DESCRIPTION
This adds a check to the makefile to ensure the sdk is isolated
from the rest of the nomad-pack code. As a result this also moves
the pointer helper into the sdk, as it is only used within the
sdk.