### PR TITLE
Fix CLI and flag tests.

### DIFF
--- a/internal/pkg/flag/set_test.go
+++ b/internal/pkg/flag/set_test.go
@@ -7,29 +7,67 @@ import (
 )
 
 func TestSets(t *testing.T) {
-	require := require.New(t)
-
 	var valA, valB int
 	sets := NewSets()
 	{
-		set := sets.NewSet("A")
-		set.IntVar(&IntVar{
-			Name:   "a",
-			Target: &valA,
+		set := sets.NewSet("setA")
+		set.IntVarP(&IntVarP{
+			IntVar: &IntVar{
+				Name:   "alpha",
+				Target: &valA,
+			},
+			Shorthand: "a",
 		})
 	}
 
 	{
-		set := sets.NewSet("B")
-		set.IntVar(&IntVar{
-			Name:   "b",
-			Target: &valB,
+		set := sets.NewSet("setB")
+		set.IntVarP(&IntVarP{
+			IntVar: &IntVar{
+				Name:   "beta",
+				Target: &valB,
+			},
+			Shorthand: "b",
 		})
 	}
 
-	err := sets.Parse([]string{"-b", "42", "-a", "21"})
-	require.NoError(err)
-
-	require.Equal(int(21), valA)
-	require.Equal(int(42), valB)
+	testCases := []struct {
+		Name        string
+		Args        []string
+		expectError bool
+	}{
+		{
+			Name: "all small flags",
+			Args: []string{"-b", "42", "-a", "21"},
+		},
+		{
+			Name: "positional argument in the middle",
+			Args: []string{"-b", "42", "something", "-a", "21"},
+		},
+		{
+			Name: "mixed flag types after positionals",
+			Args: []string{"-b", "42", "something", "--alpha", "21"},
+		},
+		{
+			Name: "posix-style long flags",
+			Args: []string{"--beta", "42", "something", "--alpha", "21"},
+		},
+		{
+			Name:        "missing value",
+			Args:        []string{"-d", "42", "-a", "21"},
+			expectError: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			err := sets.Parse(tc.Args)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, int(21), valA)
+				require.Equal(t, int(42), valB)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR is to:
* **Fix flag tests** - The flags in the test were malformed and so wouldn't add, causing the test to fail. Fixed and added a table-driven test with some more cases.

* **Fix cli tests**
    - After the refactor in #193, the relative path to the fixture folder changed. Corrected that in appropriate tests.
    - Standardized all test cleanup calls to be immediately run in a defer after `testInit` is called. Removed extra `func()` wrapper from `defer`s that don't need it
    - Updated the funcs that call the `nomad` cli binary to handle cases where the:
        - CLI is expected to return an error.
        - CLI is expected to not return an error.
        - caller doesn't care—specifically `clearJob`.
    - Added a custom error type to allow tests to collect `stderr` and `stdout` from runs of the CLI tool to facilitate test writing/debugging. 
