### PR TITLE
Standardize help strings; remove trailing spaces

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -35,7 +35,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"

--- a/docs/detailed-usage.md
+++ b/docs/detailed-usage.md
@@ -26,7 +26,7 @@ The directory structure is as follows:
                 ├── ...files containing pack contents...
 ```
 
-The contents of the `.nomad/pack` directory are needed for Nomad Pack to work properly, 
+The contents of the `.nomad/pack` directory are needed for Nomad Pack to work properly,
 but users must not manually manage or change these files. Instead, use the `registry`
 commands.
 
@@ -98,8 +98,8 @@ To deploy the resources in a pack to Nomad, use the `run` command.
 nomad-pack run hello-world
 ```
 
-By passing a `--name` value into `run`, Nomad Pack deploys each resource in the 
-pack with a metadata value for "pack name". If no name is given, the pack name 
+By passing a `--name` value into `run`, Nomad Pack deploys each resource in the
+pack with a metadata value for "pack name". If no name is given, the pack name
 is used by default.
 
 This allows Nomad Pack to manage multiple deployments of the same pack.

--- a/docs/writing-packs.md
+++ b/docs/writing-packs.md
@@ -13,8 +13,8 @@ First, make a pack registry. This will be a repository that provides the structu
 
 Cloning [hashicorp/example-nomad-pack-registry](https://github.com/hashicorp/example-nomad-pack-registry) can give you a head start.
 
-Each registry should have a README.md file that describes the packs in it, and 
-top-level directory named `packs` that contains a subdirectory for each individual 
+Each registry should have a README.md file that describes the packs in it, and
+top-level directory named `packs` that contains a subdirectory for each individual
 pack. Conventionally, the pack subdirectory name matches the pack name.
 
 The top level of a pack registry looks like the following:
@@ -265,7 +265,7 @@ This would allow templates of "simple_service" to use "demo_dep"'s helper templa
 ## Step Four: Testing your Pack
 
 As you write your pack, you will probably want to test it. To do this, pass the
-directory path as the name of the pack to the `run`, `plan`, `render`, `info`, 
+directory path as the name of the pack to the `run`, `plan`, `render`, `info`,
 `stop`, or `destroy` commands. Relative paths are supported.
 
 For instance, if your current working directory is the directory where you are

--- a/fixtures/connect.nomad
+++ b/fixtures/connect.nomad
@@ -258,7 +258,7 @@ job "countdash" {
       # The "dns" stanza allows operators to override the DNS configuration
       # inherited by the host client.
       # dns {
-      #   servers = ["1.1.1.1"] 
+      #   servers = ["1.1.1.1"]
       # }
     }
     # The "service" stanza enables Consul Connect.

--- a/fixtures/variable_test/variable_test/README.md
+++ b/fixtures/variable_test/variable_test/README.md
@@ -1,6 +1,6 @@
 # Variable Test Pack
 
-This pack can be used to test variable passing into nomad-pack. 
+This pack can be used to test variable passing into nomad-pack.git
 
 ## Inputs
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -257,8 +257,9 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 				Name:    "var-file",
 				Target:  &c.varFiles,
 				Default: make([]string, 0),
-				Usage: `Specifies the path to a variable override file. This can be provided 
-				multiple times on a single command to result in a list of files.`,
+				Usage: `Specifies the path to a variable override file. This can
+						be provided multiple times on a single command to result
+						in a list of files.`,
 				Completion: complete.PredictOr(complete.PredictFiles("*.var"), complete.PredictFiles("*.hcl")),
 			},
 			Shorthand: "f",
@@ -268,8 +269,8 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 			Name:    "var",
 			Target:  &c.vars,
 			Default: make(map[string]string),
