### PR TITLE
[chore] Update config for golang-ci-lint action

### DIFF
--- a/.github/workflows/golang-ci-lint.yml
+++ b/.github/workflows/golang-ci-lint.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
-        with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.42.0
+        


### PR DESCRIPTION
This resolves unexpected issues with the linter.  By default the `actions/setup-go@v2` installs `go1.15.15 linux/amd64`
