### PR TITLE
changelog: PRs merged since tech preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+BUG FIXES:
+
+
+IMPROVEMENTS:
+
+* cache: Moved the pack registry cache to the platform-specific user cache directory [GH-172](https://github.com/hashicorp/nomad-pack/pull/172)
+* cli: Don't build pack registry cache during the `version` command [GH-128](https://github.com/hashicorp/nomad-pack/pull/128)
+* dependencies: Removed direct import of Nomad code base [GH-157](https://github.com/hashicorp/nomad-pack/pull/157)
+* template: Added `toStringList` function [GH-136](https://github.com/hashicorp/nomad-pack/pull/136)
+
 ## 0.0.1-techpreview1 (October 19, 2021)
 
 Initial release.


### PR DESCRIPTION
I built this list from https://github.com/hashicorp/nomad-pack/pulls?q=is%3Apr+is%3Aclosed and I _think_ I got everything we need to document since the October 19 tech preview date.