### PR TITLE
Handle HEREDOC delimiter immediately before EOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 BUG FIXES:
-
+* template: Handle HEREDOC delimiter immediately before EOF [GH-191](https://github.com/hashicorp/nomad-pack/pull/191)
 
 IMPROVEMENTS:
 

--- a/fixtures/variables-with-heredoc/README.md
+++ b/fixtures/variables-with-heredoc/README.md
@@ -1,0 +1,19 @@
+# Test Pack for heredocs in varfiles
+
+Reported Error:
+
+```
+nomad-pack render toml_pack -f vars.hcl
+! Failed To Process Pack
+
+        Error:   No closing marker was found for the string.
+        Type:    *errors.errorString
+        Context: 
+                 - HCL Range: vars.hcl:5,4-4
+                 - Registry Name: dev
+                 - Pack Name: toml_pack
+                 - Pack Ref: dev
+```
+
+Found to be a case where the HEREDOC terminating string was not followed with a
+linefeed before the EOF.

--- a/fixtures/variables-with-heredoc/heredoc_variable_noeof/README.md
+++ b/fixtures/variables-with-heredoc/heredoc_variable_noeof/README.md
@@ -1,0 +1,114 @@
+# Simple Service
+
+This pack is a used to deploy a Docker image to as a service job to Nomad.
+
+This is ideal for configuring and deploying a simple web application to Nomad.
+
+## Customizing the Docker Image
+
+The docker image deployed can be replaced with a variable. In the example
+below, we will deploy and run `httpd:latest`.
+
+```
+nomad-pack run simple_service --var image="httpd:latest"
+```
+
+## Customizing Ports
+
+The ports that are exposed via Docker can be customized as well.
+
+In this case, we'll write the port values to a file called `./overrides.hcl`:
+
+```
+{
+  name = "http"
+  port = 8000
+},
+{
+  name = "https"
+  port = 8001
+}
+```
+
+Then pass the file into the run command:
+
+```
+nomad-pack run simple_service -f ./overrides.hcl`"
+```
+
+## Customizing Resources
+
+The application resource limits can be customized:
+
+```
+resources = {
+  cpu = 500
+  memory = 501
+}
+```
+
+## Customizing Environment Variables
+
+Environment variables can be added:
+
+```
+env_vars = [
+  {
+    key = "foo"
+    value = 1
+  }
+]
+```
+
+## Consul Service and Load Balancer Integration
+
+Optionally, this pack can configure a Consul service.
+
+If the `register_consul_service` is unset or set to true, the Consul service will be registered.
+
+Several load balancers in the [The Nomad Pack Community Registry](../README.md) are configured to connect to
+this service with ease.
+
+The [NginX](../nginx/README.md) and [HAProxy](../haproxy/README.md) packs can be configured to balance over the
+Consul service deployed by this pack. Just ensure that the "consul_service_name" variable provided to those
+packs matches this consul_service_name.
+
+The [Fabio](../fabio/README.md) and [Traefik](../traefik/README.md) packs are configured to search for Consul
+services with the specific tags.
+
+To tag this Consul service to work with Fabio, add `"urlprefix-<PATH>"`
+to the consul_tags. For instance, to route at the root path, you would add `"urlprefix-/"`. To route at the path `"/api/v1"`, you would add '"urlprefix-/api/v1".
+
+To tag this Consul service to work with Traefik, add "traefik.enable=true" to the consul_tags, also add "traefik.http.routers.http.rule=Path(\`<PATH>\`)". To route at the root path, you would add "traefik.http.routers.http.rule=Path(\`/\`)". To route at the path "/api/v1", you would add "traefik.http.routers.http.rule=Path(\`/api/v1\`)".
+
+```
+register_consul_service = true
+
+consul_tags = [
+  "urlprefix-/",
+  "traefik.enable=true",
+  "traefik.http.routers.http.rule=Path(`/`)",
+]
+```
+
+## Customizing Consul and Upstream Services
+
+Consul configuration can be tweaked and (upstream services)[https://www.nomadproject.io/docs/job-specification/upstreams]
+can be added as well.
+
+```
+register_consul_service = true
+consul_service_name = "app-service-name"
+has_health_check = true
+health_check = {
+  path = "/health"
+  interval = "20s"
+  timeout  = "3s"
+}
+upstreams = [
+  {
+    name = "other-service"
+    port = 8001
+  }
+]
+```

--- a/fixtures/variables-with-heredoc/heredoc_variable_noeof/metadata.hcl
+++ b/fixtures/variables-with-heredoc/heredoc_variable_noeof/metadata.hcl
@@ -1,0 +1,11 @@
+app {
+  url    = ""
+  author = "HashiCorp"
+}
+
+pack {
+  name        = "heredoc_variable_noeof"
+  description = "This pack tests a variable file with a heredoc at the EOF"
+  url         = ""
+  version     = "0.0.1"
+}

--- a/fixtures/variables-with-heredoc/heredoc_variable_noeof/templates/heredoc.nomad.tpl
+++ b/fixtures/variables-with-heredoc/heredoc_variable_noeof/templates/heredoc.nomad.tpl
@@ -1,0 +1,1 @@
+[[.heredoc_variable_noeof.heredoc]]

--- a/fixtures/variables-with-heredoc/heredoc_variable_noeof/variables.hcl
+++ b/fixtures/variables-with-heredoc/heredoc_variable_noeof/variables.hcl
@@ -1,0 +1,7 @@
+variable "heredoc" {
+	type = string
+	description = "Test Heredoc"
+	default     = <<EOF
+Heredoc!!
+EOF
+}

--- a/fixtures/variables-with-heredoc/vars.hcl
+++ b/fixtures/variables-with-heredoc/vars.hcl
@@ -1,0 +1,3 @@
+heredoc = <<EOF
+Good
+EOF

--- a/internal/pkg/variable/cli_test.go
+++ b/internal/pkg/variable/cli_test.go
@@ -1,6 +1,8 @@
 package variable
 
 import (
+	"os"
+	"path"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -128,4 +130,19 @@ func TestParser_parseCLIVariable(t *testing.T) {
 			assert.Equal(t, tc.expectedCLIVars, tc.inputParser.cliOverrideVars, tc.name)
 		}
 	}
+}
+
+func TestParser_parseHeredocAtEOF(t *testing.T) {
+	inputParser := &Parser{
+		fs:              afero.Afero{Fs: afero.OsFs{}},
+		cfg:             &ParserConfig{ParentName: "example"},
+		rootVars:        map[string]map[string]*Variable{},
+		cliOverrideVars: make(map[string][]*Variable),
+	}
+	// FIXME: Find the fixture folder in a less janky way
+	cwd, _ := os.Getwd()
+	fixturePath := path.Join(cwd, "../../../fixtures/variables-with-heredoc/vars.hcl")
+	b, diags := inputParser.loadOverrideFile(fixturePath)
+	assert.NotNil(t, b)
+	assert.Empty(t, diags)
 }

--- a/internal/pkg/variable/parser.go
+++ b/internal/pkg/variable/parser.go
@@ -128,6 +128,10 @@ func (p *Parser) Parse() (*ParsedVariables, hcl.Diagnostics) {
 func (p *Parser) loadOverrideFile(file string) (hcl.Body, hcl.Diagnostics) {
 
 	src, err := p.fs.ReadFile(file)
+	// FIXME - Workaround for ending heredoc with no linefeed.
+	// Variables files shouldn't care about the extra linefeed, but jamming one
+	// in all the time feels bad.
+	src = append(src, "\n"...)
 	if err != nil {
 		return nil, hcl.Diagnostics{
 			{


### PR DESCRIPTION
Adding a linefeed to the end of the file ensures that terminal heredoc end delimiters are processed properly. This is a bit of a hack, but is the lowest touch fix.

Fixes #189