-			Usage: `Specifies single override variables in the form of HCL syntax and
-				can be specified multiple times per command.`,
+			Usage: `Specifies single override variables in the form of HCL
+					syntax and can be specified multiple times per command.`,
 		})
 
 		f.StringVar(&flag.StringVar{
@@ -277,17 +278,17 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 			Target:  &c.deploymentName,
 			Default: "",
 			Usage: `If set, this will be the unique identifier of this deployed
-                      instance of the specified pack. If not set, the pack name will
-                      be used. This is useful for running more than one instance
-			of a pack within the same cluster. Note that this name
-                      must be globally unique within a cluster. Running the run
-                      command multiple times with the same name, will just re-submit
-	                the same pack, and apply changes if you have made any to
-                      the underlying pack. Be mindful that, whether you have made
-                      changes or not, the underlying Allocations will be replaced. 
-                      When managing packs, the name specified here is the name that
-                      should be passed to the plan or destroy commands.
-                      `,
+					instance of the specified pack. If not set, the pack name
+					will be used. This is useful for running more than one
+					instance of a pack within the same cluster. Note that this
+					name must be globally unique within a cluster. Running the
+					run command multiple times with the same name, will just
+					re-submit the same pack, and apply changes if you have made
+					any to the underlying pack. Be mindful that, whether you
+					have made changes or not, the underlying Allocations will be
+					replaced. When managing packs, the name specified here is
+					the name that should be passed to nomad-pack's plan and
+					destroy commands.`,
 		})
 	}
 	if bit&flagSetNeedsApproval != 0 {
@@ -297,7 +298,8 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 				Name:    "auto-approve",
 				Target:  &c.autoApproved,
 				Default: false,
-				Usage:   `Automatically answer confirmation prompts in the affirmative.`,
+				Usage: `Automatically answer confirmation prompts in the
+						affirmative.`,
 			},
 			Shorthand: "y",
 		})

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -49,18 +49,19 @@ func (c *DestroyCommand) Flags() *flag.Sets {
 			Name:    "registry",
 			Target:  &c.packConfig.Registry,
 			Default: "",
-			Usage:   `Specific registry name containing the pack to be destroyed.`,
+			Usage: `Specific registry name containing the pack to be
+					destroyed.`,
 		})
 
 		f.StringVar(&flag.StringVar{
 			Name:    "ref",
 			Target:  &c.packConfig.Ref,
 			Default: "",
-			Usage: `Specific git ref of the pack to be destroyed. 
-Supports tags, SHA, and latest. If no ref is specified, defaults to 
-latest.
+			Usage: `Specific git ref of the pack to be destroyed.
+					Supports tags, SHA, and latest. If no ref is specified,
+					defaults to latest.
 
-Using ref with a file path is not supported.`,
+					Using ref with a file path is not supported.`,
 		})
 
 		// TODO: is there a way to reuse the flag from StopCommand so we're not just copy/pasting
@@ -68,8 +69,9 @@ Using ref with a file path is not supported.`,
 			Name:    "global",
 			Target:  &c.global,
 			Default: false,
-			Usage: `Destroy multi-region pack in all its regions. By default, pack 
-					destroy will destroy only a single region at a time. Ignored for single-region packs.`,
+			Usage: `Destroy multi-region pack in all its regions. By default,
+					pack destroy will destroy only a single region at a time.
+					Ignored for single-region packs.`,
 		})
 	})
 }
