### PR TITLE
Check pointer validity during pack validate

### DIFF
--- a/internal/pkg/cache/registry.go
+++ b/internal/pkg/cache/registry.go
@@ -133,8 +133,13 @@ func (r *Registry) parsePackURL(packURL string) bool {
 // setURLFromPacks sets the Source since we don't have this stored in any sort of
 // reliable way.
 func (r *Registry) setURLFromPacks() {
+
 	for _, cachedPack := range r.Packs {
-		if !r.parsePackURL(cachedPack.Metadata.Pack.URL) {
+		if err := cachedPack.Validate(); err != nil {
+			continue
+		}
+
+		if r.parsePackURL(cachedPack.Metadata.Pack.URL) {
 			continue
 		}
 

--- a/sdk/pack/metadata.go
+++ b/sdk/pack/metadata.go
@@ -115,11 +115,17 @@ func (md *Metadata) Validate() error {
 // validate the MetadataApp object to ensure it meets requirements and doesn't
 // contain invalid or incorrect data.
 func (ma *MetadataApp) validate() error {
+	if ma == nil {
+		return errors.New("App is uninitialized")
+	}
 	return nil
 }
 
 // validate the MetadataPack object to ensure it meets requirements and doesn't
 // contain invalid or incorrect data.
 func (mp *MetadataPack) validate() error {
+	if mp == nil {
+		return errors.New("Pack metadata is uninitialized")
+	}
 	return nil
 }


### PR DESCRIPTION
### Reproducer

```
nomad-pack registry add pandom github.com/pandom/nomad-packs --ref=2991e5eb
```

### Root Cause

Missing/malformed Pack metadata getting into the `setURLFromPacks` method, which naively attempts to reference pack metadata without checking that the pointers are good.

### Resolution

Checked to see if the cachedPack validates. Add nil pointer checks for app and metadata as part of validate

### Related Issues

Related #13
Fixes #129 