### PR TITLE
deps: run go mod tidy.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,6 @@ github.com/hashicorp/net-rpc-msgpackrpc v0.0.0-20151116020338-a14192a58a69 h1:lc
 github.com/hashicorp/net-rpc-msgpackrpc v0.0.0-20151116020338-a14192a58a69/go.mod h1:/z+jUGRBlwVpUZfjute9jWaF6/HuhjuFQuL1YXzVD1Q=
 github.com/hashicorp/nomad v1.1.4 h1:ZhxrzLJhGzJq9EEG7XFlzhlHviqij1rEzX1Nd5lj3Lk=
 github.com/hashicorp/nomad v1.1.4/go.mod h1:zb5FH723Po1AP4letahIJCeoEq+2LvIgmY21W3kXz4g=
-github.com/hashicorp/nomad-openapi v0.0.0-20210921122032-4500c39fcb76 h1:xFn/6LoQSu1970yEctG/+vP+B1K33hdfJVuGTZ0fkrI=
-github.com/hashicorp/nomad-openapi v0.0.0-20210921122032-4500c39fcb76/go.mod h1:rnXXnlwW+0rWd53S5TXub1fIj2J/uhxl63Y0NUsYSpc=
 github.com/hashicorp/nomad-openapi v0.0.0-20211018165803-33eb48e328a1 h1:fJ5/r6e40niVrqm2s3ov5ka9CLa8V2spC12aOTstX38=
 github.com/hashicorp/nomad-openapi v0.0.0-20211018165803-33eb48e328a1/go.mod h1:uxmP0+p2PqvG6K+Mhtb58uhRaeUfVT95ql3ZxWN3Dhw=
 github.com/hashicorp/nomad/api v0.0.0-20200529203653-c4416b26d3eb/go.mod h1:DCi2k47yuUDzf2qWAK8E1RVmWgz/lc0jZQeEnICTxmY=


### PR DESCRIPTION
The make check was failing:

```
==> Checking Go mod and Go sum...
tools go.mod or go.sum needs updating
diff --git a/go.sum b/go.sum
index dd3f417..e746ac3 100644
--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,6 @@ github.com/hashicorp/net-rpc-msgpackrpc v0.0.0-20151116020338-a14192a58a69 h1:lc
 github.com/hashicorp/net-rpc-msgpackrpc v0.0.0-20151116020338-a14192a58a69/go.mod h1:/z+jUGRBlwVpUZfjute9jWaF6/HuhjuFQuL1YXzVD1Q=
makefile: add sdk isolation check and fix failure.
 github.com/hashicorp/nomad v1.1.4 h1:ZhxrzLJhGzJq9EEG7XFlzhlHviqij1rEzX1Nd5lj3Lk=
 github.com/hashicorp/nomad v1.1.4/go.mod h1:zb5FH723Po1AP4letahIJCeoEq+2LvIgmY21W3kXz4g=
-github.com/hashicorp/nomad-openapi v0.0.0-20210921122032-4500c39fcb76 h1:xFn/6LoQSu1970yEctG/+vP+B1K33hdfJVuGTZ0fkrI=
-github.com/hashicorp/nomad-openapi v0.0.0-20210921122032-4500c39fcb76/go.mod h1:rnXXnlwW+0rWd53S5TXub1fIj2J/uhxl63Y0NUsYSpc=
 github.com/hashicorp/nomad-openapi v0.0.0-20211018165803-33eb48e328a1 h1:fJ5/r6e40niVrqm2s3ov5ka9CLa8V2spC12aOTstX38=
 github.com/hashicorp/nomad-openapi v0.0.0-20211018165803-33eb48e328a1/go.mod h1:uxmP0+p2PqvG6K+Mhtb58uhRaeUfVT95ql3ZxWN3Dhw=
 github.com/hashicorp/nomad/api v0.0.0-20200529203653-c4416b26d3eb/go.mod h1:DCi2k47yuUDzf2qWAK8E1RVmWgz/lc0jZQeEnICTxmY=
make: *** [check-mod] Error 1
```