### PR TITLE
release: Remove sample RedHat docker container artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,22 +250,3 @@ jobs:
           dev_tags: |
             hashicorppreview/${{ env.repo }}:${{ env.version }}-dev
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.version }}-${{ github.sha }}
-
-  build-docker-redhat:
-    name: Docker ${{ matrix.arch }} redhat release build
-    needs:
-      - get-product-version
-      - build-linux
-    runs-on: ubuntu-latest
-    env:
-      repo: ${{ github.event.repository.name }}
-      version: ${{ needs.get-product-version.outputs.product-version }}
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: hashicorp/actions-docker-build@v1
-        with:
-          version: ${{ env.version }}
-          target: release
-          arch: amd64
-          redhat_tag: scan.connect.redhat.com/ospid-62211e0d8bf2cabc69a39c7d/${{ env.repo }}:${{ env.version }}-ubi


### PR DESCRIPTION
**Description**
In migrating to the common release toolkit, I left a sample Redhat container configuration in the build.yaml.  This PR removes it.