@@ -88,7 +90,7 @@ func (c *DestroyCommand) Help() string {
 	nomad-pack destroy example --name=dev
 
 	# Stop and delete an example pack in deployment "dev" that has a job named "test"
-	# If the same pack has been installed in deployment "dev" but overriding the job 
+	# If the same pack has been installed in deployment "dev" but overriding the job
 	# name to "hello", only "test" will be deleted
 	nomad-pack destroy example --name=dev --var=job_name=test	
 	`
@@ -97,9 +99,9 @@ func (c *DestroyCommand) Help() string {
 
 	Stop and delete the specified Nomad Pack from the configured Nomad cluster.
 	This is the same as using the command "nomad-pack stop <pack name> --purge".
-	By default, the destroy command will delete ALL jobs in the pack deployment. 
-	If a pack was run using var overrides to specify the job name(s), the var 
-	overrides MUST be provided when destroying the pack to guarantee nomad-pack 
+	By default, the destroy command will delete ALL jobs in the pack deployment.
+	If a pack was run using var overrides to specify the job name(s), the var
+	overrides MUST be provided when destroying the pack to guarantee nomad-pack
 	targets the correct job(s) in the pack deployment.
 	
 ` + c.GetExample() + c.Flags().Help())

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -198,75 +198,63 @@ Subcommands:
 var helpText = map[string][2]string{
 	"run": {
 		"Run one or more Nomad packs",
-		`
-Run one or more Nomad packs.
-The run command is used to install a Nomad Pack to a configured Nomad cluster.
-Nomad Pack will search for packs in local repositories to match the pack name(s) specified
-in the run command.
-`,
+		`The "run" command is used to install a Nomad Pack to a configured Nomad
+		cluster. Nomad Pack will search for packs in local repositories to match
+		the pack name(s) specified in the run command.`,
 	},
 	"plan": {
-		"Plan invokes a dry-run of the scheduler to determine the effects of submitting either a new or updated version of a job",
-		`
-Plan invokes a dry-run of the scheduler to determine the effects of submitting
-either a new or updated version of a job. The plan will not result in any changes 
-to the cluster but gives insight into whether the pack could be run successfully 
-and how it would affect existing allocations.
-`,
+		"Plan invokes a dry-run of the scheduler",
+		`The "plan" command invokes a dry-run of the scheduler to determine the
+		effects of submitting either a new or updated version of a job. The plan
+		will not result in any changes to the cluster but gives insight into
+		whether the pack could be run successfully and how it would affect
+		existing allocations.`,
 	},
 	"stop": {
 		"Stop a running pack",
-		`
-The stop command stops a running pack. Purge is used to stop the pack and purge it from the system.
- If not set, the job(s) in the pack will still be queryable and will be purged by the garbage collector. 
-Global will stop a multi-region job in all its regions. By default, stop will stop 
-only a single region at a time. Ignored for single-region packs. After the deregister 
-command is submitted, a new evaluation ID is printed to the screen, which can be 
-used to examine the evaluation.
-`,
+		`The "stop" command stops a running pack. The --purge flag is used to
+		stop the pack and purge it from the system. If not set, the job(s) in
+		the pack will still be queryable and will be purged by Nomad's garbage
+		collector. The --global flag will stop a multi-region job in all its
+		regions. By default, stop will stop only a single region at a time.
+		Ignored for single-region packs. After the deregister command is
+		submitted, a new evaluation ID is printed to the screen, which can be
+		used to examine the evaluation.`,
 	},
 	"info": {
 		"Info gets information on a pack",
-		`
-Info reads from a pack's metadata.hcl and variables.hcl files and prints out the details
-of a pack.
-`,
+		`The "info" command reads from a pack's metadata.hcl and variables.hcl
+		files and prints out the details of a pack.`,
 	},
 	"destroy": {
 		"Delete an existing pack",
-		`
-Destroy stops a running pack and purges it from the system. If the pack is already stopped, destroy
-will delete it from the cluster. This is the equivalent of using the stop command with the purge option.
-`,
+		`The "destroy" command stops a running pack and purges it from the system.
+		If the pack is already stopped, destroy will delete it from the cluster.
+		This is the equivalent of using the stop command with the purge option.`,
 	},
 	"status": {
 		"Status gets information on deployed packs",
-		`
-Status returns information on packs deployed in a configured Nomad cluster. If no
-pack name is specified, it will return a list of all deployed packs. If pack name
-is provided, it will return a list of the jobs in that pack, along with their status, 
-and the pack deployment they belong to. The --name flag can be used with pack name
-to limit the list of jobs to a specific deployment of the pack.`,
+		`The "status" command returns information on packs deployed in a Nomad
+		cluster. If no pack name is specified, it will return a list of all
+		deployed packs. If pack name is provided, it will return a list of the
+		jobs in that pack, along with their status, and the pack deployment they
+		belong to. The --name flag can be used with pack name to limit the list
+		of jobs to a specific deployment of the pack.`,
 	},
 	"registry add": {
 		"Adds a pack registry or a specific pack from a registry",
-		`
-Registry add can be used to add a registry, or a specific pack from a registry at
-the latest ref or at a specific ref (tag/SHA).
-`,
+		`The "registry add" command can be used to add a registry or a specific
+		pack from a registry at the latest ref or at a specific ref (tag/SHA).`,
 	},
 	"registry delete": {
 		"Deletes a pack registry or specific pack from a registry",
-		`
-Registry delete can be used to delete a registry, or a specific pack from a registry
-at the latest ref or at a specific ref (tag/SHA).
-`,
+		`The "registry delete" command can be used used to delete a registry or
+		a specific pack from a registry at the latest ref or at a specific ref
+		(tag/SHA).`,
 	},
 	"registry list": {
 		"Lists all downloaded registries and packs",
-		`
-Registry list can be used to list all registries and associated packs that have
-been downloaded to the local environment.
-`,
+		`The "registry list" command lists all registries and associated packs
+		that have been downloaded to the local environment.`,
 	},
 }

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -116,19 +116,19 @@ func (c *InfoCommand) Flags() *flag.Sets {
 			Name:    "registry",
 			Target:  &c.packConfig.Registry,
 			Default: "",
-			Usage: `Specific registry name containing the pack to retrieve info about.
-If not specified, the default registry will be used.`,
+			Usage: `Specific registry name containing the pack to retrieve info
+					about. If not specified, the default registry will be used.`,
 		})
 
 		f.StringVar(&flag.StringVar{
 			Name:    "ref",
 			Target:  &c.packConfig.Ref,
 			Default: "",
-			Usage: `Specific git ref of the pack to retrieve info about. 
-Supports tags, SHA, and latest. If no ref is specified, defaults to 
-latest.
+			Usage: `Specific git ref of the pack to retrieve info about.
+					Supports tags, SHA, and latest. If no ref is specified,
+					defaults to latest.
 
-Using ref with a file path is not supported.`,
+					Using ref with a file path is not supported.`,
 		})
 	})
 }

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -142,26 +142,27 @@ func (c *PlanCommand) Flags() *flag.Sets {
 			Name:    "ref",
 			Target:  &c.packConfig.Ref,
 			Default: "",
-			Usage: `Specific git ref of the pack to be planned. 
-Supports tags, SHA, and latest. If no ref is specified, defaults to 
-latest.
+			Usage: `Specific git ref of the pack to be planned.
+					Supports tags, SHA, and latest. If no ref is specified,
+					defaults to latest.
 
-Using ref with a file path is not supported.`,
+					Using ref with a file path is not supported.`,
 		})
 
 		f.BoolVar(&flag.BoolVar{
 			Name:    "diff",
 			Target:  &c.jobConfig.PlanConfig.Diff,
 			Default: true,
-			Usage: `Determines whether the diff between the remote job and planned 
-                    job is shown. Defaults to true.`,
+			Usage: `Determines whether the diff between the remote job and
+					planned job is shown. Defaults to true.`,
 		})
 
 		f.BoolVar(&flag.BoolVar{
 			Name:    "policy-override",
 			Target:  &c.jobConfig.PlanConfig.PolicyOverride,
 			Default: false,
-			Usage:   `Sets the flag to force override any soft mandatory Sentinel policies.`,
+			Usage: `Sets the flag to force override any soft mandatory
+					Sentinel policies.`,
 		})
 
 		f.BoolVar(&flag.BoolVar{
@@ -205,9 +206,9 @@ func (c *PlanCommand) Help() string {
 	# Plan an example pack without showing the diff
 	nomad-pack plan example --diff=false
 
-    # Plan a pack under development from the filesystem - supports current working 
-    # directory or relative path
-	nomad-pack plan . 
+	# Plan a pack under development from the filesystem - supports current
+	# working directory or relative path
+	nomad-pack plan .
 	`
 
 	return formatHelp(`
@@ -215,7 +216,7 @@ func (c *PlanCommand) Help() string {
 
 	Determine the effects of submitting a new or updated Nomad Pack
 
-    Plan will return one of the following exit codes:
+	Plan will return one of the following exit codes:
 		* code 0:   No objects will be created or destroyed.
 		* code 1:   Objects will be created or destroyed.
 		* code 255: An error occurred determining the plan.

--- a/internal/cli/registry_add.go
+++ b/internal/cli/registry_add.go
@@ -124,13 +124,15 @@ func (c *RegistryAddCommand) Flags() *flag.Sets {
 			Name:    "ref",
 			Target:  &c.ref,
 			Default: "",
-			Usage: `Specific git ref of the registry or pack to be added. 
-Supports tags, SHA, and latest. If no ref is specified, defaults to latest. 
-Running "nomad registry add" multiple times for the same ref is idempotent, 
-however running "nomad-pack registry add" without specifying a ref, or when 
-specifying @latest, is destructive, and will overwrite current @latest in the global cache.
+			Usage: `Specific git ref of the registry or pack to be added.
+					Supports tags, SHA, and latest. If no ref is specified,
+					defaults to latest. Running "nomad registry add" multiple
+					times for the same ref is idempotent, however running
+					"nomad-pack registry add" without specifying a ref, or when
+					specifying @latest, is destructive, and will overwrite
+					current @latest in the global cache.
 
-Using ref with a file path is not supported.`,
+					Using ref with a file path is not supported.`,
 		})
 	})
 }

