### PR TITLE
admin: adjusted CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,4 @@
-# Blanket ownership of all PRs.
-* @angrycub @DerekStrickland @jazzyfresh @jrasell @lgfa29
-
 # release configuration
-/.release/                              @hashicorp/release-engineering
-/.github/workflows/build.yml            @hashicorp/release-engineering
+
+/.release/                              @hashicorp/release-engineering @hashicorp/github-nomad-core @hashicorp/nomad-eng
+/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-nomad-core @hashicorp/nomad-eng


### PR DESCRIPTION
I imagine it must be getting somewhat annoying that @angrycub @jrasell and @lgfa29 get tagged automatically on every PR. This also removes users that aren't part of hashicorp org anymore. 