### PR TITLE
chore: add `.github` folder with CODEOWNERS and PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Blanket ownership of all PRs.
+* @DerekStrickland @jazzyfresh @jrasell @lgfa29

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Blanket ownership of all PRs.
-* @DerekStrickland @jazzyfresh @jrasell @lgfa29
+* @angrycub @DerekStrickland @jazzyfresh @jrasell @lgfa29

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+**Description**
+
+**Reminders**
+
+- [ ] Add `CHANGELOG.md` entry


### PR DESCRIPTION
Starting with a lightweight PR template, but we can expand as needed 🙂 