### PR TITLE
cache: respect `UserCacheDir` convention

### DIFF
--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -11,7 +11,6 @@ import (
 )
 
 const (
-	nomadCache            = ".nomad/packs"
 	DefaultRegistryName   = "default"
 	DefaultRegistrySource = "github.com/hashicorp/nomad-pack-community-registry"
 	DefaultRef            = "latest"
@@ -51,13 +50,17 @@ func (c *Cache) ensureGlobalCache() error {
 
 // DefaultCachePath returns the default cache path.
 func DefaultCachePath() string {
-	homeDir, err := os.UserHomeDir()
+	cacheDir, err := os.UserCacheDir()
 	if err != nil {
-		homeDir = "~"
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			homeDir = "~"
+		}
+		return path.Join(homeDir, ".nomad/packs")
 	}
-
-	return path.Join(homeDir, nomadCache)
+	return path.Join(cacheDir, "nomad/packs")
 }
+
 func defaultCacheConfig() *CacheConfig {
 	return &CacheConfig{
 		Path:   DefaultCachePath(),


### PR DESCRIPTION
The registry cache pollutes the user's home directory with a
`~/.nomad` directory. Desktop operating systems have platform-specific
conventions for placing cache directories (XDG standard on Unix,
`~/Library/Caches` on Darwin, `%AppData%` on Windows, etc.). Go
provides a `os.UserCacheDir` function that does the right thing for
the platform it's being called on.

---

We can't exactly unit test this change without messing up the test runner's home directory, but here's what it looks like after building locally on macOS:

```
$ nomad-pack registry list
...
$ ls ~/Library/Caches/nomad/packs/default
csi_openstack_cinder@latest     jenkins@latest                  prometheus_snmp_exporter@latest
drone@latest                    loki@latest                     promtail@latest
faasd@latest                    nginx@latest                    simple_service@latest
fabio@latest                    nomad_autoscaler@latest         tempo@latest
grafana@latest                  nomad_ingress_nginx@latest      tfc_agent@latest
haproxy@latest                  outline@latest                  traefik@latest
hello_world@latest              prometheus@latest               wordpress@latest
influxdb@latest                 prometheus_node_exporter@latest
```