### PR TITLE
Make CLI unit tests pass

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -5,10 +5,15 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"testing"
 
+	"github.com/hashicorp/nomad-pack/internal/pkg/cache"
+	"github.com/hashicorp/nomad-pack/internal/pkg/logging"
 	"github.com/stretchr/testify/require"
 )
+
+// These tests currently require the nomad agent -dev to be running.
 
 // TODO: Test job run with diffs
 // TODO: Test job run plan with diffs
@@ -17,292 +22,143 @@ import (
 // TODO: Test outputPlannedJob that returns non-zero exit code
 
 func TestVersion(t *testing.T) {
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
-
+	testInit(t)
 	exitCode := Main([]string{"nomad-pack", "-v"})
 	require.Equal(t, 0, exitCode)
-	os.Setenv("NOMAD_ADDR", nomadAddr)
+	reset()
 }
 
 func TestJobRun(t *testing.T) {
-	// TODO: Integrate test agent and solve envar dependency
-	// this currently requires nomad agent -dev to be running and the
-	// NOMAD_ADDR envar to be set.
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	testInit(t)
 
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
+	defer func() {
+		clearJob(t, &cache.PackConfig{Name: testPack})
+	}()
 
-	c := RunCommand{baseCommand: baseCommand}
-
-	exitCode := c.Run([]string{"example"})
+	exitCode := runCmd().Run([]string{testPack})
 	require.Equal(t, 0, exitCode)
-
-	os.Setenv("NOMAD_ADDR", nomadAddr)
-	// TODO: add var overrides when fixed
 }
 
 // Confirm that another pack with the same job names but a different deployment name fails
 func TestJobRunConflictingDeployment(t *testing.T) {
-	// TODO: Integrate test agent and solve envar dependency
-	// this currently requires nomad agent -dev to be running and the
-	// NOMAD_ADDR envar to be set.
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
-
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
-
-	runCommand := RunCommand{baseCommand: baseCommand}
+	testInit(t)
 
 	// Register the initial pack
-	exitCode := runCommand.Run([]string{"example"})
+	exitCode := runCmd().Run([]string{testPack})
+	defer func() {
+		clearJob(t, &cache.PackConfig{Name: testPack})
+	}()
+
+	// deploymentName := runCmd.deploymentName
 	require.Equal(t, 0, exitCode)
 
-	exitCode = runCommand.Run([]string{"example", "--name=with-name"})
+	exitCode = runCmd().Run([]string{testPack, "--name=with-name"})
 	require.Equal(t, 1, exitCode)
 
 	// Confirm that it's still possible to update the existing pack
-	exitCode = runCommand.Run([]string{"example"})
+	exitCode = runCmd().Run([]string{testPack})
 	require.Equal(t, 0, exitCode)
-
-	// Delete the pack
-	stopCommand := StopCommand{baseCommand: baseCommand}
-	exitCode = stopCommand.Run([]string{runCommand.deploymentName, "--purge=true"})
-	require.Equal(t, 0, exitCode)
-
-	os.Setenv("NOMAD_ADDR", nomadAddr)
 }
 
 // Check for conflict with non-pack job i.e. no meta
 func TestJobRunConflictingNonPackJob(t *testing.T) {
-	// TODO: Integrate test agent and solve envar dependency
-	// this currently requires nomad agent -dev to be running and the
-	// NOMAD_ADDR envar to be set.
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	testInit(t)
 
 	// Register non pack job
-	nomadPath, err := exec.LookPath("nomad")
-	require.NoError(t, err)
-	nomadCommand := exec.Command(nomadPath, "run", "../fixtures/example.nomad")
-	err = nomadCommand.Run()
-	require.NoError(t, err)
+	nomadExec(t, "run", "../fixtures/simple.nomad")
 
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
-
-	runCommand := RunCommand{baseCommand: baseCommand}
+	defer func() {
+		clearJob(t, &cache.PackConfig{Name: testPack})
+	}()
 
 	// Now try to register the pack
-	exitCode := runCommand.Run([]string{"example"})
+	exitCode := runCmd().Run([]string{testPack})
 	require.Equal(t, 1, exitCode)
-
-	// cleanup job
-	nomadCommand = exec.Command(nomadPath, "job", "stop", "-purge", "example")
-	err = nomadCommand.Run()
-	require.NoError(t, err)
-	os.Setenv("NOMAD_ADDR", nomadAddr)
 }
 
-// Check for conflict with job that has meta, but no deployment key
-func TestJobRunConflictingJobWithMetaButNoDeploymentKey(t *testing.T) {
-	// TODO: Integrate test agent and solve envar dependency
-	// this currently requires nomad agent -dev to be running and the
-	// NOMAD_ADDR envar to be set.
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+// Check for conflict with job that has meta
+func TestJobRunConflictingJobWithMeta(t *testing.T) {
+	testInit(t)
 
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
+	defer func() {
+		clearJob(t, &cache.PackConfig{Name: testPack})
+	}()
 
-	runCommand := RunCommand{baseCommand: baseCommand}
-
-	nomadPath, err := exec.LookPath("nomad")
-	require.NoError(t, err)
-
-	nomadCommand := exec.Command(nomadPath, "run", "../fixtures/example-with-meta.nomad")
-	err = nomadCommand.Run()
-	require.NoError(t, err)
+	nomadExec(t, "run", "../fixtures/simple-with-meta.nomad")
 
 	// Now try to register
-	exitCode := runCommand.Run([]string{"example"})
+	exitCode := runCmd().Run([]string{testPack})
 	require.Equal(t, 1, exitCode)
-
-	// cleanup job
-	nomadCommand = exec.Command(nomadPath, "job", "stop", "-purge", "example")
-	err = nomadCommand.Run()
-	require.NoError(t, err)
-
-	os.Setenv("NOMAD_ADDR", nomadAddr)
 }
 
 func TestJobRunFails(t *testing.T) {
-	// Fails with unavailable packs
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	testInit(t)
 
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
-
-	c := &RunCommand{baseCommand: baseCommand}
-
-	exitCode := c.Run([]string{"fake-example"})
+	exitCode := runCmd().Run([]string{"fake-job"})
 	require.Equal(t, 1, exitCode)
-	os.Setenv("NOMAD_ADDR", nomadAddr)
+
+	reset()
 }
 
 func TestJobPlan(t *testing.T) {
-	// TODO: Integrate test agent and solve envar dependency
-	// this currently requires nomad agent -dev to be running and the
-	// NOMAD_ADDR envar to be set.
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	testInit(t)
 
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
-
-	c := &PlanCommand{baseCommand: baseCommand}
-	exitCode := c.Run([]string{"example"})
-
+	exitCode := planCmd().Run([]string{testPack})
 	// Should return 1 indicating an allocation will be placed
 	require.Equal(t, 1, exitCode)
-	os.Setenv("NOMAD_ADDR", nomadAddr)
+
+	reset()
 }
 
 // Confirm that another pack with the same job names but a different deployment name fails
 func TestJobPlanConflictingDeployment(t *testing.T) {
-	// TODO: Integrate test agent and solve envar dependency
-	// this currently requires nomad agent -dev to be running and the
-	// NOMAD_ADDR envar to be set.
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	testInit(t)
 
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
-
-	runCommand := RunCommand{baseCommand: baseCommand}
+	defer func() {
+		clearJob(t, &cache.PackConfig{Name: testPack})
+	}()
 
 	// Register the initial pack
-	exitCode := runCommand.Run([]string{"example"})
+	exitCode := runCmd().Run([]string{testPack})
 	require.Equal(t, 0, exitCode)
 
-	// Plan another pack
-	planCommand := PlanCommand{baseCommand: baseCommand}
-	exitCode = planCommand.Run([]string{"example"}) // works because pack name above gets version appended.
-	require.Equal(t, 255, exitCode)
+	exitCode = runCmd().Run([]string{testPack, testRefFlag})
+	require.Equal(t, 1, exitCode)
 
-	// Delete the pack
-	stopCommand := StopCommand{baseCommand: baseCommand}
-	exitCode = stopCommand.Run([]string{runCommand.deploymentName, "--purge=true"})
-	require.Equal(t, 0, exitCode)
-
-	os.Setenv("NOMAD_ADDR", nomadAddr)
+	reset()
 }
 
 // Check for conflict with non-pack job i.e. no meta
 func TestJobPlanConflictingNonPackJob(t *testing.T) {
-	// TODO: Integrate test agent and solve envar dependency
-	// this currently requires nomad agent -dev to be running and the
-	// NOMAD_ADDR envar to be set.
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	testInit(t)
+	defer func() {
+		clearJob(t, &cache.PackConfig{Name: testPack})
+	}()
 
 	// Register non pack job
-	nomadPath, err := exec.LookPath("nomad")
-	require.NoError(t, err)
-	nomadCommand := exec.Command(nomadPath, "run", "../fixtures/example.nomad")
-	err = nomadCommand.Run()
-	require.NoError(t, err)
-
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
-
-	planCommand := PlanCommand{baseCommand: baseCommand}
+	nomadExec(t, "run", "../fixtures/simple.nomad")
 
 	// Now try to plan the pack
-	exitCode := planCommand.Run([]string{"example"})
+	exitCode := planCmd().Run([]string{testPack})
 	require.Equal(t, 255, exitCode)
 
-	// cleanup job
-	nomadCommand = exec.Command(nomadPath, "job", "stop", "-purge", "example")
-	err = nomadCommand.Run()
-	require.NoError(t, err)
-	os.Setenv("NOMAD_ADDR", nomadAddr)
-}
-
-// Check for conflict with job that has meta, but no deployment key
-func TestJobPlanConflictingJobWithMetaButNoDeploymentKey(t *testing.T) {
-	// TODO: Integrate test agent and solve envar dependency
-	// this currently requires nomad agent -dev to be running and the
-	// NOMAD_ADDR envar to be set.
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
-
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
-
-	nomadPath, err := exec.LookPath("nomad")
-	require.NoError(t, err)
-
-	nomadCommand := exec.Command(nomadPath, "run", "../fixtures/example-with-meta.nomad")
-	err = nomadCommand.Run()
-	require.NoError(t, err)
-
-	// Now try to register
-	planCommand := PlanCommand{baseCommand: baseCommand}
-	exitCode := planCommand.Run([]string{"example"})
-	require.Equal(t, 255, exitCode)
-
-	// cleanup job
-	nomadCommand = exec.Command(nomadPath, "job", "stop", "-purge", "example")
-	err = nomadCommand.Run()
-	require.NoError(t, err)
-
-	os.Setenv("NOMAD_ADDR", nomadAddr)
+	reset()
 }
 
 func TestJobStop(t *testing.T) {
-	// TODO: Integrate test agent and solve envar dependency
-	// this currently requires nomad agent -dev to be running and the
-	// NOMAD_ADDR envar to be set.
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	testInit(t)
 
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
-
-	runCommand := &RunCommand{baseCommand: baseCommand}
-	exitCode := runCommand.Run([]string{"example"})
-
+	exitCode := runCmd().Run([]string{testPack})
 	require.Equal(t, 0, exitCode)
 
-	d := &StopCommand{baseCommand: baseCommand}
-	exitCode = d.Run([]string{runCommand.packConfig.Name, "--purge=true"})
+	exitCode = stopCmd().Run([]string{testPack, "--purge=true"})
 	require.Equal(t, 0, exitCode)
 
-	os.Setenv("NOMAD_ADDR", nomadAddr)
+	reset()
 }
 
 func TestJobStopConflicts(t *testing.T) {
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
-
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
+	testInit(t)
 
 	cases := []struct {
 		name           string
@@ -316,14 +172,14 @@ func TestJobStopConflicts(t *testing.T) {
 		{
 			name:           "non-pack-job",
 			nonPackJob:     true,
-			packName:       "nomad_example",
+			packName:       testPack,
 			deploymentName: "",
-			jobName:        "nomad_example",
+			jobName:        testPack,
 		},
 		{
 			name:           "same-pack-diff-deploy",
 			nonPackJob:     false,
-			packName:       "nomad_example",
+			packName:       testPack,
 			deploymentName: "foo",
 			jobName:        "job2",
 		},
@@ -331,167 +187,106 @@ func TestJobStopConflicts(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			// Create job
-			nomadPath, err := exec.LookPath("nomad")
-			require.NoError(t, err)
+			defer func() {
+				// Purge job. Use nomad command since it'll work for all jobs
+				nomadExec(t, "stop", "-purge", c.jobName)
+			}()
 
+			// Create job
 			if c.nonPackJob {
-				nomadCommand := exec.Command(nomadPath, "run", "../fixtures/example.nomad")
-				err = nomadCommand.Run()
-				require.NoError(t, err)
+				nomadExec(t, "run", "../fixtures/simple.nomad")
 			} else {
-				r := &RunCommand{baseCommand: baseCommand}
 				deploymentName := fmt.Sprintf("--name=%s", c.deploymentName)
 				varJobName := fmt.Sprintf("--var=job_name=%s", c.jobName)
-				exitCode := r.Run([]string{c.packName, deploymentName, varJobName})
+				exitCode := runCmd().Run([]string{c.packName, deploymentName, varJobName})
 				require.Equal(t, 0, exitCode)
 			}
 
 			// Try to stop job
-			s := &StopCommand{baseCommand: baseCommand}
-			exitCode := s.Run([]string{c.packName})
+			exitCode := stopCmd().Run([]string{c.packName})
 			require.Equal(t, 1, exitCode)
-
-			// Purge job. Use nomad command since it'll work for all jobs
-			nomadCommand := exec.Command(nomadPath, "stop", "-purge", c.jobName)
-			err = nomadCommand.Run()
-			require.NoError(t, err)
 		})
 	}
-	os.Setenv("NOMAD_ADDR", nomadAddr)
+
+	reset()
 }
 
 // Destroy is just an alias for stop --purge so we only need to
 // test that specific functionality
 func TestJobDestroy(t *testing.T) {
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	testInit(t)
 
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
-
-	r := &RunCommand{baseCommand: baseCommand}
-	r.Run([]string{"nomad_example"})
-
-	d := &DestroyCommand{&StopCommand{baseCommand: baseCommand}}
-	d.Run([]string{"nomad_example"})
-
-	// Assert job no longer queryable
-	nomadPath, err := exec.LookPath("nomad")
-	require.NoError(t, err)
-
-	nomadCommand := exec.Command(nomadPath, "status", "nomad_example")
-	err = nomadCommand.Run()
-	require.NoError(t, err)
-
-	os.Setenv("NOMAD_ADDR", nomadAddr)
-}
-
-func TestJobDestroyFails(t *testing.T) {
-	// Check you can't pass --purge flag to destroy command since
-	// that doesn't make sense
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
-
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
-
-	r := &RunCommand{baseCommand: baseCommand}
-	exitCode := r.Run([]string{"nomad_example"})
+	exitCode := runCmd().Run([]string{testPack})
 	require.Equal(t, 0, exitCode)
 
-	d := &DestroyCommand{&StopCommand{baseCommand: baseCommand}}
-	exitCode = d.Run([]string{"nomad_example", "destroy", "--purge"})
-	require.Equal(t, 1, exitCode)
+	exitCode = destroyCmd().Run([]string{testPack})
+	require.Equal(t, 0, exitCode)
 
-	os.Setenv("NOMAD_ADDR", nomadAddr)
+	// Assert job no longer queryable
+	nomadExpectErr(t, "status", testPack)
+
+	reset()
 }
 
 // Test that destroy properly uses var overrides to target the job
 func TestJobDestroyWithOverrides(t *testing.T) {
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	testInit(t)
 
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
-
+	// 	TODO: Table Testing
 	// Create multiple jobs in the same pack deployment
-	r := &RunCommand{baseCommand: baseCommand}
-	deployName := "--name=test"
+
 	jobNames := []string{"foo", "bar"}
 	for _, j := range jobNames {
-		exitCode := r.Run([]string{"nomad_example", deployName, `--var=job_name=` + j})
+		exitCode := runCmd().Run([]string{testPack, `--var=job_name=` + j})
 		require.Equal(t, 0, exitCode)
 	}
 
 	// Stop nonexistent job
-	d := &DestroyCommand{StopCommand: &StopCommand{baseCommand: baseCommand}}
-	exitCode := d.Run([]string{r.packConfig.Name, deployName, "--var=job_name=baz"})
+	exitCode := destroyCmd().Run([]string{testPack, "--var=job_name=baz"})
 	require.Equal(t, 1, exitCode)
 
 	// Stop job with var override
-	exitCode = d.Run([]string{r.packConfig.Name, deployName, "--var=job_name=foo"})
+	exitCode = destroyCmd().Run([]string{testPack, "--var=job_name=foo"})
 	require.Equal(t, 0, exitCode)
 
 	// Assert job "bar" still exists
-	nomadPath, err := exec.LookPath("nomad")
-	require.NoError(t, err)
-	nomadCmd := exec.Command(nomadPath, "status", "bar")
-	err = nomadCmd.Run()
-	require.NoError(t, err)
+	nomadExec(t, "status", "bar")
 
 	// Stop job with no overrides passed
-	exitCode = d.Run([]string{r.packConfig.Name, deployName})
+	exitCode = destroyCmd().Run([]string{testPack})
 	require.Equal(t, 0, exitCode)
 
 	// Assert job bar is gone
-	nomadCmd = exec.Command(nomadPath, "status", "bar")
-	err = nomadCmd.Run()
-	require.Error(t, err)
+	nomadExpectErr(t, "status", "bar")
 
-	os.Setenv("NOMAD_ADDR", nomadAddr)
+	reset()
 }
 
 func TestFlagProvidedButNotDefined(t *testing.T) {
-	// TODO: Integrate test agent and solve envar dependency
-	// this currently requires nomad agent -dev to be running and the
-	// NOMAD_ADDR envar to be set.
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	testInit(t)
 
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
-
-	r := &RunCommand{baseCommand: baseCommand}
 	// There is no job flag. This tests that adding an unspecified flag does not
 	// create an invalid memory address error
 	// Posix case
-	exitCode := r.Run([]string{"example", "--job=provided-but-not-defined"})
+	exitCode := runCmd().Run([]string{"nginx", "--job=provided-but-not-defined"})
 	require.Equal(t, 1, exitCode)
 
 	// std go case
-	exitCode = r.Run([]string{"-job=provided-but-not-defined", "example"})
+	exitCode = runCmd().Run([]string{"-job=provided-but-not-defined", "nginx"})
 	require.Equal(t, 1, exitCode)
 
-	os.Setenv("NOMAD_ADDR", nomadAddr)
+	reset()
 }
 
 func TestStatus(t *testing.T) {
-	// TODO: Integrate test agent and solve envar dependency
-	// this currently requires nomad agent -dev to be running and the
-	// NOMAD_ADDR envar to be set.
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	testInit(t)
+	defer func() {
+		clearJob(t, &cache.PackConfig{Name: testPack})
+	}()
 
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
+	exitCode := runCmd().Run([]string{testPack})
+	require.Equal(t, 0, exitCode)
 
-	s := &StatusCommand{baseCommand: baseCommand}
 	cases := []struct {
 		name string
 		args []string
@@ -502,37 +297,117 @@ func TestStatus(t *testing.T) {
 		},
 		{
 			name: "with-pack-name",
-			args: []string{"nomad_example"},
+			args: []string{testPack},
 		},
 		{
-			name: "with-pack-and-deploy-name",
-			args: []string{"nomad_example", "--name=foo"},
+			name: "with-pack-and-registry-name",
+			args: []string{testPack, "--registry=default"},
+		},
+		{
+			name: "with-pack-and-ref",
+			args: []string{testPack, "--ref=latest"},
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			exitCode := s.Run(c.args)
+			exitCode = statusCmd().Run(c.args)
 			require.Equal(t, 0, exitCode)
 		})
 	}
-	os.Setenv("NOMAD_ADDR", nomadAddr)
+
+	reset()
 }
 
 func TestStatusFails(t *testing.T) {
-	// TODO: Integrate test agent and solve envar dependency
-	// this currently requires nomad agent -dev to be running and the
-	// NOMAD_ADDR envar to be set.
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	testInit(t)
 
-	baseCommand := &baseCommand{
-		Ctx: context.Background(),
-	}
-	s := &StatusCommand{baseCommand: baseCommand}
+	statusCmd := &StatusCommand{baseCommand: baseCmd()}
 
-	exitCode := s.Run([]string{"--name=foo"})
+	exitCode := statusCmd.Run([]string{"--name=foo"})
 	require.Equal(t, 1, exitCode)
 
-	os.Setenv("NOMAD_ADDR", nomadAddr)
+	reset()
+}
+
+var nomadAddr string
+var testPack = "simple_service"
+var testRefFlag = "--ref=48eb7d5"
+
+// reduce boilerplate copy pasta with a factory method.
+func baseCmd() *baseCommand {
+	return &baseCommand{Ctx: context.Background()}
+}
+
+func planCmd() *PlanCommand {
+	return &PlanCommand{baseCommand: baseCmd()}
+}
+
+func runCmd() *RunCommand {
+	return &RunCommand{baseCommand: baseCmd()}
+}
+
+func destroyCmd() *DestroyCommand {
+	return &DestroyCommand{&StopCommand{baseCommand: baseCmd()}}
+}
+
+func statusCmd() *StatusCommand {
+	return &StatusCommand{baseCommand: baseCmd()}
+}
+
+func stopCmd() *StopCommand {
+	return &StopCommand{baseCommand: baseCmd()}
+}
+
+// Save the current machine's NOMAD_ADDR so that tests can reset developer.
+// environment. Added to every test to allow one of ad hoc testing.
+func testInit(t *testing.T) {
+	nomadAddr = os.Getenv("NOMAD_ADDR")
+	_ = os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+
+	// Make sure the alternate ref registry is loaded to the environment.
+	_, err := os.Stat(path.Join(cache.DefaultCachePath(), cache.DefaultRegistryName, "simple_service@48eb7d5"))
+	if err != nil && os.IsNotExist(err) {
+		var c *cache.Cache
+		c, err = cache.NewCache(&cache.CacheConfig{
+			Path:   cache.DefaultCachePath(),
+			Eager:  false,
+			Logger: logging.Default(),
+		})
+		require.NoError(t, err)
+		_, err = c.Add(&cache.AddOpts{
+			RegistryName: cache.DefaultRegistryName,
+			Source:       cache.DefaultRegistrySource,
+			Ref:          "48eb7d5",
+		})
+		require.NoError(t, err)
+	}
+}
+
+// Reset NOMAD_ADDR after test. Added to every test to allow one of ad hoc testing.
+func reset() {
+	_ = os.Setenv("NOMAD_ADDR", nomadAddr)
+}
+
+// deferable func to ensure tests don't leave nomad dev agent with running job
+// that can affect other tests.
+func clearJob(t *testing.T, cfg *cache.PackConfig) {
+	nomadExec(t, "job", "stop", "-purge", cfg.Name)
+	reset()
+}
+
+func nomadExec(t *testing.T, args ...string) {
+	nomadPath, err := exec.LookPath("nomad")
+	require.NoError(t, err)
+	nomadCmd := exec.Command(nomadPath, args...)
+	err = nomadCmd.Run()
+	require.NoError(t, err)
+}
+
+func nomadExpectErr(t *testing.T, args ...string) {
+	nomadPath, err := exec.LookPath("nomad")
+	require.NoError(t, err)
+	nomadCmd := exec.Command(nomadPath, args...)
+	err = nomadCmd.Run()
+	require.Error(t, err)
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -109,14 +109,6 @@ func Commands(
 		globalOptions: opts,
 	}
 
-	// aliases is a list of command aliases we have. The key is the CLI
-	// command (the alias) and the value is the existing target command.
-	// aliases := map[string]string{
-	// 	"build":   "artifact build",
-	// 	"deploy":  "deployment deploy",
-	// 	"install": "server install",
-	// }
-
 	// start building our commands
 	commands := map[string]cli.CommandFactory{
 		"render": func() (cli.Command, error) {

--- a/cli/run.go
+++ b/cli/run.go
@@ -130,7 +130,7 @@ func (c *RunCommand) run() int {
 	if c.packConfig.Registry == cache.DevRegistryName {
 		c.ui.Success(fmt.Sprintf("Pack successfully deployed. Use %s to manage this this deployed instance with plan, stop, destroy, or info", c.packConfig.SourcePath))
 	} else {
-		c.ui.Success(fmt.Sprintf("Pack successfully deployed. Use %s with --ref=%s to manage this this deployed instance with plan, stop, destroy, or info", c.deploymentName, c.packConfig.Ref))
+		c.ui.Success(fmt.Sprintf("Pack successfully deployed. Use %s with --ref=%s to manage this this deployed instance with plan, stop, destroy, or info", c.packConfig.Name, c.packConfig.Ref))
 	}
 
 	output, err := packManager.ProcessOutputTemplate()

--- a/cli/status.go
+++ b/cli/status.go
@@ -106,8 +106,18 @@ func (c *StatusCommand) Flags() *flag.Sets {
 			Name:    "registry",
 			Target:  &c.packConfig.Registry,
 			Default: "",
-			Usage: `Specific registry name containing the pack inspect.
+			Usage: `Specific registry name containing the pack to inspect.
 If not specified, the default registry will be used.`,
+		})
+
+		f.StringVar(&flag.StringVar{
+			Name:    "ref",
+			Target:  &c.packConfig.Ref,
+			Default: "",
+			Usage: `Specific git ref of the pack to inspect. 
+Supports tags, SHA, and latest. If no ref is specified, defaults to latest.
+
+Using ref with a file path is not supported.`,
 		})
 	})
 }

--- a/fixtures/simple-with-meta.nomad
+++ b/fixtures/simple-with-meta.nomad
@@ -1,0 +1,41 @@
+job "simple_service" {
+
+  datacenters = [ "dc1" ]
+
+  meta {
+    my-key = "my-value"
+  }
+
+  type = "service"
+
+  group "app" {
+    count = 1
+
+    network {
+      port "http" {
+        to = 8000
+      }
+    }
+
+    restart {
+      attempts = 2
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image = "mnomitch/hello_world_server"
+        ports = ["http"]
+      }
+
+      resources {
+        cpu    = 200
+        memory = 256
+      }
+    }
+  }
+}

--- a/fixtures/simple.nomad
+++ b/fixtures/simple.nomad
@@ -1,0 +1,36 @@
+job "simple_service" {
+
+  datacenters = [ "dc1" ]
+  type = "service"
+
+  group "app" {
+    count = 1
+
+    network {
+      port "http" {
+        to = 8000
+      }
+    }
+
+    restart {
+      attempts = 2
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image = "mnomitch/hello_world_server"
+        ports = ["http"]
+      }
+
+      resources {
+        cpu    = 200
+        memory = 256
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR includes the following:

- Make CLI unit tests pass with updated flags
- Refactors CLI unit tests to reduce boilerplate
- Consistent naming conventions in CLI unit tests
- Adds `ref` flag to `StatusCommand`
- Fixes display logic on `RunCommand` output

Relates to #148 