### PR TITLE
Use Pack metadata `Name` in error context once known.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 * cli: Add missing --name flag for status command [[GH-212](https://github.com/hashicorp/nomad-pack/pull/212)]
+* cli: Use Pack metadata `Name` in error context once known [[GH-217](https://github.com/hashicorp/nomad-pack/pull/217)
 
 IMPROVEMENTS:
 * cli: Add flags to configure Nomad API client [[GH-213](https://github.com/hashicorp/nomad-pack/pull/213)]

--- a/fixtures/variable_test/unexpected.vars.hcl
+++ b/fixtures/variable_test/unexpected.vars.hcl
@@ -1,0 +1,3 @@
+much = 10000000
+surprise = "very"
+wow = true

--- a/fixtures/variable_test/variable_test/README.md
+++ b/fixtures/variable_test/variable_test/README.md
@@ -2,6 +2,9 @@
 
 This pack can be used to test variable passing into nomad-pack.
 
+> **NOTE**: The pack's folder name doesn't match the pack's name intentionally
+> to test error context output when running a pack from the filesystem.
+
 ## Inputs
 
 * **input** [default: `default`]- This is the only variable used in the template.

--- a/fixtures/variable_test/variable_test/metadata.hcl
+++ b/fixtures/variable_test/variable_test/metadata.hcl
@@ -4,8 +4,8 @@ app {
 }
 
 pack {
-  name        = "variable_test"
-  description = "This pack tests a variable overrides"
+  name        = "variable_test_pack"
+  description = "This pack tests variable overrides"
   url         = ""
   version     = "0.0.1"
 }

--- a/fixtures/variable_test/variable_test/templates/test.nomad.tpl
+++ b/fixtures/variable_test/variable_test/templates/test.nomad.tpl
@@ -1,1 +1,1 @@
-[[.variable_test.input]]
+[[.variable_test_pack.input]]

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -353,7 +353,7 @@ func TestStatus(t *testing.T) {
 				args := append([]string{"status"}, tc.args...)
 				result := runTestPackCmd(t, s, args)
 				require.Equal(t, 0, result.exitCode)
-				require.Contains(t, result.cmdOut.String(), "simple_raw_exec | dev ")
+				require.Contains(t, result.cmdOut.String(), "simple_raw_exec | "+cache.DevRegistryName+" ")
 			})
 		}
 	})

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -24,7 +24,9 @@ func initPackCommand(cfg *cache.PackConfig) (errorContext *errors.UIErrorContext
 	errorContext.Add(errors.UIContextPrefixRegistryName, cfg.Registry)
 	errorContext.Add(errors.UIContextPrefixPackName, cfg.Name)
 	errorContext.Add(errors.UIContextPrefixPackRef, cfg.Ref)
-
+	if cfg.Registry == cache.DevRegistryName && cfg.Ref == cache.DevRef {
+		errorContext.Add(errors.UIContextPrefixPackPath, cfg.Path)
+	}
 	return
 }
 

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -106,6 +106,8 @@ func registryPackRow(cachedRegistry *cache.Registry, cachedPack *cache.Pack) []t
 func renderPack(manager *manager.PackManager, ui terminal.UI, errCtx *errors.UIErrorContext) (*renderer.Rendered, error) {
 	r, err := manager.ProcessTemplates()
 	if err != nil {
+		packName := manager.PackName()
+		errCtx.Add(errors.UIContextPrefixPackName, packName)
 		for i := range err {
 			err[i].Context.Append(errCtx)
 			ui.ErrorWithContext(err[i].Err, "failed to process pack", err[i].Context.GetAll()...)

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -15,8 +15,8 @@ const (
 	DefaultRegistryName   = "default"
 	DefaultRegistrySource = "github.com/hashicorp/nomad-pack-community-registry"
 	DefaultRef            = "latest"
-	DevRegistryName       = "dev"
-	DevRef                = "dev"
+	DevRegistryName       = "<<local folder>>"
+	DevRef                = "<<none>>"
 )
 
 // NewCache instantiates a new cache instance with the specified config. If no

--- a/internal/pkg/errors/error_context.go
+++ b/internal/pkg/errors/error_context.go
@@ -13,8 +13,20 @@ type ErrorContext struct {
 // NewErrorContext creates an empty ErrorContext.
 func NewErrorContext() *ErrorContext { return &ErrorContext{} }
 
-// Add formats and appends the passed prefix and value onto the error contexts.
+// Add formats and upserts the passed prefix and value onto the error contexts.
 func (ctx *ErrorContext) Add(prefix, val string) {
+	idx := -1
+	for i, c := range ctx.contexts {
+		if strings.HasPrefix(c, prefix) {
+			idx = i
+			break
+		}
+	}
+	if idx != -1 {
+		ctx.contexts[idx] = prefix + val
+		return
+	}
+
 	ctx.contexts = append(ctx.contexts, prefix+val)
 }
 

--- a/internal/pkg/errors/ui_context.go
+++ b/internal/pkg/errors/ui_context.go
@@ -36,8 +36,20 @@ type UIErrorContext struct {
 // NewUIErrorContext creates an empty UIErrorContext.
 func NewUIErrorContext() *UIErrorContext { return &UIErrorContext{} }
 
-// Add formats and appends the passed prefix and value onto the error contexts.
+// Add formats and upserts the passed prefix and value onto the error contexts.
 func (u *UIErrorContext) Add(prefix, val string) {
+	idx := -1
+	for i, c := range u.contexts {
+		if strings.HasPrefix(c, prefix) {
+			idx = i
+			break
+		}
+	}
+	if idx != -1 {
+		u.contexts[idx] = prefix + val
+		return
+	}
+
 	u.contexts = append(u.contexts, prefix+val)
 }
 

--- a/internal/pkg/manager/manager.go
+++ b/internal/pkg/manager/manager.go
@@ -28,6 +28,9 @@ type PackManager struct {
 	cfg      *Config
 	client   *v1.Client
 	renderer *renderer.Renderer
+
+	// loadedPack is unavailable until the loadAndValidatePacks func is run.
+	loadedPack *pack.Pack
 }
 
 func NewPackManager(cfg *Config, client *v1.Client) *PackManager {
@@ -54,6 +57,8 @@ func (pm *PackManager) ProcessTemplates() (*renderer.Rendered, []*errors.Wrapped
 			Context: errors.NewUIErrorContext(),
 		}}
 	}
+
+	pm.loadedPack = loadedPack
 
 	// Root vars are nested under the parent pack name, which is currently
 	// just the pack name without the version. We want to slice the string
@@ -162,4 +167,17 @@ func (pm *PackManager) loadAndValidatePack(cur *pack.Pack, depsPath string) erro
 	}
 
 	return nil
+}
+
+func (pm *PackManager) PackName() string {
+	if pm.loadedPack != nil {
+		return pm.loadedPack.Name()
+	}
+
+	name := path.Base(pm.cfg.Path)
+	idx := strings.LastIndex(path.Base(pm.cfg.Path), "@")
+	if idx != -1 {
+		name = path.Base(pm.cfg.Path)[0:idx]
+	}
+	return name
 }


### PR DESCRIPTION
**Description**
- Add test fixtures for `nomad-pack #214` - #214
- Less likely sentinel values for pack from folder
- Add pack path to error context for pack from file
- Store `loadedPack` in pack manager
- Make `Add` an upsert in error context
- Retrieve packname from manager; upsert into err context
- Add changelog

**Reminders**
- [x] Add `CHANGELOG.md` entry

Closes #214