### PR TITLE
[generate] Fix typo in generator's helper template

### DIFF
--- a/internal/creator/templates/pack_helpers.tpl
+++ b/internal/creator/templates/pack_helpers.tpl
@@ -3,7 +3,7 @@
 [[- if eq .my.job_name "" -]]
 [[- .nomad_pack.pack.name | quote -]]
 [[- else -]]
-[[- .myjob_name | quote -]]
+[[- .my.job_name | quote -]]
 [[- end ]]
 [[- end ]]
 


### PR DESCRIPTION
**Description**
There's a missing `.` in the template. 😢 Not a released issue, so skipping the changelog for it.

**Reminders**

- [ ] ~Add `CHANGELOG.md` entry~
