### PR TITLE
renderer: skip empty templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ IMPROVEMENTS:
 * deps: Update the Nomad OpenAPI depedency [[GH-288](https://github.com/hashicorp/nomad-pack/pull/288)] and require Go 1.18 as a build dependency
 * template: Render other templates than jobspecs inside `templates/` [[GH-303](https://github.com/hashicorp/nomad-pack/pull/303)]
 * template: Automatically format templates before outputting [[GH-311](https://github.com/hashicorp/nomad-pack/pull/311)]
+* template: Skip templates that would render to just whitespace [[GH-313](https://github.com/hashicorp/nomad-pack/pull/313)]
 
 ## 0.0.1-techpreview.3 (July 21, 2022)
 

--- a/internal/pkg/renderer/renderer.go
+++ b/internal/pkg/renderer/renderer.go
@@ -111,6 +111,12 @@ func (r *Renderer) Render(p *pack.Pack, variables map[string]interface{}) (*Rend
 		// Split the name so the element at index zero becomes the pack name.
 		nameSplit := strings.Split(name, "/")
 
+		// If we encounter a template that's empty (just renders to whitespace),
+		// we skip it.
+		if len(strings.TrimSpace(replacedTpl)) == 0 {
+			continue
+		}
+
 		if r.Format {
 			// hclfmt the templates
 			f, err := printer.Format([]byte(replacedTpl))


### PR DESCRIPTION
**Description**

This PR adds support for optional jobs, effectively skipping rendering of templates that would render to just whitespace. 
Resolves #188 
Relates to #308 

**Reminders**

- [x] Add `CHANGELOG.md` entry
