### PR TITLE
fix: change render-aux-files flag behavior for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## UNRELEASED
 
 IMPROVEMENTS:
-* cli: Add flag `--render-aux-files` that allows to render any files found in `templates/` [[GH-303](https://github.com/hashicorp/nomad-pack/pull/303)]
 * deps: Update the Nomad OpenAPI depedency [[GH-288](https://github.com/hashicorp/nomad-pack/pull/288)] and require Go 1.18 as a build dependency
+* template: Render other templates than jobspecs inside `templates/` [[GH-303](https://github.com/hashicorp/nomad-pack/pull/303)]
 
 ## 0.0.1-techpreview.3 (July 21, 2022)
 

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -290,7 +290,7 @@ func (c *RenderCommand) Flags() *flag.Sets {
 		})
 
 		f.BoolVar(&flag.BoolVar{
-			Name:    "no-render-aux-files",
+			Name:    "skip-aux-files",
 			Target:  &c.noRenderAuxFiles,
 			Default: false,
 			Usage: `Controls whether or not the rendered output contains auxiliary

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -290,7 +290,7 @@ func (c *RenderCommand) Flags() *flag.Sets {
 		})
 
 		f.BoolVar(&flag.BoolVar{
-			Name:    "render-aux-files",
+			Name:    "no-render-aux-files",
 			Target:  &c.noRenderAuxFiles,
 			Default: false,
 			Usage: `Controls whether or not the rendered output contains auxiliary

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -32,9 +32,9 @@ type RenderCommand struct {
 	// standard output.
 	renderToDir string
 
-	// renderAuxFiles is a boolean flag to control whether we should also render
+	// noRenderAuxFiles is a boolean flag to control whether we should also render
 	// auxiliary files inside templates/
-	renderAuxFiles bool
+	noRenderAuxFiles bool
 
 	// overwriteAll is set to true when someone specifies "a" to the y/n/a
 	overwriteAll bool
@@ -197,7 +197,7 @@ func (c *RenderCommand) Run(args []string) int {
 	}
 	packManager := generatePackManager(c.baseCommand, client, c.packConfig)
 
-	renderOutput, err := renderPack(packManager, c.baseCommand.ui, c.renderAuxFiles, errorContext)
+	renderOutput, err := renderPack(packManager, c.baseCommand.ui, !c.noRenderAuxFiles, errorContext)
 	if err != nil {
 		return 1
 	}
@@ -291,8 +291,8 @@ func (c *RenderCommand) Flags() *flag.Sets {
 
 		f.BoolVar(&flag.BoolVar{
 			Name:    "render-aux-files",
-			Target:  &c.renderAuxFiles,
-			Default: true,
+			Target:  &c.noRenderAuxFiles,
+			Default: false,
 			Usage: `Controls whether or not the rendered output contains auxiliary
 					files found in the 'templates' folder.`,
 		})


### PR DESCRIPTION
Since we want to render auxiliary files by default, the flag to control it should be `--no-render-aux-files` rather than `--render-aux-files`. See https://github.com/hashicorp/nomad-pack/pull/311 for an example of similar behavior. 