### PR TITLE
Parse pack URLs with URL.Parse to get clean hostnames.

### DIFF
--- a/internal/pkg/cache/add.go
+++ b/internal/pkg/cache/add.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	gg "github.com/hashicorp/go-getter"
@@ -129,7 +130,8 @@ func (c *Cache) cloneRemoteGitRegistry(opts *AddOpts) (err error) {
 
 	// Append the pack name to the go-getter url if a pack name was specified
 	if opts.PackName != "" {
-		url = fmt.Sprintf("%s.git//packs/%s", opts.Source, opts.PackName)
+		src := strings.TrimRight(opts.Source, ".git") // to make the next command work consistently
+		url = fmt.Sprintf("%s.git//packs/%s", src, opts.PackName)
 	}
 
 	// If ref is set, add query string variable

--- a/internal/pkg/cache/registry.go
+++ b/internal/pkg/cache/registry.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/hashicorp/nomad-pack/internal/pkg/loader"
 	"github.com/hashicorp/nomad-pack/sdk/pack"
@@ -122,23 +121,8 @@ func (r *Registry) setURLFromPacks() {
 			continue
 		}
 
-		segmentCount := 2
-
-		var segments []string
-		if packURL.Hostname() != "" {
-			segments = append(segments, packURL.Hostname())
-			segmentCount += 1
-		}
-
-		segments = append(segments, strings.Split(strings.TrimLeft(packURL.Path, "/"), "/")...)
-
-		// Set the count to len of segments in case URL is not formatted correctly.
-		if len(segments) < 3 {
-			segmentCount = len(segments)
-		}
-
-		// set the URL back to a joined url.
-		r.Source = strings.Join(segments[:segmentCount], "/")
+		dir, _ := path.Split(packURL.Path)
+		r.Source = path.Join(packURL.Hostname(), dir)
 
 		// Exit once we have a valid pack
 		return

--- a/internal/pkg/cache/registry.go
+++ b/internal/pkg/cache/registry.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/hashicorp/nomad-pack/internal/pkg/loader"
 	"github.com/hashicorp/nomad-pack/sdk/pack"
@@ -100,29 +101,42 @@ func (r *Registry) get(opts *GetOpts, cache *Cache) (err error) {
 
 	return
 }
+func (r *Registry) parsePackURL(packURL string) bool {
+	if packURL == "" {
+		return false
+	}
+	// Get the pack url from the metadata. This fix still assumes that the
+	// Pack.URL contains an actual URL and not a ssh or file-shaped path.
+	// TODO: make this parsing more flexible.
+	parsedPackURL, err := url.Parse(packURL)
+
+	// If the pack url can not be parsed, show a warning and continue. If a
+	// valid pack url occurs later, this will be overwritten. This at least
+	// prevents hitting the base case of "registry contains no valid packs"
+	if err != nil {
+		r.Source = fmt.Sprintf("invalid url (%s)", packURL)
+		return false
+	}
+
+	// chop off the pack name
+	dir, _ := path.Split(parsedPackURL.Path)
+	// hop off the "/packs" component of the directory
+	dir, _ = path.Split(strings.TrimSuffix(dir, "/"))
+	// don't display the .git; note because this is still a path it ends in a /
+	dir = strings.TrimSuffix(dir, ".git/")
+
+	r.Source = path.Join(parsedPackURL.Hostname(), dir)
+	return true
+
+}
 
 // setURLFromPacks sets the Source since we don't have this stored in any sort of
 // reliable way.
 func (r *Registry) setURLFromPacks() {
 	for _, cachedPack := range r.Packs {
-		if cachedPack.Metadata.Pack.URL == "" {
+		if !r.parsePackURL(cachedPack.Metadata.Pack.URL) {
 			continue
 		}
-
-		// Get the pack url from the metadata. This fix still assumes that the
-		// Pack.URL contains an actual URL and not a ssh or file-shaped path.
-		packURL, err := url.Parse(cachedPack.Metadata.Pack.URL)
-
-		// If the pack url can not be parsed, show a warning and continue. If a
-		// valid pack url occurs later, this will be overwritten. This at least
-		// prevents hitting the base case of "registry contains no valid packs"
-		if err != nil {
-			r.Source = fmt.Sprintf("invalid url (%s)", cachedPack.Metadata.Pack.URL)
-			continue
-		}
-
-		dir, _ := path.Split(packURL.Path)
-		r.Source = path.Join(packURL.Hostname(), dir)
 
 		// Exit once we have a valid pack
 		return


### PR DESCRIPTION
Switches implementation to use URL parsing to enable hostnames other than github.com.  This fixes #161. 

There is an open question about unparsable URLs in the Pack.URL field of the metadata.  For now, I opted to output the error message in the list output but continue rather than failing completely, since the pack would still be able to be rendered.