### PR TITLE
Add operations flagset to status command for --name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 BUG FIXES:
+* cli: Add missing --name flag for status command [[GH-212](https://github.com/hashicorp/nomad-pack/pull/212)]
 
 IMPROVEMENTS:
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -302,8 +302,11 @@ func TestStatusFails(t *testing.T) {
 	defer reset()
 	statusCmd := &StatusCommand{baseCommand: baseCmd()}
 
+	// test validation for name flag without pack
 	exitCode := statusCmd.Run([]string{"--name=foo"})
 	require.Equal(t, 1, exitCode)
+	// TODO: Check for correct output (this test has been passing, but has actually been broken)
+	// "--name can only be used if pack name is provided"
 }
 
 var nomadAddr string

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -97,7 +97,7 @@ func (c *StatusCommand) renderAllDeployedPacks(jobsApi *v1.Jobs, errorContext *e
 }
 
 func (c *StatusCommand) Flags() *flag.Sets {
-	return c.flagSet(0, func(set *flag.Sets) {
+	return c.flagSet(flagSetOperation, func(set *flag.Sets) {
 		c.packConfig = &cache.PackConfig{}
 
 		f := set.NewSet("Status Options")


### PR DESCRIPTION
**Description**
The `TestStatusFails` test was supposed to be validating that providing the `--name` flag absent a pack name was an error; however, the test currently only looks for a non-successful error code.  In this case, the `--name` flag was missing from the status command, but since that error also returned exitcode 1 the test was passing anyway.

I've updated the command, and there is a big test improvement PR coming that will enable us to check the returned errors from command calls.

**Reminders**
- [x] Add `CHANGELOG.md` entry
