### PR TITLE
vars: do not error if variable not present in pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ IMPROVEMENTS:
 * template: Render other templates than jobspecs inside `templates/` [[GH-303](https://github.com/hashicorp/nomad-pack/pull/303)]
 * template: Automatically format templates before outputting [[GH-311](https://github.com/hashicorp/nomad-pack/pull/311)]
 * template: Skip templates that would render to just whitespace [[GH-313](https://github.com/hashicorp/nomad-pack/pull/313)]
+* vars: Produce a warning, not an error, if variable overrides refer to variables not present in the pack [[GH-315](https://github.com/hashicorp/nomad-pack/pull/315)]
 
 ## 0.0.1-techpreview.3 (July 21, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ IMPROVEMENTS:
 * template: Render other templates than jobspecs inside `templates/` [[GH-303](https://github.com/hashicorp/nomad-pack/pull/303)]
 * template: Automatically format templates before outputting [[GH-311](https://github.com/hashicorp/nomad-pack/pull/311)]
 * template: Skip templates that would render to just whitespace [[GH-313](https://github.com/hashicorp/nomad-pack/pull/313)]
-* vars: Produce a warning, not an error, if variable overrides refer to variables not present in the pack [[GH-315](https://github.com/hashicorp/nomad-pack/pull/315)]
+* vars: Add flag to ignore variables provided in the given var-files unused by the pack [[GH-315](https://github.com/hashicorp/nomad-pack/pull/315)]
 
 ## 0.0.1-techpreview.3 (July 21, 2022)
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -60,6 +60,10 @@ type baseCommand struct {
 	// for defined input variables
 	varFiles []string
 
+	// ignoreMissingVars determines whether variable overrides that do not correspond
+	// to variables defined in the pack should be ignored or produce an error
+	ignoreMissingVars bool
+
 	// autoApproved is true when the user supplies the --auto-approve or -y flag
 	autoApproved bool
 
@@ -277,6 +281,14 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 				Completion: complete.PredictOr(complete.PredictFiles("*.var"), complete.PredictFiles("*.hcl")),
 			},
 			Shorthand: "f",
+		})
+
+		f.BoolVar(&flag.BoolVar{
+			Name:    "ignore-missing-vars",
+			Target:  &c.ignoreMissingVars,
+			Default: false,
+			Usage: `Determines whether override variables not present in the
+					pack should be ignored or produce an error.`,
 		})
 
 		f.StringMapVar(&flag.StringMapVar{

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -109,9 +109,10 @@ func renderPack(
 	ui terminal.UI,
 	renderAux bool,
 	format bool,
+	ignoreMissingVars bool,
 	errCtx *errors.UIErrorContext,
 ) (*renderer.Rendered, error) {
-	r, err := manager.ProcessTemplates(renderAux, format)
+	r, err := manager.ProcessTemplates(renderAux, format, ignoreMissingVars)
 	if err != nil {
 		packName := manager.PackName()
 		errCtx.Add(errors.UIContextPrefixPackName, packName)

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -53,6 +53,7 @@ func (c *InfoCommand) Run(args []string) int {
 	variableParser, err := variable.NewParser(&variable.ParserConfig{
 		ParentName:        path.Base(packPath),
 		RootVariableFiles: pack.RootVariableFiles(),
+		IgnoreMissingVars: c.baseCommand.ignoreMissingVars,
 	})
 	if err != nil {
 		return 1

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -58,7 +58,14 @@ func (c *PlanCommand) Run(args []string) int {
 	packManager := generatePackManager(c.baseCommand, client, c.packConfig)
 
 	// load pack
-	r, err := renderPack(packManager, c.baseCommand.ui, false, false, errorContext)
+	r, err := renderPack(
+		packManager,
+		c.baseCommand.ui,
+		false,
+		false,
+		c.baseCommand.ignoreMissingVars,
+		errorContext,
+	)
 	if err != nil {
 		return c.exitCodeError
 	}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -201,7 +201,14 @@ func (c *RenderCommand) Run(args []string) int {
 	}
 	packManager := generatePackManager(c.baseCommand, client, c.packConfig)
 
-	renderOutput, err := renderPack(packManager, c.baseCommand.ui, !c.noRenderAuxFiles, !c.noFormat, errorContext)
+	renderOutput, err := renderPack(
+		packManager,
+		c.baseCommand.ui,
+		!c.noRenderAuxFiles,
+		!c.noFormat,
+		c.baseCommand.ignoreMissingVars,
+		errorContext,
+	)
 	if err != nil {
 		return 1
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -66,7 +66,14 @@ func (c *RunCommand) run() int {
 
 	// Render the pack now, before creating the deployer. If we get an error
 	// we won't make it to the deployer.
-	r, err := renderPack(packManager, c.baseCommand.ui, false, false, errorContext)
+	r, err := renderPack(
+		packManager,
+		c.baseCommand.ui,
+		false,
+		false,
+		c.baseCommand.ignoreMissingVars,
+		errorContext,
+	)
 	if err != nil {
 		return 255
 	}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -82,7 +82,14 @@ func (c *StopCommand) Run(args []string) int {
 		var r *renderer.Rendered
 
 		// render the pack
-		r, err = renderPack(packManager, c.baseCommand.ui, false, false, errorContext)
+		r, err = renderPack(
+			packManager,
+			c.baseCommand.ui,
+			false,
+			false,
+			c.baseCommand.ignoreMissingVars,
+			errorContext,
+		)
 		if err != nil {
 			return 255
 		}

--- a/internal/pkg/manager/manager.go
+++ b/internal/pkg/manager/manager.go
@@ -47,7 +47,7 @@ func NewPackManager(cfg *Config, client *v1.Client) *PackManager {
 // TODO(jrasell) figure out whether we want an error or hcl.Diagnostics return
 // object. If we stick to an error, then we need to come up with a way of
 // nicely formatting them.
-func (pm *PackManager) ProcessTemplates(renderAux bool, format bool) (*renderer.Rendered, []*errors.WrappedUIContext) {
+func (pm *PackManager) ProcessTemplates(renderAux bool, format bool, ignoreMissingVars bool) (*renderer.Rendered, []*errors.WrappedUIContext) {
 
 	loadedPack, err := pm.loadAndValidatePacks()
 	if err != nil {
@@ -75,6 +75,7 @@ func (pm *PackManager) ProcessTemplates(renderAux bool, format bool) (*renderer.
 		FileOverrides:     pm.cfg.VariableFiles,
 		CLIOverrides:      pm.cfg.VariableCLIArgs,
 		EnvOverrides:      pm.cfg.VariableEnvVars,
+		IgnoreMissingVars: ignoreMissingVars,
 	})
 	if err != nil {
 		return nil, []*errors.WrappedUIContext{{

--- a/internal/pkg/variable/error.go
+++ b/internal/pkg/variable/error.go
@@ -23,8 +23,8 @@ func safeDiagnosticsExtend(base, new hcl.Diagnostics) hcl.Diagnostics {
 
 func diagnosticMissingRootVar(name string, sub *hcl.Range) *hcl.Diagnostic {
 	return &hcl.Diagnostic{
-		Severity: hcl.DiagError,
-		Summary:  "Missing base variable declaration to override",
+		Severity: hcl.DiagWarning,
+		Summary:  fmt.Sprintf("Pack does not contain variable %s to override", name),
 		Detail:   fmt.Sprintf(`There is no variable named %q. An override file can only override a variable that was already declared in a primary configuration file.`, name),
 		Subject:  sub,
 	}

--- a/internal/pkg/variable/error.go
+++ b/internal/pkg/variable/error.go
@@ -23,8 +23,8 @@ func safeDiagnosticsExtend(base, new hcl.Diagnostics) hcl.Diagnostics {
 
 func diagnosticMissingRootVar(name string, sub *hcl.Range) *hcl.Diagnostic {
 	return &hcl.Diagnostic{
-		Severity: hcl.DiagWarning,
-		Summary:  fmt.Sprintf("Pack does not contain variable %s to override", name),
+		Severity: hcl.DiagError,
+		Summary:  "Missing base variable declaration to override",
 		Detail:   fmt.Sprintf(`There is no variable named %q. An override file can only override a variable that was already declared in a primary configuration file.`, name),
 		Subject:  sub,
 	}

--- a/internal/pkg/variable/parser.go
+++ b/internal/pkg/variable/parser.go
@@ -56,6 +56,10 @@ type ParserConfig struct {
 	// CLIOverrides are key=value variables and take the highest precedence of
 	// all sources. If the same key is supplied twice, the last wins.
 	CLIOverrides map[string]string
+
+	// IgnoreMissingVars determines whether we error or not on variable overrides
+	// that don't have corresponding vars in the pack.
+	IgnoreMissingVars bool
 }
 
 func NewParser(cfg *ParserConfig) (*Parser, error) {
@@ -123,7 +127,9 @@ func (p *Parser) Parse() (*ParsedVariables, hcl.Diagnostics) {
 			for _, v := range variables {
 				existing, exists := p.rootVars[packName][v.Name]
 				if !exists {
-					diags = diags.Append(diagnosticMissingRootVar(v.Name, v.DeclRange.Ptr()))
+					if !p.cfg.IgnoreMissingVars {
+						diags = diags.Append(diagnosticMissingRootVar(v.Name, v.DeclRange.Ptr()))
+					}
 					continue
 				}
 				if mergeDiags := existing.merge(v); mergeDiags.HasErrors() {


### PR DESCRIPTION
**Description**

If there are variables in the var-file that aren't present in the pack, we should issue a warning, not an error. This is opt-in behavior, enabled by passing a `--ignore-missing-vars` flag. 

Resolves #302 
Relates to #308 

**Reminders**

- [x] Add `CHANGELOG.md` entry
