### PR TITLE
Alias standard library errors funcs into internal errors package

### DIFF
--- a/cli/helpers.go
+++ b/cli/helpers.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	stdErrors "errors"
 	"fmt"
 	"os"
 
@@ -114,7 +113,7 @@ func renderPack(manager *manager.PackManager, ui terminal.UI, errCtx *errors.UIE
 			err[i].Context.Append(errCtx)
 			ui.ErrorWithContext(err[i].Err, "failed to process pack", err[i].Context.GetAll()...)
 		}
-		return nil, stdErrors.New("failed to render")
+		return nil, errors.New("failed to render")
 	}
 	return r, nil
 }

--- a/cli/registry_add.go
+++ b/cli/registry_add.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	stdErrors "errors"
 	"fmt"
 	"strings"
 
@@ -70,7 +69,7 @@ func (c *RegistryAddCommand) Run(args []string) int {
 
 	// If subprocess fails to add any packs, report this to the user.
 	if len(newRegistry.Packs) == 0 {
-		c.ui.ErrorWithContext(stdErrors.New("failed to add packs for registry"), "see output for reason", errorContext.GetAll()...)
+		c.ui.ErrorWithContext(errors.New("failed to add packs for registry"), "see output for reason", errorContext.GetAll()...)
 		return 1
 	}
 

--- a/cli/render.go
+++ b/cli/render.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	stdErrors "errors"
 	"fmt"
 	"io/fs"
 	"io/ioutil"
@@ -99,7 +98,7 @@ func validateOutDir(path string) error {
 	info, err := os.Stat(path)
 
 	if err != nil {
-		if stdErrors.Is(err, fs.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 
@@ -107,7 +106,7 @@ func validateOutDir(path string) error {
 	}
 
 	if !info.IsDir() {
-		return stdErrors.New("--to-dir must be a directory")
+		return errors.New("--to-dir must be a directory")
 	}
 
 	return nil
@@ -117,7 +116,7 @@ func maybeCreateDestinationDir(path string) error {
 	_, err := os.Stat(path)
 
 	// If the directory doesn't exist, create it.
-	if stdErrors.Is(err, fs.ErrNotExist) {
+	if errors.Is(err, fs.ErrNotExist) {
 		err := os.MkdirAll(path, 0755)
 		if err != nil {
 			return err
@@ -235,7 +234,7 @@ func (c *RenderCommand) Run(args []string) int {
 		if c.renderToDir != "" {
 			err = render.toFile(c, errorContext)
 			if err != nil {
-				if stdErrors.Is(err, context.Canceled) {
+				if errors.Is(err, context.Canceled) {
 					return 1
 				}
 				c.ui.ErrorWithContext(err, "failed to render to file", errorContext.GetAll()...)

--- a/internal/pkg/cache/delete.go
+++ b/internal/pkg/cache/delete.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	stdErrors "errors"
 	"fmt"
 	"os"
 	"path"
@@ -20,7 +19,7 @@ func (c *Cache) Delete(opts *DeleteOpts) (err error) {
 
 	// if cache directory is empty return error
 	if opts.cachePath == "" {
-		err = stdErrors.New("cache path is required")
+		err = errors.New("cache path is required")
 		return
 	}
 
@@ -69,7 +68,7 @@ func (c *Cache) Delete(opts *DeleteOpts) (err error) {
 
 	// If nothing got deleted, throw an error.
 	if deleteCount == 0 {
-		err = stdErrors.New("error deleting packs")
+		err = errors.New("error deleting packs")
 		logger.ErrorWithContext(err, "no packs found matching arguments", c.ErrorContext.GetAll()...)
 		return
 	}

--- a/internal/pkg/errors/cache.go
+++ b/internal/pkg/errors/cache.go
@@ -1,20 +1,16 @@
 package errors
 
-import (
-	stdErrors "errors"
-)
-
 var (
-	ErrCachePathRequired       = stdErrors.New("cache path is required")
-	ErrInvalidCachePath        = stdErrors.New("invalid cache path")
-	ErrInvalidRegistryRevision = stdErrors.New("invalid revision")
-	ErrInvalidRegistrySource   = stdErrors.New("invalid registry source")
-	ErrNoRegistriesAdded       = stdErrors.New("no registries were added to the cache")
-	ErrPackNameRequired        = stdErrors.New("pack name is required")
-	ErrPackNotFound            = stdErrors.New("pack not found")
-	ErrRegistryNameRequired    = stdErrors.New("registry name is required")
-	ErrRegistryNotFound        = stdErrors.New("registry not found")
-	ErrRegistrySourceRequired  = stdErrors.New("registry source is required")
+	ErrCachePathRequired       = newError("cache path is required")
+	ErrInvalidCachePath        = newError("invalid cache path")
+	ErrInvalidRegistryRevision = newError("invalid revision")
+	ErrInvalidRegistrySource   = newError("invalid registry source")
+	ErrNoRegistriesAdded       = newError("no registries were added to the cache")
+	ErrPackNameRequired        = newError("pack name is required")
+	ErrPackNotFound            = newError("pack not found")
+	ErrRegistryNameRequired    = newError("registry name is required")
+	ErrRegistryNotFound        = newError("registry not found")
+	ErrRegistrySourceRequired  = newError("registry source is required")
 )
 
 // UIContextPrefix* are the prefixes commonly used to create a string used in

--- a/internal/pkg/errors/errors.go
+++ b/internal/pkg/errors/errors.go
@@ -1,0 +1,15 @@
+package errors
+
+import (
+	stdErrors "errors"
+)
+
+var As = stdErrors.As
+var Is = stdErrors.Is
+var New = stdErrors.New
+var Unwrap = stdErrors.Unwrap
+
+// newError is an alias to the standard errors.New func for use inside
+// the errors package to make the code's intention more obvious than
+// undecorated calls to New might.
+var newError = stdErrors.New

--- a/internal/pkg/errors/ui_context.go
+++ b/internal/pkg/errors/ui_context.go
@@ -1,14 +1,13 @@
 package errors
 
 import (
-	stdErrors "errors"
 	"strings"
 )
 
 // ErrNoTemplatesRendered is an error to be used when the CLI runs a render
 // process that doesn't result in parent templates. This helps provide a clear
 // indication to the problem, as I have certainly been confused by this.
-var ErrNoTemplatesRendered = stdErrors.New("no templates were rendered by the renderer process run")
+var ErrNoTemplatesRendered = newError("no templates were rendered by the renderer process run")
 
 // UIContextPrefix* are the prefixes commonly used to create a string used in
 // UI errors outputs. If a prefix is used more than once, it should have a

--- a/internal/pkg/errors/wrapped_context.go
+++ b/internal/pkg/errors/wrapped_context.go
@@ -1,7 +1,6 @@
 package errors
 
 import (
-	stdErrors "errors"
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
@@ -39,7 +38,7 @@ func HCLDiagsToWrappedUIContext(diags hcl.Diagnostics) []*WrappedUIContext {
 	wrapped := make([]*WrappedUIContext, len(diags))
 	for i, diag := range diags {
 		wrapped[i] = &WrappedUIContext{
-			Err:     stdErrors.New(diag.Detail),
+			Err:     newError(diag.Detail),
 			Subject: diag.Summary,
 			Context: NewUIErrorContext(),
 		}

--- a/internal/pkg/errors/wrapped_context_test.go
+++ b/internal/pkg/errors/wrapped_context_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/pkg/errors/wrapped_context_test.go
+++ b/internal/pkg/errors/wrapped_context_test.go
@@ -1,9 +1,9 @@
 package errors
 
 import (
-	stdErrors "errors"
-	"github.com/hashicorp/hcl/v2"
 	"testing"
+
+	"github.com/hashicorp/hcl/v2"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -16,7 +16,7 @@ func TestWrappedUIContext_Error(t *testing.T) {
 	}{
 		{
 			inputWrappedUIContext: &WrappedUIContext{
-				Err:     stdErrors.New("tis but a scratch"),
+				Err:     newError("tis but a scratch"),
 				Subject: "the cause of camalot",
 				Context: &UIErrorContext{contexts: []string{"King: Arthur"}},
 			},
@@ -48,7 +48,7 @@ func TestWrappedUIContext_HCLDiagsToWrappedUIContext(t *testing.T) {
 			},
 			expectedOutput: []*WrappedUIContext{
 				{
-					Err:     stdErrors.New("this is the longer detail and is the real error"),
+					Err:     newError("this is the longer detail and is the real error"),
 					Subject: "some poor diag detail",
 					Context: &UIErrorContext{contexts: []string{"HCL Range: test.hcl:0,0-0"}},
 				},

--- a/internal/runner/job/error.go
+++ b/internal/runner/job/error.go
@@ -1,7 +1,6 @@
 package job
 
 import (
-	stdErrors "errors"
 	"regexp"
 	"strings"
 
@@ -34,7 +33,7 @@ func newValidationDeployerError(err error, sub, tplName string) *errors.WrappedU
 
 func newNoParsedTemplatesError(sub string, errCtx *errors.UIErrorContext) *errors.WrappedUIContext {
 	return &errors.WrappedUIContext{
-		Err:     stdErrors.New("no parsed templates found"),
+		Err:     errors.New("no parsed templates found"),
 		Subject: sub,
 		Context: errCtx,
 	}


### PR DESCRIPTION
Aliasing these functions allows developers to not have to include one or the other package under an import alias.

Added a `newError` alias to the `New` function to make creating errors inside of the package a little more explicit.

Refactored code to use alias methods.