### PR TITLE
Render to Files

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/nomad-pack/internal/pkg/cache"
 	"io"
 	"os"
 	"path"
 	"runtime"
+
+	"github.com/hashicorp/nomad-pack/internal/pkg/cache"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -55,6 +56,9 @@ type baseCommand struct {
 	// varFiles is an HCL file(s) setting one or more values
 	// for defined input variables
 	varFiles []string
+
+	// autoApproved is true when the user supplies the --auto-approve or -y flag
+	autoApproved bool
 
 	// deploymentName is the unique identifier of the deployed
 	// instance of a specified pack. Used for running more than
@@ -276,7 +280,15 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
                       should be passed to the plan or destroy commands.
                       `,
 		})
-
+		f.BoolVarP(&flag.BoolVarP{
+			BoolVar: &flag.BoolVar{
+				Name:    "auto-approve",
+				Target:  &c.autoApproved,
+				Default: false,
+				Usage:   `Automatically answer confirmation prompts in the affirmative.`,
+			},
+			Shorthand: "y",
+		})
 	}
 
 	if f != nil {

--- a/cli/helpers.go
+++ b/cli/helpers.go
@@ -214,7 +214,7 @@ func generateRunner(client *v1.Client, packType, cliCfg interface{}, runnerCfg *
 	case "job":
 		jobConfig, ok := cliCfg.(*job.CLIConfig)
 		if !ok {
-			return nil, fmt.Errorf("failed to assert correct config, unsiutable type %T", cliCfg)
+			return nil, fmt.Errorf("failed to assert correct config, unsuitable type %T", cliCfg)
 		}
 		deployerImpl = job.NewDeployer(client, jobConfig)
 	default:

--- a/cli/render.go
+++ b/cli/render.go
@@ -60,7 +60,7 @@ func (r Render) toFile(c *RenderCommand, ec *errors.UIErrorContext) error {
 	var overwrite bool
 
 	if !c.autoApproved && c.ui.Interactive() {
-		overwrite, err = askForOverwrite(c)
+		overwrite, err = confirmOverwrite(c)
 		if err != nil {
 			return err
 		}

--- a/cli/render.go
+++ b/cli/render.go
@@ -103,7 +103,7 @@ func validateOutDir(path string) error {
 			return nil
 		}
 
-		return fmt.Errorf("unexpected error testing --to-dir path: %w", err)
+		return fmt.Errorf("unexpected error validating --to-dir path: %w", err)
 	}
 
 	if !info.IsDir() {

--- a/docs/detailed-usage.md
+++ b/docs/detailed-usage.md
@@ -82,12 +82,12 @@ This can be useful when writing a pack, debugging deployments, integrating Nomad
 
 The `render` command takes the `--var` and `--var-file` flags that `run` takes.
 
-The `--too` flag determines the directory where the rendered templates will be written.
+The `--to-dir` flag determines the directory where the rendered templates will be written.
 
 The `--render-output-template` can be passed to additionally render the output template. Some output templates rely on a deployment for information. In these cases, the output template may not be rendered with all necessary information.
 
 ```
-nomad-pack render hello-world --to ./tmp --var greeting=hola --render-output-template
+nomad-pack render hello-world --to-dir ./tmp --var greeting=hola --render-output-template
 ```
 
 ## Run

--- a/terminal/glint.go
+++ b/terminal/glint.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
@@ -9,11 +10,15 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/bgentry/speakeasy"
+	"github.com/fatih/color"
+	"github.com/mattn/go-isatty"
 	"github.com/mitchellh/go-glint"
 	"github.com/olekukonko/tablewriter"
 )
 
 type glintUI struct {
+	ctx context.Context
 	d   *glint.Document
 	row []glint.Component
 }
@@ -22,6 +27,7 @@ func GlintUI(ctx context.Context) UI {
 	result := &glintUI{
 		d:   glint.New(),
 		row: make([]glint.Component, 0),
+		ctx: ctx,
 	}
 
 	go result.d.Render(ctx)
@@ -34,15 +40,48 @@ func (ui *glintUI) Close() error {
 }
 
 func (ui *glintUI) Input(input *Input) (string, error) {
-	return "", ErrNonInteractive
+	var buf bytes.Buffer
+
+	// Write the prompt, add a space.
+	ui.Output(input.Prompt, WithStyle(input.Style), WithWriter(&buf))
+	fmt.Fprint(color.Output, strings.TrimRight(buf.String(), "\r\n"))
+	fmt.Fprint(color.Output, " ")
+
+	// Ask for input in a go-routine so that we can ignore it.
+	errCh := make(chan error, 1)
+	lineCh := make(chan string, 1)
+	go func() {
+		var line string
+		var err error
+		if input.Secret && isatty.IsTerminal(os.Stdin.Fd()) {
+			line, err = speakeasy.Ask("")
+		} else {
+			r := bufio.NewReader(os.Stdin)
+			line, err = r.ReadString('\n')
+		}
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		lineCh <- strings.TrimRight(line, "\r\n")
+	}()
+
+	select {
+	case err := <-errCh:
+		return "", err
+	case line := <-lineCh:
+		return line, nil
+	case <-ui.ctx.Done():
+		// Print newline so that any further output starts properly
+		fmt.Fprintln(color.Output)
+		return "", ui.ctx.Err()
+	}
 }
 
 // Interactive implements UI
 func (ui *glintUI) Interactive() bool {
-	// TODO(mitchellh): We can make this interactive later but Glint itself
-	// doesn't support input yet. We can pause the document, do some input,
-	// then resume potentially.
-	return false
+	return isatty.IsTerminal(os.Stdin.Fd())
 }
 
 // Output implements UI

--- a/terminal/noninteractive.go
+++ b/terminal/noninteractive.go
@@ -208,8 +208,15 @@ func (ui *nonInteractiveUI) ErrorWithContext(err error, sub string, ctx ...strin
 	ui.Error(strings.Title(sub))
 	ui.Error("  Error: " + err.Error())
 	ui.Error("  Context:")
+	max := 0
 	for _, entry := range ctx {
-		ui.Error("    " + entry)
+		if loc := strings.Index(entry, ":") + 1; loc > max {
+			max = loc
+		}
+	}
+	for _, entry := range ctx {
+		padding := max - strings.Index(entry, ":") + 1
+		ui.Error("  " + strings.Repeat(" ", padding) + entry)
 	}
 }
 

--- a/terminal/noninteractive.go
+++ b/terminal/noninteractive.go
@@ -205,7 +205,12 @@ func (ui *nonInteractiveUI) Error(msg string) {
 // ErrorWithContext satisfies the ErrorWithContext function on the UI
 // interface.
 func (ui *nonInteractiveUI) ErrorWithContext(err error, sub string, ctx ...string) {
-	ErrorWithContext(err, sub, ctx...)
+	ui.Error(strings.Title(sub))
+	ui.Error("  Error: " + err.Error())
+	ui.Error("  Context:")
+	for _, entry := range ctx {
+		ui.Error("    " + entry)
+	}
 }
 
 // Header implements UI

--- a/terminal/table.go
+++ b/terminal/table.go
@@ -72,13 +72,17 @@ func (u *basicUI) Table(tbl *Table, opts ...Option) {
 }
 
 const (
-	Yellow = "yellow"
-	Green  = "green"
-	Red    = "red"
+	Yellow  = YellowStyle
+	Green   = GreenStyle
+	Red     = RedStyle
+	Bold    = BoldStyle
+	Default = DefaultStyle
 )
 
 var colorMapping = map[string]int{
-	Green:  tablewriter.FgGreenColor,
-	Yellow: tablewriter.FgYellowColor,
-	Red:    tablewriter.FgRedColor,
+	Green:   tablewriter.FgGreenColor,
+	Yellow:  tablewriter.FgYellowColor,
+	Red:     tablewriter.FgRedColor,
+	Bold:    tablewriter.Bold,
+	Default: tablewriter.Normal,
 }


### PR DESCRIPTION
- Implement --render-to-file
- Add non-interactive ErrorWithContext
- Format Error Context Elements
- Add auto-approve flag
- Update to --to-dir; adopt --auto-approve flag for overwrite
- Implemented Input in glintUI
- Missed the callsite renaming confirmOverwrite

Closes #109 