### PR TITLE
renderer: format templates before outputting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 * cli: Add flag `--render-aux-files` that allows to render any files found in `templates/` [[GH-303](https://github.com/hashicorp/nomad-pack/pull/303)]
 * deps: Update the Nomad OpenAPI depedency [[GH-288](https://github.com/hashicorp/nomad-pack/pull/288)] and require Go 1.18 as a build dependency
+* template: Automatically format templates before outputting [[GH-311](https://github.com/hashicorp/nomad-pack/pull/311)]
 
 ## 0.0.1-techpreview.3 (July 21, 2022)
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -487,6 +487,7 @@ func TestCLI_PackRender_MyAlias(t *testing.T) {
 
 	result := runPackCmd(t, []string{
 		"render",
+		"--no-format=true",
 		getTestPackPath("my_alias_test"),
 	})
 	require.Empty(t, result.cmdErr.String(), "cmdErr should be empty, but was %q", result.cmdErr.String())

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -108,9 +108,10 @@ func renderPack(
 	manager *manager.PackManager,
 	ui terminal.UI,
 	renderAux bool,
+	format bool,
 	errCtx *errors.UIErrorContext,
 ) (*renderer.Rendered, error) {
-	r, err := manager.ProcessTemplates(renderAux)
+	r, err := manager.ProcessTemplates(renderAux, format)
 	if err != nil {
 		packName := manager.PackName()
 		errCtx.Add(errors.UIContextPrefixPackName, packName)

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -58,7 +58,7 @@ func (c *PlanCommand) Run(args []string) int {
 	packManager := generatePackManager(c.baseCommand, client, c.packConfig)
 
 	// load pack
-	r, err := renderPack(packManager, c.baseCommand.ui, false, errorContext)
+	r, err := renderPack(packManager, c.baseCommand.ui, false, false, errorContext)
 	if err != nil {
 		return c.exitCodeError
 	}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -36,6 +36,10 @@ type RenderCommand struct {
 	// auxiliary files inside templates/
 	renderAuxFiles bool
 
+	// noFormat is a boolean flag to control whether we should hcl-format the
+	// templates before rendering them.
+	noFormat bool
+
 	// overwriteAll is set to true when someone specifies "a" to the y/n/a
 	overwriteAll bool
 }
@@ -197,7 +201,7 @@ func (c *RenderCommand) Run(args []string) int {
 	}
 	packManager := generatePackManager(c.baseCommand, client, c.packConfig)
 
-	renderOutput, err := renderPack(packManager, c.baseCommand.ui, c.renderAuxFiles, errorContext)
+	renderOutput, err := renderPack(packManager, c.baseCommand.ui, c.renderAuxFiles, !c.noFormat, errorContext)
 	if err != nil {
 		return 1
 	}
@@ -295,6 +299,13 @@ func (c *RenderCommand) Flags() *flag.Sets {
 			Default: true,
 			Usage: `Controls whether or not the rendered output contains auxiliary
 					files found in the 'templates' folder.`,
+		})
+
+		f.BoolVar(&flag.BoolVar{
+			Name:    "no-format",
+			Target:  &c.noFormat,
+			Default: false,
+			Usage:   `Controls whether or not to format templates before outputting.`,
 		})
 
 		f.StringVarP(&flag.StringVarP{

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -66,7 +66,7 @@ func (c *RunCommand) run() int {
 
 	// Render the pack now, before creating the deployer. If we get an error
 	// we won't make it to the deployer.
-	r, err := renderPack(packManager, c.baseCommand.ui, false, errorContext)
+	r, err := renderPack(packManager, c.baseCommand.ui, false, false, errorContext)
 	if err != nil {
 		return 255
 	}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -82,7 +82,7 @@ func (c *StopCommand) Run(args []string) int {
 		var r *renderer.Rendered
 
 		// render the pack
-		r, err = renderPack(packManager, c.baseCommand.ui, false, errorContext)
+		r, err = renderPack(packManager, c.baseCommand.ui, false, false, errorContext)
 		if err != nil {
 			return 255
 		}

--- a/internal/pkg/manager/manager.go
+++ b/internal/pkg/manager/manager.go
@@ -47,7 +47,7 @@ func NewPackManager(cfg *Config, client *v1.Client) *PackManager {
 // TODO(jrasell) figure out whether we want an error or hcl.Diagnostics return
 // object. If we stick to an error, then we need to come up with a way of
 // nicely formatting them.
-func (pm *PackManager) ProcessTemplates(renderAux bool) (*renderer.Rendered, []*errors.WrappedUIContext) {
+func (pm *PackManager) ProcessTemplates(renderAux bool, format bool) (*renderer.Rendered, []*errors.WrappedUIContext) {
 
 	loadedPack, err := pm.loadAndValidatePacks()
 	if err != nil {
@@ -100,6 +100,9 @@ func (pm *PackManager) ProcessTemplates(renderAux bool) (*renderer.Rendered, []*
 
 	// should auxiliary files be rendered as well?
 	pm.renderer.RenderAuxFiles = renderAux
+
+	// should we format before rendering?
+	pm.renderer.Format = format
 
 	rendered, err := r.Render(loadedPack, mapVars)
 	if err != nil {

--- a/internal/pkg/renderer/renderer.go
+++ b/internal/pkg/renderer/renderer.go
@@ -112,7 +112,7 @@ func (r *Renderer) Render(p *pack.Pack, variables map[string]interface{}) (*Rend
 		nameSplit := strings.Split(name, "/")
 
 		if r.Format {
-			// hclfmt the tempaltes
+			// hclfmt the templates
 			f, err := printer.Format([]byte(replacedTpl))
 			if err != nil {
 				return nil, fmt.Errorf("failed to format the template %s, %v", name, err)

--- a/internal/pkg/renderer/renderer.go
+++ b/internal/pkg/renderer/renderer.go
@@ -123,9 +123,9 @@ func (r *Renderer) Render(p *pack.Pack, variables map[string]interface{}) (*Rend
 		// Add the rendered pack template to our output, depending on whether
 		// it's name matches that of our parent.
 		if nameSplit[0] == p.Name() {
-			rendered.parentRenders[name] = string(replacedTpl)
+			rendered.parentRenders[name] = replacedTpl
 		} else {
-			rendered.dependentRenders[name] = string(replacedTpl)
+			rendered.dependentRenders[name] = replacedTpl
 		}
 	}
 


### PR DESCRIPTION
**Description**

This PR introduces HCL formatting of templates before they are outputted. An additional flag `--no-format` is now also available for the `render` command to override this behavior. 

Resolves #301 
Relates to #308 

**Reminders**

- [x] Add `CHANGELOG.md` entry
