### PR TITLE
Fixed render's overwrite prompt

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -280,6 +280,9 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
                       should be passed to the plan or destroy commands.
                       `,
 		})
+	}
+	if bit&flagSetNeedsApproval != 0 {
+		f := set.NewSet("Approval Options")
 		f.BoolVarP(&flag.BoolVarP{
 			BoolVar: &flag.BoolVar{
 				Name:    "auto-approve",
@@ -312,8 +315,9 @@ func (c *baseCommand) helpUsageMessage() string {
 type flagSetBit uint
 
 const (
-	flagSetNone      flagSetBit = 1 << iota
-	flagSetOperation            // shared flags for operations (run, plan, etc)
+	flagSetNone          flagSetBit = 1 << iota
+	flagSetOperation                // shared flags for operations (run, plan, etc)
+	flagSetNeedsApproval            // adds the -y flag for commands that require approval to run
 )
 
 var (

--- a/cli/render.go
+++ b/cli/render.go
@@ -91,11 +91,13 @@ func confirmOverwrite(c *RenderCommand, path string) (bool, error) {
 		switch overwrite {
 		case "a":
 			c.overwriteAll = true
-			fallthrough
+			return true, nil
 		case "y":
 			return true, nil
 		case "n":
 			return false, nil
+		default:
+			c.ui.Output("Please select a valid option.\n", terminal.WithStyle(terminal.ErrorBoldStyle))
 		}
 	}
 }
@@ -138,11 +140,9 @@ func maybeCreateDestinationDir(path string) error {
 func writeFile(c *RenderCommand, path string, content string) error {
 	// Check to see if the file already exists and validate against the value
 	// of overwrite.
-	var overwrite bool
-
 	_, err := os.Stat(path)
 	if err == nil {
-		overwrite, err = confirmOverwrite(c, path)
+		overwrite, err := confirmOverwrite(c, path)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- moved approve to its own flagset so it can be used w/o the other ones
- added an "a" to the overwrite options so that all overwrites can be set at once interactively