--- a/internal/cli/registry_delete.go
+++ b/internal/cli/registry_delete.go
@@ -91,20 +91,20 @@ func (c *RegistryDeleteCommand) Flags() *flag.Sets {
 			Name:    "target",
 			Target:  &c.target,
 			Default: "",
-			Usage: `A specific pack within the registry to be deleted. 
-If a ref flag has been added, only that ref of the target pack will be deleted.
-`,
+			Usage: `A specific pack within the registry to be deleted. If a ref
+					flag has been added, only that ref of the target pack will
+					be deleted.`,
 		})
 
 		f.StringVar(&flag.StringVar{
 			Name:    "ref",
 			Target:  &c.ref,
 			Default: "",
-			Usage: `Specific git ref of the registry or pack to be deleted. 
-Supports tags, SHA, and latest. If no ref is specified, defaults to 
-latest.
+			Usage: `Specific git ref of the registry or pack to be deleted.
+					Supports tags, SHA, and latest. If no ref is specified,
+					defaults to latest.
 
-Using ref with a file path is not supported.`,
+					Using ref with a file path is not supported.`,
 		})
 	})
 }

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -272,17 +272,18 @@ func (c *RenderCommand) Flags() *flag.Sets {
 			Target:  &c.packConfig.Registry,
 			Default: "",
 			Usage: `Specific registry name containing the pack to be rendered.
-If not specified, the default registry will be used.`,
+					If not specified, the default registry will be used.`,
 		})
 
 		f.StringVar(&flag.StringVar{
 			Name:    "ref",
 			Target:  &c.packConfig.Ref,
 			Default: "",
-			Usage: `Specific git ref of the pack to be rendered. 
-Supports tags, SHA, and latest. If no ref is specified, defaults to latest.
+			Usage: `Specific git ref of the pack to be rendered.
+					Supports tags, SHA, and latest. If no ref is specified,
+					defaults to latest.
 
-Using ref with a file path is not supported.`,
+					Using ref with a file path is not supported.`,
 		})
 
 		f.BoolVar(&flag.BoolVar{
@@ -290,20 +291,18 @@ Using ref with a file path is not supported.`,
 			Target:  &c.renderOutputTemplate,
 			Default: false,
 			Usage: `Controls whether or not the output template file within the
-                      pack is rendered and displayed.`,
+					pack is rendered and displayed.`,
 		})
 
 		f.StringVarP(&flag.StringVarP{
 			StringVar: &flag.StringVar{
 				Name:   "to-dir",
 				Target: &c.renderToDir,
-				Usage: `Path to write rendered job files to in addition to standard
-				output.`,
-				// Aliases: []string{"to"},
+				Usage: `Path to write rendered job files to in addition to
+						standard output.`,
 			},
 			Shorthand: "o",
 		})
-
 	})
 }
 
@@ -334,9 +333,9 @@ func (c *RenderCommand) Help() string {
 	# overwrite existing files.
 	nomad-pack render example --to-dir ~/out --auto-approve
 
-    # Render a pack under development from the filesystem - supports current working 
-    # directory or relative path
-	nomad-pack render . 
+	# Render a pack under development from the filesystem - supports current
+	# working directory or relative path
+	nomad-pack render .
 	`
 
 	return formatHelp(`

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -167,22 +167,24 @@ func (c *RunCommand) Flags() *flag.Sets {
 			Name:    "ref",
 			Target:  &c.packConfig.Ref,
 			Default: "",
-			Usage: `Specific git ref of the pack to be run. 
-Supports tags, SHA, and latest. If no ref is specified, defaults to latest.
+			Usage: `Specific git ref of the pack to be run.
+					Supports tags, SHA, and latest. If no ref is specified,
+					defaults to latest.
 
-Using ref with a file path is not supported.`,
+					Using ref with a file path is not supported.`,
 		})
 
 		f.Uint64Var(&flag.Uint64Var{
 			Name:    "check-index",
 			Target:  &c.jobConfig.RunConfig.CheckIndex,
 			Default: 0,
-			Usage: `If set, the job is only registered or updated if the passed 
-                   job modify index matches the server side version. If a check-index
-                   value of zero is passed, the job is only registered if it does
-                   not yet exist. If a non-zero value is passed, it ensures that
-                   the job is being updated from a known state. The use of this
-                   flag is most common in conjunction with job plan command.`,
+			Usage: `If set, the job is only registered or updated if the passed
+					job modify index matches the server side version. If a
+					check-index value of zero is passed, the job is only
+					registered if it does not yet exist. If a non-zero value is
+					passed, it ensures that the job is being updated from a
+					known state. The use of this flag is most common in
+					conjunction with job plan command.`,
 		})
 
 		f.StringVar(&flag.StringVar{
@@ -190,23 +192,23 @@ Using ref with a file path is not supported.`,
 			Target:  &c.jobConfig.RunConfig.ConsulToken,
 			Default: "",
 			Usage: `If set, the passed Consul token is stored in the job before
-                      sending to the Nomad servers. This allows passing the Consul
-                      token without storing it in the job file. This overrides the
-                      token found in the $CONSUL_HTTP_TOKEN environment variable
-                      and that found in the job.`,
+					sending to the Nomad servers. This allows passing the Consul
+					token without storing it in the job file. This overrides the
+					token found in the $CONSUL_HTTP_TOKEN environment variable
+					and that found in the job.`,
 		})
 
 		f.StringVar(&flag.StringVar{
 			Name:    "consul-namespace",
 			Target:  &c.jobConfig.RunConfig.ConsulNamespace,
 			Default: "",
-			Usage: `If set, any services in the job will be registered into the 
-                    specified Consul namespace. Any template stanza reading from 
-                    Consul KV will be scoped to the the specified Consul namespace. 
-                    If Consul ACLs are enabled and the allow_unauthenticated Nomad 
-                    server Consul configuration is not enabled, then a Consul token 
-                    must be supplied with appropriate service and kv Consul ACL 
-                    policy permissions.`,
+			Usage: `If set, any services in the job will be registered into the
+					specified Consul namespace. Any template stanza reading from
+					Consul KV will be scoped to the the specified Consul
+					namespace. If Consul ACLs are enabled and the
+					allow_unauthenticated Nomad server Consul configuration is
+					not enabled, then a Consul token must be supplied with
+					appropriate service and KV Consul ACL policy permissions.`,
 		})
 
 		f.StringVar(&flag.StringVar{
@@ -214,41 +216,42 @@ Using ref with a file path is not supported.`,
 			Target:  &c.jobConfig.RunConfig.VaultToken,
 			Default: "",
 			Usage: `If set, the passed Vault token is stored in the job before
-                      sending to the Nomad servers. This allows passing the Vault 
-                      token without storing it in the job file. This overrides the 
-                      token found in the $VAULT_TOKEN environment variable and 
-                      that found in the job.`,
+					sending to the Nomad servers. This allows passing the Vault
+					token without storing it in the job file. This overrides the
+					token found in the $VAULT_TOKEN environment variable and
+					that found in the job.`,
 		})
 
 		f.StringVar(&flag.StringVar{
 			Name:    "vault-namespace",
 			Target:  &c.jobConfig.RunConfig.VaultNamespace,
 			Default: "",
-			Usage: `If set, the passed Vault namespace is stored in the job before 
-                    sending to the Nomad servers.`,
+			Usage: `If set, the passed Vault namespace is stored in the job
+					before sending to the Nomad servers.`,
 		})
 
 		f.BoolVar(&flag.BoolVar{
 			Name:    "policy-override",
 			Target:  &c.jobConfig.RunConfig.PolicyOverride,
 			Default: false,
-			Usage: `Sets the flag to force override any soft mandatory Sentinel 
-                      policies.`,
+			Usage: `Sets the flag to force override any soft mandatory Sentinel
+					policies.`,
 		})
 
 		f.BoolVar(&flag.BoolVar{
 			Name:    "preserve-counts",
 			Target:  &c.jobConfig.RunConfig.PreserveCounts,
 			Default: false,
-			Usage: `If set, the existing task group counts will be preserved 
-                      when updating a job.`,
+			Usage: `If set, the existing task group counts will be preserved
+					when updating a job.`,
 		})
 
 		f.BoolVar(&flag.BoolVar{
 			Name:    "hcl1",
 			Target:  &c.jobConfig.RunConfig.HCL1,
 			Default: false,
-			Usage:   `If set, the hcl V1 parser will be used to parse the job file.`,
+			Usage: `If set, the hcl V1 parser will be used to parse the job
+					file.`,
 		})
 
 		f.BoolVar(&flag.BoolVar{
@@ -257,7 +260,7 @@ Using ref with a file path is not supported.`,
 			Target:  &c.jobConfig.RunConfig.EnableRollback,
 			Default: false,
 			Usage: `EXPERIMENTAL. If set, any pack failure will cause nomad pack
-                       to attempt to rollback the entire deployment.`,
+					to attempt to rollback the entire deployment.`,
 		})
 	})
 }
@@ -277,7 +280,7 @@ func (c *RunCommand) Help() string {
 	nomad-pack run example
 
 	# Run an example pack with the specified deployment name "dev"
-	nomad-pack run example --name=dev 
+	nomad-pack run example --name=dev
 
 	# Run an example pack with override variables in a variable file
 	nomad-pack run example --var-file="./overrides.hcl"
@@ -285,9 +288,9 @@ func (c *RunCommand) Help() string {
 	# Run an example pack with cli variable overrides
 	nomad-pack run example --var="redis_image_version=latest" --var="redis_resources={"cpu": "1000", "memory": "512"}"
 
-	# Run a pack under development from the filesystem - supports current working 
-    # directory or relative path
-	nomad-pack run . 
+	# Run a pack under development from the filesystem - supports current
+	# working directory or relative path
+	nomad-pack run .
 	`
 
 	return formatHelp(`

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -107,17 +107,18 @@ func (c *StatusCommand) Flags() *flag.Sets {
 			Target:  &c.packConfig.Registry,
 			Default: "",
 			Usage: `Specific registry name containing the pack to inspect.
-If not specified, the default registry will be used.`,
+					If not specified, the default registry will be used.`,
 		})
 
 		f.StringVar(&flag.StringVar{
 			Name:    "ref",
 			Target:  &c.packConfig.Ref,
 			Default: "",
-			Usage: `Specific git ref of the pack to inspect. 
-Supports tags, SHA, and latest. If no ref is specified, defaults to latest.
+			Usage: `Specific git ref of the pack to inspect.
+					Supports tags, SHA, and latest. If no ref is specified,
+					defaults to latest.
 
-Using ref with a file path is not supported.`,
+					Using ref with a file path is not supported.`,
 		})
 	})
 }
