### PR TITLE
docs: remove author and url fields from writing packs

### DIFF
--- a/docs/writing-packs.md
+++ b/docs/writing-packs.md
@@ -48,10 +48,8 @@ The directory should have the following contents:
 The `metadata.hcl` file contains important key value information regarding the pack. It contains the following blocks and their associated fields:
 
 - "app {url}" - The HTTP(S) url to the homepage of the application to provide a quick reference to the documentation and help pages.
-- "app {author}" - An identifier to the author and maintainer of the pack.
 - "pack {name}" - The name of the pack.
 - "pack {description}" - A small overview of the application that is deployed by the pack.
-- "pack {url}" - The source URL for the pack itself.
 - "pack {version}" - The version of the pack.
 - "dependency {name}" - The dependencies that the pack has on other packs. Multiple dependencies can be supplied.
 - "dependency {source}" - The source URL for this dependency.
@@ -61,13 +59,11 @@ An example `metadata.hcl` file:
 ```
 app {
   url = "https://github.com/mikenomitch/hello_world_server"
-  author = "Mike Nomitch"
 }
 
 pack {
   name = "hello_world"
   description = "This pack contains a single job that renders hello world, or a different greeting, to the screen."
-  url = "https://github.com/hashicorp/nomad-pack-community-registry/hello_world"
   version = "0.3.2"
 }
 ```


### PR DESCRIPTION
Originally `app.author` was intended to be the actual author of the
app, but many pack maintainers put their own names here. We have the
GitHub handles of the actual maintainers, so remove this field from
the guide.

Likewise, the `pack.url` field doesn't match the actual registry URL
if someone forks a registry. Remove that field as well.

ref conversation with @mikenomitch in https://github.com/hashicorp/nomad-pack-community-registry/pull/113#discussion_r848825515 and https://github.com/hashicorp/nomad-pack-community-registry/pull/113#discussion_r848827897