### PR TITLE
helper: swap strings.Title for helper.Title

### DIFF
--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	v1client "github.com/hashicorp/nomad-openapi/clients/go/v1"
@@ -11,6 +10,7 @@ import (
 	"github.com/hashicorp/nomad-pack/internal/pkg/errors"
 	"github.com/hashicorp/nomad-pack/internal/pkg/flag"
 	"github.com/hashicorp/nomad-pack/internal/pkg/renderer"
+	"github.com/hashicorp/nomad-pack/sdk/helper"
 	"github.com/posener/complete"
 )
 
@@ -140,7 +140,7 @@ func (c *StopCommand) Run(args []string) int {
 
 		// TODO: add interactive support
 		if !c.confirmStop() {
-			c.ui.Info(fmt.Sprintf("%s job %q aborted by user", strings.Title(stopOrDestroy), job.GetID()))
+			c.ui.Info(fmt.Sprintf("%s job %q aborted by user", helper.Title(stopOrDestroy), job.GetID()))
 			continue
 		}
 

--- a/internal/pkg/variable/error.go
+++ b/internal/pkg/variable/error.go
@@ -2,9 +2,9 @@ package variable
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/nomad-pack/sdk/helper"
 )
 
 func safeDiagnosticsAppend(base hcl.Diagnostics, new *hcl.Diagnostic) hcl.Diagnostics {
@@ -43,7 +43,7 @@ func diagnosticFailedToConvertCty(err error, sub *hcl.Range) *hcl.Diagnostic {
 	return &hcl.Diagnostic{
 		Severity: hcl.DiagError,
 		Summary:  "Failed to convert Cty to interface",
-		Detail:   strings.Title(err.Error()),
+		Detail:   helper.Title(err.Error()),
 		Subject:  sub,
 	}
 }

--- a/internal/testui/main.go
+++ b/internal/testui/main.go
@@ -11,6 +11,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/fatih/color"
+	"github.com/hashicorp/nomad-pack/sdk/helper"
 	"github.com/hashicorp/nomad-pack/terminal"
 	"github.com/olekukonko/tablewriter"
 )
@@ -199,7 +200,7 @@ func (ui *nonInteractiveTestUI) Error(msg string) {
 // ErrorWithContext satisfies the ErrorWithContext function on the UI
 // interface.
 func (ui *nonInteractiveTestUI) ErrorWithContext(err error, sub string, ctx ...string) {
-	ui.Error(strings.Title(sub))
+	ui.Error(helper.Title(sub))
 	ui.Error("  Error: " + err.Error())
 	ui.Error("  Context:")
 	max := 0

--- a/sdk/helper/title.go
+++ b/sdk/helper/title.go
@@ -1,0 +1,15 @@
+package helper
+
+import (
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var (
+	titleFmt = cases.Title(language.AmericanEnglish)
+)
+
+// Title returns the American English title format of s.
+func Title(s string) string {
+	return titleFmt.String(s)
+}

--- a/sdk/helper/title_test.go
+++ b/sdk/helper/title_test.go
@@ -1,0 +1,22 @@
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTitle(t *testing.T) {
+	cases := []struct {
+		s   string
+		exp string
+	}{
+		{s: "hello", exp: "Hello"},
+		{s: "hello world", exp: "Hello World"},
+	}
+
+	for _, tc := range cases {
+		result := Title(tc.s)
+		require.Equal(t, tc.exp, result)
+	}
+}

--- a/terminal/glint.go
+++ b/terminal/glint.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bgentry/speakeasy"
 	"github.com/fatih/color"
+	"github.com/hashicorp/nomad-pack/sdk/helper"
 	"github.com/mattn/go-isatty"
 	"github.com/mitchellh/go-glint"
 	"github.com/olekukonko/tablewriter"
@@ -355,7 +356,7 @@ func (ui *glintUI) ErrorWithContext(err error, sub string, ctx ...string) {
 	// Title the error output in red with the subject.
 	d.Append(glint.Layout(
 		glint.Style(
-			glint.Text(fmt.Sprintf("! %s\n", strings.Title(sub))),
+			glint.Text(fmt.Sprintf("! %s\n", helper.Title(sub))),
 			glint.Color("red"),
 		),
 	).Row())

--- a/terminal/noninteractive.go
+++ b/terminal/noninteractive.go
@@ -12,6 +12,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/fatih/color"
+	"github.com/hashicorp/nomad-pack/sdk/helper"
 	"github.com/olekukonko/tablewriter"
 )
 
@@ -205,7 +206,7 @@ func (ui *nonInteractiveUI) Error(msg string) {
 // ErrorWithContext satisfies the ErrorWithContext function on the UI
 // interface.
 func (ui *nonInteractiveUI) ErrorWithContext(err error, sub string, ctx ...string) {
-	ui.Error(strings.Title(sub))
+	ui.Error(helper.Title(sub))
 	ui.Error("  Error: " + err.Error())
 	ui.Error("  Context:")
 	max := 0

--- a/terminal/ui.go
+++ b/terminal/ui.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/fatih/color"
+	"github.com/hashicorp/nomad-pack/sdk/helper"
 	"github.com/mitchellh/go-glint"
 )
 
@@ -261,7 +261,7 @@ func ErrorWithContext(err error, sub string, ctx ...string) {
 	// Title the error output in red with the subject.
 	d.Append(glint.Layout(
 		glint.Style(
-			glint.Text(fmt.Sprintf("! %s\n", strings.Title(sub))),
+			glint.Text(fmt.Sprintf("! %s\n", helper.Title(sub))),
 			glint.Color("red"),
 		),
 	).Row())


### PR DESCRIPTION
In Go 1.18+, `strings.Title` is deprecated. This causes `make dev` to fail because
the deprecation is caught by `staticcheck`, e.g.

```
➜ go version 
go version go1.18.3 linux/amd64
```

```
==> Linting source code...
terminal/glint.go:358:37: SA1019: strings.Title is deprecated: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead. (staticcheck)
			glint.Text(fmt.Sprintf("! %s\n", strings.Title(sub))),
```

This PR creates `sdk/helper.Title`, which under the hood uses https://pkg.go.dev/golang.org/x/text/cases#Caser
to perform the same function.

More info in https://stackoverflow.com/questions/71620717/in-go-1-18-strings-title-is-deprecated-what-to-use-now-and-how