@@ -135,22 +136,26 @@ func (c *StatusCommand) Help() string {
 	# Get a list of all deployed packs and their registries
 	nomad-pack status
 	
-	# Get a list of all deployed jobs in pack example, along with their status and deployment names
+	# Get a list of all deployed jobs in pack example, along with their status
+	# and deployment names
 	nomad-pack status example
 
-	# Get a list of all deployed jobs and their status for an example pack in the deployment name "dev"
+	# Get a list of all deployed jobs and their status for an example pack in
+	# the deployment name "dev"
 	nomad-pack status example --name=dev
 
-    # Get a list of all deployed jobs and their status for an example pack in the deployment name "dev"
+	# Get a list of all deployed jobs and their status for an example pack in
+	# the deployment name "dev"
 	nomad-pack status example --name=dev --registry=community
 	`
 
 	return formatHelp(`
 	Usage: nomad-pack status <name> [options]
 
-	Get information on deployed Nomad Packs. If no pack name is specified, it will return
-	a list of all deployed packs. If pack name is specified, it will return a list of all
-	deployed jobs belonging to that pack, along with their status and deployment names.
+	Get information on deployed Nomad Packs. If no pack name is specified, it
+	will return	a list of all deployed packs. If pack name is specified, it will
+	return a list of all deployed jobs belonging to that pack, along with their
+	status and deployment names.
 
 ` + c.GetExample() + c.Flags().Help())
 }

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -258,26 +258,29 @@ func (c *StopCommand) Flags() *flag.Sets {
 			Name:    "ref",
 			Target:  &c.packConfig.Ref,
 			Default: "",
-			Usage: `Specific git ref of the pack to be stopped. 
-Supports tags, SHA, and latest. If no ref is specified, defaults to latest.
+			Usage: `Specific git ref of the pack to be stopped.
+					Supports tags, SHA, and latest. If no ref is specified,
+					defaults to latest.
 
-Using ref with a file path is not supported.`,
+					Using ref with a file path is not supported.`,
 		})
 
 		f.BoolVar(&flag.BoolVar{
 			Name:    "purge",
 			Target:  &c.purge,
 			Default: false,
-			Usage: `Purge is used to stop packs and purge them from the system. 
-					If not set, packs will still be queryable and will be purged by the garbage collector.`,
+			Usage: `Purge is used to stop packs and purge them from the system.
+					If not set, packs will still be queryable and will be purged
+					by the garbage collector.`,
 		})
 
 		f.BoolVar(&flag.BoolVar{
 			Name:    "global",
 			Target:  &c.global,
 			Default: false,
-			Usage: `Stop multi-region pack in all its regions. By default, pack 
-					stop will stop only a single region at a time. Ignored for single-region jobs.`,
+			Usage: `Stop multi-region pack in all its regions. By default, pack
+					stop will stop only a single region at a time. Ignored for
+					single-region jobs.`,
 		})
 	})
 }
@@ -299,19 +302,21 @@ func (c *StopCommand) Help() string {
 	nomad-pack stop example --name=dev --purge
 
 	# Stop an example pack in deployment "dev" that has a job named "test"
-	# If the same pack has been installed in deployment "dev" but overriding the job 
-	# name to "hello", only "test" will be stopped
+	# If the same pack has been installed in deployment "dev" but overriding the
+	# job name to "hello", only "test" will be stopped
 	nomad-pack stop example --name=dev --var=job_name=test
 	`
 	return formatHelp(`
 	Usage: nomad-pack stop <pack name> [options]
 
-	Stop the specified Nomad Pack in the configured Nomad cluster. To delete the pack from
-	the cluster, specify "--purge", or use the command "nomad-pack destroy <pack name>."
-	By default, the stop command will stop ALL jobs in the pack deployment. If a pack
-	was run using var overrides to specify the job name(s), the var overrides MUST be
-	provided when stopping the pack to guarantee nomad-pack targets the correct job(s)
-	in the pack deployment.
+	Stop the specified Nomad Pack in the configured Nomad cluster. To delete the
+	pack from the cluster, specify "--purge", or use the "nomad-pack destroy"
+	command.
+
+	By default, the stop command will stop ALL jobs in the pack deployment. If a
+	pack was run using variable overrides to specify the job name(s), the same
+	variable overrides MUST be provided when stopping the pack to guarantee that
+	nomad-pack targets the correct job(s) in the pack deployment.
 	
 ` + c.GetExample() + c.Flags().Help())
 }

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -45,8 +45,8 @@ func (c *VersionCommand) Synopsis() string {
 
 func (c *VersionCommand) Help() string {
 	return formatHelp(`
-Usage: nomad-pack version
+	Usage: nomad-pack version
 
-  Prints the version information for Nomad Pack.
+	Prints the version information for Nomad Pack.
 `)
 }

--- a/internal/pkg/flag/set.go
+++ b/internal/pkg/flag/set.go
@@ -372,11 +372,11 @@ func hasGoFlags(args []string) bool {
 	return false
 }
 
-var errFlagAfterArgs = errors.New(strings.TrimSpace(`
-Flags must be specified before positional arguments when using Go standard 
-library style flags. For example, "nomad-pack plan -verbose example" instead
-of "nomad-pack plan example -verbose".
+var errFlagAfterArgs = errors.New(strings.ReplaceAll(strings.TrimSpace(`
+	Flags must be specified before positional arguments when using Go standard
+	library style flags. For example, "nomad-pack plan -verbose example" instead
+	of "nomad-pack plan example -verbose".
 
-The CLI also accepts posix flags, which does allow flags after positional
-arguments. For example, both "nomad-pack plan --verbose example" and 
-"nomad-pack plan example --verbose" are valid commands.`))
+	The CLI also accepts posix flags, which does allow flags after positional
+	arguments. For example, both "nomad-pack plan --verbose example" and
+	"nomad-pack plan example --verbose" are valid commands.`), "\t", " "))

--- a/internal/pkg/spinner/README.md
+++ b/internal/pkg/spinner/README.md
@@ -240,7 +240,7 @@ fmt.Println(s.Active())
 
 Feature suggested and write up by [dekz](https://github.com/dekz)
 
-Setting the Spinner Writer to Stderr helps show progress to the user, with the enhancement to chain, pipe or redirect the output. 
+Setting the Spinner Writer to Stderr helps show progress to the user, with the enhancement to chain, pipe or redirect the output.
 
 This is the preferred method of setting a Writer at this time.
 
@@ -269,9 +269,9 @@ Add additional output when the spinner/indicator has completed. The "final" outp
 ```Go
 s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 s.FinalMSG = "Complete!\nNew line!\nAnother one!\n"
-s.Start()                 
+s.Start()
 time.Sleep(4 * time.Second)
-s.Stop()                   
+s.Stop()
 ```
 
 Output


### PR DESCRIPTION
Standardizing the spacing throughout the project.
- Tabs to indent continuation lines in long rawstrings.
- Remove trailing whitespace.
