### PR TITLE
Skip upload action if running in `act`

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -33,7 +33,7 @@ jobs:
       # Upload the original go test log as an artifact for later review.
       - name: Upload test log
         uses: actions/upload-artifact@v2
-        if: always()
+        if: ${{ !env.ACT }}
         with:
           name: test-log
           path: /tmp/test-output.log


### PR DESCRIPTION
**Description**
Updates the go-test action to skip the upload step when running the GitHub actions using [`act`](https://github.com/nektos/act)
