### PR TITLE
template: Add support for custom Spew configurations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ BUG FIXES:
 
 IMPROVEMENTS:
 * cli: Add flags to configure Nomad API client [[GH-213](https://github.com/hashicorp/nomad-pack/pull/213)]
+* template: Add support for custom Spew configurations. [[GH-220](https://github.com/hashicorp/nomad-pack/pull/220)]
 
 ## 0.0.1-techpreview2 (February 07, 2022)
 

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/zclconf/go-cty v1.9.0
-	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	google.golang.org/grpc v1.44.0
 )
 
@@ -235,11 +235,11 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	github.com/zclconf/go-cty-yaml v1.0.2 // indirect
 	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
-	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/internal/pkg/renderer/funcs.go
+++ b/internal/pkg/renderer/funcs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"strconv"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
@@ -96,193 +95,47 @@ func toStringList(l []interface{}) (string, error) {
 }
 
 // Spew helper funcs
-func withIndent(in string, v interface{}) (interface{}, error) {
-	act := "withIndent"
-	spew, err := parseSpewParam(act, v)
-	if err != nil {
-		return nil, err
-	}
-	spew.Indent = in
-	return spew, nil
+func withIndent(in string, s *spew.ConfigState) interface{} {
+	s.Indent = in
+	return s
 }
 
-func withMaxDepth(in, inS interface{}) (interface{}, error) {
-	act := "withMaxDepth"
-	i, err := parseIntParam(act, in)
-	if err != nil {
-		return nil, err
-	}
+func withMaxDepth(in int, s *spew.ConfigState) interface{} {
+	s.MaxDepth = in
+	return s
+}
 
-	s, err := parseSpewParam(act, inS)
-	if err != nil {
-		return nil, err
-	}
-	s.MaxDepth = i
+func withDisableMethods(s *spew.ConfigState) interface{} {
+	s.DisableMethods = true
+	return s
+}
+
+func withDisablePointerMethods(s *spew.ConfigState) interface{} {
+	s.DisablePointerMethods = true
+	return s
+}
+
+func withDisablePointerAddresses(s *spew.ConfigState) interface{} {
+	s.DisablePointerAddresses = true
+	return s
+}
+
+func withDisableCapacities(s *spew.ConfigState) interface{} {
+	s.DisableCapacities = true
+	return s
+}
+
+func withContinueOnMethod(s *spew.ConfigState) (interface{}, error) {
+	s.ContinueOnMethod = true
 	return s, nil
 }
 
-func withDisableMethods(in, inS interface{}) (interface{}, error) {
-	act := "withDisableMethods"
-	b, err := parseBoolParam(act, in)
-	if err != nil {
-		return nil, err
-	}
-
-	s, err := parseSpewParam(act, inS)
-	if err != nil {
-		return nil, err
-	}
-	s.DisableMethods = b
-	return s, nil
+func withSortKeys(s *spew.ConfigState) interface{} {
+	s.SortKeys = true
+	return s
 }
 
-func withDisablePointerMethods(in, inS interface{}) (interface{}, error) {
-	act := "withDisablePointerMethods"
-	b, err := parseBoolParam(act, in)
-	if err != nil {
-		return nil, err
-	}
-
-	s, err := parseSpewParam(act, inS)
-	if err != nil {
-		return nil, err
-	}
-	s.DisablePointerMethods = b
-	return s, nil
-}
-
-func withDisablePointerAddresses(in, inS interface{}) (interface{}, error) {
-	act := "withDisablePointerAddresses"
-	b, err := parseBoolParam(act, in)
-	if err != nil {
-		return nil, err
-	}
-
-	s, err := parseSpewParam(act, inS)
-	if err != nil {
-		return nil, err
-	}
-	s.DisablePointerAddresses = b
-	return s, nil
-}
-
-func withDisableCapacities(in, inS interface{}) (interface{}, error) {
-	act := "withDisableCapacities"
-	b, err := parseBoolParam(act, in)
-	if err != nil {
-		return nil, err
-	}
-
-	s, err := parseSpewParam(act, inS)
-	if err != nil {
-		return nil, err
-	}
-	s.DisableCapacities = b
-	return s, nil
-}
-
-func withContinueOnMethod(in, inS interface{}) (interface{}, error) {
-	act := "withContinueOnMethod"
-	b, err := parseBoolParam(act, in)
-	if err != nil {
-		return nil, err
-	}
-
-	s, err := parseSpewParam(act, inS)
-	if err != nil {
-		return nil, err
-	}
-	s.ContinueOnMethod = b
-	return s, nil
-}
-
-func withSortKeys(in, inS interface{}) (interface{}, error) {
-	act := "withSortKeys"
-	b, err := parseBoolParam(act, in)
-	if err != nil {
-		return nil, err
-	}
-
-	s, err := parseSpewParam(act, inS)
-	if err != nil {
-		return nil, err
-	}
-	s.SortKeys = b
-	return s, nil
-}
-
-func withSpewKeys(in, inS interface{}) (interface{}, error) {
-	act := "withSpewKeys"
-	b, err := parseBoolParam(act, in)
-	if err != nil {
-		return nil, err
-	}
-
-	s, err := parseSpewParam(act, inS)
-	if err != nil {
-		return nil, err
-	}
-	s.SpewKeys = b
-	return s, nil
-}
-
-type ErrSpewConfig struct {
-	act    string
-	got    string
-	expect string
-}
-
-func newErrSpewConfig(act, expect string, got interface{}) ErrSpewConfig {
-	return ErrSpewConfig{
-		act:    act,
-		expect: expect,
-		got:    fmt.Sprintf("%T", got),
-	}
-}
-
-func (e ErrSpewConfig) Error() string {
-	return fmt.Sprintf("invalid parameter: expected %s, received %s", e.expect, e.got)
-}
-
-func parseBoolParam(act string, in interface{}) (bool, error) {
-	var b bool
-	switch in := in.(type) {
-	case bool:
-		b = in
-	case string:
-		var err error
-		b, err = strconv.ParseBool(in)
-		if err != nil {
-			return false, newErrSpewConfig(act, "bool or bool-like string", in)
-		}
-	default:
-		return false, newErrSpewConfig(act, "bool or bool-like string", in)
-	}
-	return b, nil
-}
-
-func parseIntParam(act string, in interface{}) (int, error) {
-	var i int
-	switch in := in.(type) {
-	case int:
-		i = in
-	case string:
-		var err error
-		pi, err := strconv.ParseInt(in, 0, 32)
-		i = int(pi)
-		if err != nil {
-			return -1, newErrSpewConfig(act, "int or int-like string", in)
-		}
-	default:
-		return -1, newErrSpewConfig(act, "int or int-like string", in)
-	}
-	return i, nil
-}
-
-func parseSpewParam(act string, in interface{}) (*spew.ConfigState, error) {
-	if spew, ok := in.(*spew.ConfigState); ok {
-		return spew, nil
-	} else {
-		return nil, newErrSpewConfig(act, "*spew.ConfigState", spew)
-	}
+func withSpewKeys(s *spew.ConfigState) interface{} {
+	s.SpewKeys = true
+	return s
 }

--- a/internal/pkg/renderer/funcs.go
+++ b/internal/pkg/renderer/funcs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"strconv"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
@@ -23,6 +24,17 @@ func funcMap(nomadClient *v1.Client) template.FuncMap {
 	// variables.
 	f["spewDump"] = spew.Sdump
 	f["spewPrintf"] = spew.Sprintf
+	f["customSpew"] = spew.NewDefaultConfig
+	f["withIndent"] = withIndent
+	f["withMaxDepth"] = withMaxDepth
+	f["withDisableMethods"] = withDisableMethods
+	f["withDisablePointerMethods"] = withDisablePointerMethods
+	f["withDisablePointerAddresses"] = withDisablePointerAddresses
+	f["withDisableCapacities"] = withDisableCapacities
+	f["withContinueOnMethod"] = withContinueOnMethod
+	f["withDisableMethods"] = withDisableMethods
+	f["withSortKeys"] = withSortKeys
+	f["withSpewKeys"] = withSpewKeys
 
 	if nomadClient != nil {
 		f["nomadNamespaces"] = nomadNamespaces(nomadClient)
@@ -81,4 +93,196 @@ func toStringList(l []interface{}) (string, error) {
 		out += fmt.Sprintf("%q", l[i])
 	}
 	return "[" + out + "]", nil
+}
+
+// Spew helper funcs
+func withIndent(in string, v interface{}) (interface{}, error) {
+	act := "withIndent"
+	spew, err := parseSpewParam(act, v)
+	if err != nil {
+		return nil, err
+	}
+	spew.Indent = in
+	return spew, nil
+}
+
+func withMaxDepth(in, inS interface{}) (interface{}, error) {
+	act := "withMaxDepth"
+	i, err := parseIntParam(act, in)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := parseSpewParam(act, inS)
+	if err != nil {
+		return nil, err
+	}
+	s.MaxDepth = i
+	return s, nil
+}
+
+func withDisableMethods(in, inS interface{}) (interface{}, error) {
+	act := "withDisableMethods"
+	b, err := parseBoolParam(act, in)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := parseSpewParam(act, inS)
+	if err != nil {
+		return nil, err
+	}
+	s.DisableMethods = b
+	return s, nil
+}
+
+func withDisablePointerMethods(in, inS interface{}) (interface{}, error) {
+	act := "withDisablePointerMethods"
+	b, err := parseBoolParam(act, in)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := parseSpewParam(act, inS)
+	if err != nil {
+		return nil, err
+	}
+	s.DisablePointerMethods = b
+	return s, nil
+}
+
+func withDisablePointerAddresses(in, inS interface{}) (interface{}, error) {
+	act := "withDisablePointerAddresses"
+	b, err := parseBoolParam(act, in)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := parseSpewParam(act, inS)
+	if err != nil {
+		return nil, err
+	}
+	s.DisablePointerAddresses = b
+	return s, nil
+}
+
+func withDisableCapacities(in, inS interface{}) (interface{}, error) {
+	act := "withDisableCapacities"
+	b, err := parseBoolParam(act, in)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := parseSpewParam(act, inS)
+	if err != nil {
+		return nil, err
+	}
+	s.DisableCapacities = b
+	return s, nil
+}
+
+func withContinueOnMethod(in, inS interface{}) (interface{}, error) {
+	act := "withContinueOnMethod"
+	b, err := parseBoolParam(act, in)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := parseSpewParam(act, inS)
+	if err != nil {
+		return nil, err
+	}
+	s.ContinueOnMethod = b
+	return s, nil
+}
+
+func withSortKeys(in, inS interface{}) (interface{}, error) {
+	act := "withSortKeys"
+	b, err := parseBoolParam(act, in)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := parseSpewParam(act, inS)
+	if err != nil {
+		return nil, err
+	}
+	s.SortKeys = b
+	return s, nil
+}
+
+func withSpewKeys(in, inS interface{}) (interface{}, error) {
+	act := "withSpewKeys"
+	b, err := parseBoolParam(act, in)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := parseSpewParam(act, inS)
+	if err != nil {
+		return nil, err
+	}
+	s.SpewKeys = b
+	return s, nil
+}
+
+type ErrSpewConfig struct {
+	act    string
+	got    string
+	expect string
+}
+
+func newErrSpewConfig(act, expect string, got interface{}) ErrSpewConfig {
+	return ErrSpewConfig{
+		act:    act,
+		expect: expect,
+		got:    fmt.Sprintf("%T", got),
+	}
+}
+
+func (e ErrSpewConfig) Error() string {
+	return fmt.Sprintf("invalid parameter: expected %s, received %s", e.expect, e.got)
+}
+
+func parseBoolParam(act string, in interface{}) (bool, error) {
+	var b bool
+	switch in := in.(type) {
+	case bool:
+		b = in
+	case string:
+		var err error
+		b, err = strconv.ParseBool(in)
+		if err != nil {
+			return false, newErrSpewConfig(act, "bool or bool-like string", in)
+		}
+	default:
+		return false, newErrSpewConfig(act, "bool or bool-like string", in)
+	}
+	return b, nil
+}
+
+func parseIntParam(act string, in interface{}) (int, error) {
+	var i int
+	switch in := in.(type) {
+	case int:
+		i = in
+	case string:
+		var err error
+		pi, err := strconv.ParseInt(in, 0, 32)
+		i = int(pi)
+		if err != nil {
+			return -1, newErrSpewConfig(act, "int or int-like string", in)
+		}
+	default:
+		return -1, newErrSpewConfig(act, "int or int-like string", in)
+	}
+	return i, nil
+}
+
+func parseSpewParam(act string, in interface{}) (*spew.ConfigState, error) {
+	if spew, ok := in.(*spew.ConfigState); ok {
+		return spew, nil
+	} else {
+		return nil, newErrSpewConfig(act, "*spew.ConfigState", spew)
+	}
 }

--- a/internal/pkg/renderer/funcs.go
+++ b/internal/pkg/renderer/funcs.go
@@ -21,8 +21,8 @@ func funcMap(nomadClient *v1.Client) template.FuncMap {
 
 	// Add debugging functions. These are useful when debugging templates and
 	// variables.
-	f["spewDump"] = spewDump
-	f["spewPrintf"] = spewPrintf
+	f["spewDump"] = spew.Sdump
+	f["spewPrintf"] = spew.Sprintf
 
 	if nomadClient != nil {
 		f["nomadNamespaces"] = nomadNamespaces(nomadClient)
@@ -82,11 +82,3 @@ func toStringList(l []interface{}) (string, error) {
 	}
 	return "[" + out + "]", nil
 }
-
-// spewDump dumps the entire contents of the interface as a string. The output
-// includes the content types and values and is extremely useful for debugging.
-func spewDump(a interface{}) string { return spew.Sdump(a) }
-
-// spewPrintf dumps the supplied arguments into a string according to the
-// supplied format. This is useful when debugging.
-func spewPrintf(format string, args ...interface{}) string { return spew.Sprintf(format, args) }

--- a/internal/pkg/renderer/funcs_test.go
+++ b/internal/pkg/renderer/funcs_test.go
@@ -1,9 +1,13 @@
 package renderer
 
 import (
+	"bytes"
 	"testing"
+	"text/template"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_toStringList(t *testing.T) {
@@ -28,5 +32,212 @@ func Test_toStringList(t *testing.T) {
 	for _, tc := range testCases {
 		actualOutput, _ := toStringList(tc.input)
 		assert.Equal(t, tc.expectedOutput, actualOutput)
+	}
+}
+
+const (
+	// Baseline spew output
+	outB = "(renderer.Foo) {\n unexportedField: (renderer.Bar) {\n  data: (*uint)(100)\n },\n ExportedField: (map[interface {}]interface {}) (len=1) {\n  (string) (len=3) \"one\": (bool) true\n }\n}\n"
+	// Indent test output with indent set to ∫
+	outI = "(renderer.Foo) {\n∫unexportedField: (renderer.Bar) {\n∫∫data: (*uint)(100)\n∫},\n∫ExportedField: (map[interface {}]interface {}) (len=1) {\n∫∫(string) (len=3) \"one\": (bool) true\n∫}\n}\n"
+	// MaxDepth output for MaxDepth = 1
+	outM = "(renderer.Foo) {\n unexportedField: (renderer.Bar) {\n  <max depth reached>\n },\n ExportedField: (map[interface {}]interface {}) (len=1) {\n  <max depth reached>\n }\n}\n"
+)
+
+func TestSpewHelpers(t *testing.T) {
+	noPointerSpew := func() *spew.ConfigState {
+		cs := spew.NewDefaultConfig()
+		cs.DisablePointerAddresses = true
+		cs.SortKeys = true
+		return cs
+	}
+
+	testCases := []struct {
+		desc      string
+		input     func(*spew.ConfigState) interface{}
+		spew      func() *spew.ConfigState
+		expect    interface{}
+		expectErr bool
+	}{
+		{
+			desc:   "noop",
+			expect: outB,
+			spew:   noPointerSpew,
+			input: func(cs *spew.ConfigState) interface{} {
+				return cs
+			},
+		},
+		{
+			desc:   "indent",
+			expect: outI,
+			spew:   noPointerSpew,
+			input: func(cs *spew.ConfigState) interface{} {
+				s, err := withIndent("∫", cs)
+				if err != nil {
+					return err
+				}
+				return s
+			},
+		},
+		{
+			desc:      "maxdepth-bad",
+			expect:    "invalid parameter: expected int or int-like string, received string",
+			expectErr: true,
+			spew:      noPointerSpew,
+			input: func(cs *spew.ConfigState) interface{} {
+				s, err := withMaxDepth("BAD", cs)
+				if err != nil {
+					return err
+				}
+				return s
+			},
+		},
+		{
+			desc:   "maxdepth-string",
+			expect: outM,
+			spew:   noPointerSpew,
+			input: func(cs *spew.ConfigState) interface{} {
+				s, err := withMaxDepth("1", cs)
+				if err != nil {
+					return err
+				}
+				return s
+			},
+		},
+		{
+			desc:   "maxdepth-int",
+			expect: outM,
+			spew:   noPointerSpew,
+			input: func(cs *spew.ConfigState) interface{} {
+				s, err := withMaxDepth(1, cs)
+				if err != nil {
+					return err
+				}
+				return s
+			},
+		},
+		{
+			desc:   "good_bool",
+			expect: outB,
+			spew:   spew.NewDefaultConfig, // using the default which contains pointer addresses.
+			input: func(cs *spew.ConfigState) interface{} {
+				s, err := withDisablePointerAddresses("true", cs)
+				if err != nil {
+					return err
+				}
+				return s
+			},
+		},
+		{
+			desc:      "bad_bool",
+			expect:    "invalid parameter: expected bool or bool-like string, received string",
+			expectErr: true,
+			spew:      spew.NewDefaultConfig,
+			input: func(cs *spew.ConfigState) interface{} {
+				s, err := withDisablePointerAddresses("BAD", cs)
+				if err != nil {
+					return err
+				}
+				return s
+			},
+		},
+	}
+	type Bar struct {
+		data *uint
+	}
+
+	type Foo struct {
+		unexportedField Bar
+		ExportedField   map[interface{}]interface{}
+	}
+	var a uint = 100
+	bar := Bar{&a}
+	s1 := Foo{bar, map[interface{}]interface{}{"one": true}}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			c := tC.spew()
+			o := tC.input(c)
+			switch o := o.(type) {
+			case *spew.ConfigState:
+				c = o
+			case error:
+				if tC.expectErr {
+					require.Error(t, o)
+					require.Equal(t, tC.expect, o.Error())
+					return
+				} else {
+					require.FailNow(t, "unexpected error", "error: %v", o)
+				}
+			default:
+				require.FailNow(t, "o not a *spew.ConfigState, got %T", o)
+			}
+
+			out := c.Sdump(s1)
+			require.Equal(t, tC.expect, out)
+		})
+	}
+}
+
+func TestSpewHelpersInTemplate(t *testing.T) {
+
+	testCases := []struct {
+		desc      string
+		input     string
+		expect    interface{}
+		expectErr bool
+	}{
+		{
+			desc:   "baseline",
+			expect: outB,
+			input:  "[[ $A := customSpew | withDisablePointerAddresses true ]][[$A.Sdump .]]",
+		},
+		{
+			desc:   "indent",
+			expect: outI,
+			input:  `[[ $A := customSpew | withDisablePointerAddresses true | withIndent "∫"]][[$A.Sdump .]]`,
+		},
+		{
+			desc:   "maxdepth-int",
+			expect: outM,
+			input:  "[[ $A := customSpew | withDisablePointerAddresses true | withMaxDepth 1 ]][[$A.Sdump .]]",
+		},
+		{
+			desc:   "maxdepth-string",
+			expect: outM,
+			input:  `[[ $A := customSpew | withDisablePointerAddresses true | withMaxDepth "1" ]][[$A.Sdump .]]`,
+		},
+		{
+			desc:      "maxdepth-bad",
+			expect:    "error calling withMaxDepth: invalid parameter: expected int or int-like string, received string",
+			expectErr: true,
+			input:     `[[ $A := customSpew | withDisablePointerAddresses true | withMaxDepth "bad" ]][[$A.Sdump .]]`,
+		},
+	}
+	type Bar struct {
+		data *uint
+	}
+
+	type Foo struct {
+		unexportedField Bar
+		ExportedField   map[interface{}]interface{}
+	}
+	var a uint = 100
+	bar := Bar{&a}
+	s1 := Foo{bar, map[interface{}]interface{}{"one": true}}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			var b bytes.Buffer
+			tpl := template.Must(template.New("test").Funcs(funcMap(nil)).Delims("[[", "]]").Parse(tC.input))
+			err := tpl.Execute(&b, s1)
+			if tC.expectErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tC.expect)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tC.expect, b.String())
+		})
 	}
 }


### PR DESCRIPTION
**Description**
Adds a `customSpew` function and several `with...` functions to set the [spew.ConfigState](https://pkg.go.dev/github.com/davecgh/go-spew/spew#ConfigState) parameters. 

**Reminders**
- [x] Add `CHANGELOG.md` entry
