### PR TITLE
renderer: render auxiliary files, and not just templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 IMPROVEMENTS:
+* cli: Add flag `--render-aux-files` that allows to render any files found in `templates/` [[GH-303](https://github.com/hashicorp/nomad-pack/pull/303)]
 * deps: Update the Nomad OpenAPI depedency [[GH-288](https://github.com/hashicorp/nomad-pack/pull/288)] and require Go 1.18 as a build dependency
 
 ## 0.0.1-techpreview.3 (July 21, 2022)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -69,7 +69,7 @@ hclfmt: ## Format HCL files with hclfmt
 
 .PHONY: dev
 dev: GOPATH=$(shell go env GOPATH)
-dev: lint
+dev:
 	@echo "==> Building nomad-pack..."
 	@CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o ./bin/nomad-pack
 	@rm -f $(GOPATH)/bin/nomad-pack

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -6,6 +6,7 @@ import (
 
 	v1client "github.com/hashicorp/nomad-openapi/clients/go/v1"
 	v1 "github.com/hashicorp/nomad-openapi/v1"
+
 	"github.com/hashicorp/nomad-pack/internal/pkg/cache"
 	"github.com/hashicorp/nomad-pack/internal/pkg/errors"
 	"github.com/hashicorp/nomad-pack/internal/pkg/manager"
@@ -103,8 +104,13 @@ func registryPackRow(cachedRegistry *cache.Registry, cachedPack *cache.Pack) []t
 // between layers.
 // Uses the pack manager to parse the templates, override template variables with var files
 // and cli vars as applicable
-func renderPack(manager *manager.PackManager, ui terminal.UI, errCtx *errors.UIErrorContext) (*renderer.Rendered, error) {
-	r, err := manager.ProcessTemplates()
+func renderPack(
+	manager *manager.PackManager,
+	ui terminal.UI,
+	renderAux bool,
+	errCtx *errors.UIErrorContext,
+) (*renderer.Rendered, error) {
+	r, err := manager.ProcessTemplates(renderAux)
 	if err != nil {
 		packName := manager.PackName()
 		errCtx.Add(errors.UIContextPrefixPackName, packName)

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -58,7 +58,7 @@ func (c *PlanCommand) Run(args []string) int {
 	packManager := generatePackManager(c.baseCommand, client, c.packConfig)
 
 	// load pack
-	r, err := renderPack(packManager, c.baseCommand.ui, errorContext)
+	r, err := renderPack(packManager, c.baseCommand.ui, false, errorContext)
 	if err != nil {
 		return c.exitCodeError
 	}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -229,7 +229,7 @@ func (c *RenderCommand) Run(args []string) int {
 	// displayed before the template renders, so the UI looks OK.
 	if c.renderOutputTemplate {
 		var outputRender string
-		outputRender, err = packManager.ProcessOutputTemplate(c.renderAuxFiles)
+		outputRender, err = packManager.ProcessOutputTemplate()
 		if err != nil {
 			c.ui.ErrorWithContext(err, "failed to render output template", errorContext.GetAll()...)
 		} else {

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -23,12 +23,19 @@ import (
 type RenderCommand struct {
 	*baseCommand
 	packConfig *cache.PackConfig
+
 	// renderOutputTemplate is a boolean flag to control whether the output
 	// template is rendered.
 	renderOutputTemplate bool
+
 	// renderToDir is the path to write rendered job files to in addition to
 	// standard output.
 	renderToDir string
+
+	// renderAuxFiles is a boolean flag to control whether we should also render
+	// auxiliary files inside templates/
+	renderAuxFiles bool
+
 	// overwriteAll is set to true when someone specifies "a" to the y/n/a
 	overwriteAll bool
 }
@@ -190,7 +197,7 @@ func (c *RenderCommand) Run(args []string) int {
 	}
 	packManager := generatePackManager(c.baseCommand, client, c.packConfig)
 
-	renderOutput, err := renderPack(packManager, c.baseCommand.ui, errorContext)
+	renderOutput, err := renderPack(packManager, c.baseCommand.ui, c.renderAuxFiles, errorContext)
 	if err != nil {
 		return 1
 	}
@@ -202,7 +209,7 @@ func (c *RenderCommand) Run(args []string) int {
 		return 1
 	}
 
-	var renders = []Render{}
+	var renders []Render
 
 	// Iterate the rendered files and add these to the list of renders to
 	// output. This allows errors to surface and end things without emitting
@@ -222,7 +229,7 @@ func (c *RenderCommand) Run(args []string) int {
 	// displayed before the template renders, so the UI looks OK.
 	if c.renderOutputTemplate {
 		var outputRender string
-		outputRender, err = packManager.ProcessOutputTemplate()
+		outputRender, err = packManager.ProcessOutputTemplate(c.renderAuxFiles)
 		if err != nil {
 			c.ui.ErrorWithContext(err, "failed to render output template", errorContext.GetAll()...)
 		} else {
@@ -280,6 +287,14 @@ func (c *RenderCommand) Flags() *flag.Sets {
 			Default: false,
 			Usage: `Controls whether or not the output template file within the
 					pack is rendered and displayed.`,
+		})
+
+		f.BoolVar(&flag.BoolVar{
+			Name:    "render-aux-files",
+			Target:  &c.renderAuxFiles,
+			Default: true,
+			Usage: `Controls whether or not the rendered output contains auxiliary
+					files found in templates/.`,
 		})
 
 		f.StringVarP(&flag.StringVarP{

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -66,7 +66,7 @@ func (c *RunCommand) run() int {
 
 	// Render the pack now, before creating the deployer. If we get an error
 	// we won't make it to the deployer.
-	r, err := renderPack(packManager, c.baseCommand.ui, errorContext)
+	r, err := renderPack(packManager, c.baseCommand.ui, false, errorContext)
 	if err != nil {
 		return 255
 	}
@@ -140,7 +140,7 @@ func (c *RunCommand) run() int {
 		c.ui.Success(fmt.Sprintf("Pack successfully deployed. Use %s with --ref=%s to manage this deployed instance with plan, stop, destroy, or info", c.packConfig.Name, c.packConfig.Ref))
 	}
 
-	output, err := packManager.ProcessOutputTemplate()
+	output, err := packManager.ProcessOutputTemplate(false)
 	if err != nil {
 		c.ui.ErrorWithContext(err, "failed to render output template", "Pack Name: "+c.packConfig.Name)
 		return 1

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -140,7 +140,7 @@ func (c *RunCommand) run() int {
 		c.ui.Success(fmt.Sprintf("Pack successfully deployed. Use %s with --ref=%s to manage this deployed instance with plan, stop, destroy, or info", c.packConfig.Name, c.packConfig.Ref))
 	}
 
-	output, err := packManager.ProcessOutputTemplate(false)
+	output, err := packManager.ProcessOutputTemplate()
 	if err != nil {
 		c.ui.ErrorWithContext(err, "failed to render output template", "Pack Name: "+c.packConfig.Name)
 		return 1

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -82,7 +82,7 @@ func (c *StopCommand) Run(args []string) int {
 		var r *renderer.Rendered
 
 		// render the pack
-		r, err = renderPack(packManager, c.baseCommand.ui, errorContext)
+		r, err = renderPack(packManager, c.baseCommand.ui, false, errorContext)
 		if err != nil {
 			return 255
 		}

--- a/internal/pkg/loader/loader.go
+++ b/internal/pkg/loader/loader.go
@@ -103,6 +103,12 @@ func loadFiles(files []*pack.File) (*pack.Pack, error) {
 			// object templates and helpers.
 			p.TemplateFiles = append(p.TemplateFiles, f)
 
+		case strings.HasPrefix(f.Name, "templates/") &&
+			!strings.HasSuffix(f.Name, ".tpl"):
+			// if there are any other files inside the "templates/" directory,
+			// add them to the aux files array
+			p.AuxiliaryFiles = append(p.AuxiliaryFiles, f)
+
 		default:
 			// Do nothing with other files; this might change in the future.
 			continue

--- a/internal/pkg/loader/loader.go
+++ b/internal/pkg/loader/loader.go
@@ -104,7 +104,7 @@ func loadFiles(files []*pack.File) (*pack.Pack, error) {
 			p.TemplateFiles = append(p.TemplateFiles, f)
 
 		case strings.HasPrefix(f.Name, "templates/") &&
-			!strings.HasSuffix(f.Name, ".tpl"):
+			strings.HasSuffix(f.Name, ".tpl"):
 			// if there are any other files inside the "templates/" directory,
 			// add them to the aux files array
 			p.AuxiliaryFiles = append(p.AuxiliaryFiles, f)

--- a/internal/pkg/manager/manager.go
+++ b/internal/pkg/manager/manager.go
@@ -113,8 +113,7 @@ func (pm *PackManager) ProcessTemplates(renderAux bool) (*renderer.Rendered, []*
 }
 
 // ProcessOutputTemplate performs the output template rendering.
-func (pm *PackManager) ProcessOutputTemplate(aux bool) (string, error) {
-	pm.renderer.RenderAuxFiles = aux
+func (pm *PackManager) ProcessOutputTemplate() (string, error) {
 	return pm.renderer.RenderOutput()
 }
 

--- a/internal/pkg/manager/manager.go
+++ b/internal/pkg/manager/manager.go
@@ -47,7 +47,7 @@ func NewPackManager(cfg *Config, client *v1.Client) *PackManager {
 // TODO(jrasell) figure out whether we want an error or hcl.Diagnostics return
 // object. If we stick to an error, then we need to come up with a way of
 // nicely formatting them.
-func (pm *PackManager) ProcessTemplates() (*renderer.Rendered, []*errors.WrappedUIContext) {
+func (pm *PackManager) ProcessTemplates(renderAux bool) (*renderer.Rendered, []*errors.WrappedUIContext) {
 
 	loadedPack, err := pm.loadAndValidatePacks()
 	if err != nil {
@@ -98,6 +98,9 @@ func (pm *PackManager) ProcessTemplates() (*renderer.Rendered, []*errors.Wrapped
 	r.Client = pm.client
 	pm.renderer = r
 
+	// should auxiliary files be rendered as well?
+	pm.renderer.RenderAuxFiles = renderAux
+
 	rendered, err := r.Render(loadedPack, mapVars)
 	if err != nil {
 		return nil, []*errors.WrappedUIContext{{
@@ -110,7 +113,10 @@ func (pm *PackManager) ProcessTemplates() (*renderer.Rendered, []*errors.Wrapped
 }
 
 // ProcessOutputTemplate performs the output template rendering.
-func (pm *PackManager) ProcessOutputTemplate() (string, error) { return pm.renderer.RenderOutput() }
+func (pm *PackManager) ProcessOutputTemplate(aux bool) (string, error) {
+	pm.renderer.RenderAuxFiles = aux
+	return pm.renderer.RenderOutput()
+}
 
 // loadAndValidatePacks triggers the initial parent load and then starts the
 // dependent pack loader. The returned pack will therefore be fully populated.

--- a/internal/pkg/renderer/renderer.go
+++ b/internal/pkg/renderer/renderer.go
@@ -119,8 +119,8 @@ func (r *Renderer) Render(p *pack.Pack, variables map[string]interface{}) (*Rend
 // RenderOutput performs the output template rendering.
 func (r *Renderer) RenderOutput() (string, error) {
 
-	// If we don't have a template file, then return early.
-	if r.pack.OutputTemplateFile == nil {
+	// If we don't have a template file or any aux files, return early.
+	if r.pack.OutputTemplateFile == nil && r.pack.AuxiliaryFiles == nil {
 		return "", nil
 	}
 

--- a/sdk/pack/pack.go
+++ b/sdk/pack/pack.go
@@ -30,6 +30,10 @@ type Pack struct {
 	// files within the list will be processed by the rendering engine.
 	TemplateFiles []*File
 
+	// AuxiliaryFiles are the files included in the "templates" directory of the
+	// Pack that will also be rendered, but not run.
+	AuxiliaryFiles []*File
+
 	// RootVariableFile is the file which contains the root variables that can
 	// include a description, type, and default value. This is parsed along
 	// with any override variables and stored within Variables.


### PR DESCRIPTION
**Description**

This PR allows for rendering any files found in the `templates/` directory, and introduces `--render-aux-files` flag for the `render` command to control that behavior. Resolves #299 

**Reminders**

- [x] Add `CHANGELOG.md` entry
