### PR TITLE
docs: nested template requires `.` to pass variables

### DIFF
--- a/docs/writing-packs.md
+++ b/docs/writing-packs.md
@@ -225,7 +225,7 @@ Then in the parent templates, "job_a.nomad.tpl" and "job_b.nomad.tpl", we would 
 job "job_a" {
   type = "service"
 
-  [[template "region"]]
+  [[ template "region" . ]]
 
   ...etc...
 }


### PR DESCRIPTION
Without including the `.` in the nested template caller, the variables
for the parent won't be rendered in the child templates.

Ran into this while working on https://github.com/hashicorp/nomad-pack-community-registry/pull/113 and was very confused :grinning: