### PR TITLE
removes duplicate `this`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ FEATURES:
 BUG FIXES:
 
 * cli: Add missing --name flag for status command [[GH-212](https://github.com/hashicorp/nomad-pack/pull/212)]
+* cli: Remove duplicate `this` in some command outputs [[GH-251](https://github.com/hashicorp/nomad-pack/pull/251)]
 * cli: Use Pack metadata `Name` in error context once known [[GH-217](https://github.com/hashicorp/nomad-pack/pull/217)]
 * runner: Update runner to properly handle dependencies [[GH-229](https://github.com/hashicorp/nomad-pack/pull/229)]
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -135,9 +135,9 @@ func (c *RunCommand) run() int {
 	}
 
 	if c.packConfig.Registry == cache.DevRegistryName {
-		c.ui.Success(fmt.Sprintf("Pack successfully deployed. Use %s to manage this this deployed instance with plan, stop, destroy, or info", c.packConfig.SourcePath))
+		c.ui.Success(fmt.Sprintf("Pack successfully deployed. Use %s to manage this deployed instance with plan, stop, destroy, or info", c.packConfig.SourcePath))
 	} else {
-		c.ui.Success(fmt.Sprintf("Pack successfully deployed. Use %s with --ref=%s to manage this this deployed instance with plan, stop, destroy, or info", c.packConfig.Name, c.packConfig.Ref))
+		c.ui.Success(fmt.Sprintf("Pack successfully deployed. Use %s with --ref=%s to manage this deployed instance with plan, stop, destroy, or info", c.packConfig.Name, c.packConfig.Ref))
 	}
 
 	output, err := packManager.ProcessOutputTemplate()


### PR DESCRIPTION
**Description**

Removes a duplicate `this` (`manage this this deployed` -> `manage this deployed`)

**Reminders**

- [x] Add `CHANGELOG.md` entry
