### PR TITLE
pack: Author field no longer supported in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 * deps: Update the Nomad OpenAPI depedency [[GH-288](https://github.com/hashicorp/nomad-pack/pull/288)] and require Go 1.18 as a build dependency
+* pack: Author field no longer supported in pack metadata [[GH-317](https://github.com/hashicorp/nomad-pack/pull/317)]
 * template: Render other templates than jobspecs inside `templates/` [[GH-303](https://github.com/hashicorp/nomad-pack/pull/303)]
 * template: Automatically format templates before outputting [[GH-311](https://github.com/hashicorp/nomad-pack/pull/311)]
 * template: Skip templates that would render to just whitespace [[GH-313](https://github.com/hashicorp/nomad-pack/pull/313)]

--- a/docs/writing-packs.md
+++ b/docs/writing-packs.md
@@ -48,7 +48,6 @@ The directory should have the following contents:
 The `metadata.hcl` file contains important key value information regarding the pack. It contains the following blocks and their associated fields:
 
 - "app {url}" - The HTTP(S) url to the homepage of the application to provide a quick reference to the documentation and help pages.
-- "app {author}" - An identifier to the author and maintainer of the pack.
 - "pack {name}" - The name of the pack.
 - "pack {description}" - A small overview of the application that is deployed by the pack.
 - "pack {url}" - The source URL for the pack itself.
@@ -61,7 +60,6 @@ An example `metadata.hcl` file:
 ```
 app {
   url = "https://github.com/mikenomitch/hello_world_server"
-  author = "Mike Nomitch"
 }
 
 pack {
@@ -240,7 +238,6 @@ First, packs must define their dependencies in `metadata.hcl`. A pack stanza wit
 ```
 app {
   url = "https://some-url-for-the-application.dev"
-  author = "Borman Norlaug"
 }
 
 pack {

--- a/fixtures/bad_pack/metadata.hcl
+++ b/fixtures/bad_pack/metadata.hcl
@@ -3,7 +3,6 @@
 
 app {
   url    = "https://learn.hashicorp.com/tutorials/nomad/get-started-run?in=nomad/get-started"
-  author = "HashiCorp"
 }
 
 pack {

--- a/fixtures/test_registry/packs/my_alias_test/deps/child1/metadata.hcl
+++ b/fixtures/test_registry/packs/my_alias_test/deps/child1/metadata.hcl
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 app {
-  url    = ""
-  author = "HashiCorp"
+  url = ""
 }
 
 pack {

--- a/fixtures/test_registry/packs/my_alias_test/deps/child2/metadata.hcl
+++ b/fixtures/test_registry/packs/my_alias_test/deps/child2/metadata.hcl
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 app {
-  url    = ""
-  author = "HashiCorp"
+  url = ""
 }
 
 pack {

--- a/fixtures/test_registry/packs/my_alias_test/metadata.hcl
+++ b/fixtures/test_registry/packs/my_alias_test/metadata.hcl
@@ -3,7 +3,6 @@
 
 app {
   url    = ""
-  author = "HashiCorp"
 }
 
 pack {

--- a/fixtures/test_registry/packs/my_alias_test/metadata.hcl
+++ b/fixtures/test_registry/packs/my_alias_test/metadata.hcl
@@ -3,7 +3,7 @@
 
 app {
   url    = ""
-  author = "Nomad Team" # author field deprecated, left here to make sure we don't panic and fail gracefully
+  author = "Nomad Team"
 }
 
 pack {

--- a/fixtures/test_registry/packs/my_alias_test/metadata.hcl
+++ b/fixtures/test_registry/packs/my_alias_test/metadata.hcl
@@ -3,6 +3,7 @@
 
 app {
   url    = ""
+  author = "Nomad Team" # author field deprecated, left here to make sure we don't panic and fail gracefully
 }
 
 pack {

--- a/fixtures/test_registry/packs/simple_raw_exec/metadata.hcl
+++ b/fixtures/test_registry/packs/simple_raw_exec/metadata.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 app {
-  url = ""
+  url    = ""
   author = "Nomad Team" # author field deprecated, left here to make sure we don't panic and fail gracefully
 }
 

--- a/fixtures/test_registry/packs/simple_raw_exec/metadata.hcl
+++ b/fixtures/test_registry/packs/simple_raw_exec/metadata.hcl
@@ -3,6 +3,7 @@
 
 app {
   url = ""
+  author = "Nomad Team" # author field deprecated, left here to make sure we don't panic and fail gracefully
 }
 
 pack {

--- a/fixtures/test_registry/packs/simple_raw_exec/metadata.hcl
+++ b/fixtures/test_registry/packs/simple_raw_exec/metadata.hcl
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 app {
-  url    = ""
-  author = "HashiCorp"
+  url = ""
 }
 
 pack {

--- a/fixtures/variable_test/variable_test/metadata.hcl
+++ b/fixtures/variable_test/variable_test/metadata.hcl
@@ -3,7 +3,6 @@
 
 app {
   url    = ""
-  author = "HashiCorp"
 }
 
 pack {

--- a/fixtures/variable_test/variable_test/metadata.hcl
+++ b/fixtures/variable_test/variable_test/metadata.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 app {
-  url    = ""
+  url = ""
 }
 
 pack {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -15,6 +15,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/nomad/command/agent"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+
 	ct "github.com/hashicorp/nomad-pack/internal/cli/testhelper"
 	"github.com/hashicorp/nomad-pack/internal/pkg/cache"
 	flag "github.com/hashicorp/nomad-pack/internal/pkg/flag"
@@ -23,9 +27,6 @@ import (
 	"github.com/hashicorp/nomad-pack/internal/pkg/version"
 	"github.com/hashicorp/nomad-pack/internal/runner/job"
 	"github.com/hashicorp/nomad-pack/internal/testui"
-	"github.com/hashicorp/nomad/command/agent"
-	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/require"
 )
 
 // TODO: Test job run with diffs

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -85,12 +85,6 @@ func (c *InfoCommand) Run(args []string) int {
 		glint.Text(pack.Metadata.App.URL),
 	).Row())
 
-	doc.Append(glint.Layout(
-		glint.Style(glint.Text("Application Author "), glint.Bold()),
-		glint.Text(pack.Metadata.App.Author),
-		glint.Text("\n"),
-	).Row())
-
 	for pName, variables := range parsedVars.Vars {
 
 		doc.Append(glint.Layout(

--- a/internal/creator/templates/pack_metadata.hcl
+++ b/internal/creator/templates/pack_metadata.hcl
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 app {
-  url    = ""
-  author = ""
+  url = ""
 }
 pack {
   name        = "{{.PackName}}"

--- a/internal/pkg/cache/add.go
+++ b/internal/pkg/cache/add.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	gg "github.com/hashicorp/go-getter"
+
 	"github.com/hashicorp/nomad-pack/internal/pkg/errors"
 	"github.com/hashicorp/nomad-pack/internal/pkg/helper/filesystem"
 	pkgVersion "github.com/hashicorp/nomad-pack/internal/pkg/version"

--- a/internal/pkg/cache/add.go
+++ b/internal/pkg/cache/add.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	gg "github.com/hashicorp/go-getter"
-
 	"github.com/hashicorp/nomad-pack/internal/pkg/errors"
 	"github.com/hashicorp/nomad-pack/internal/pkg/helper/filesystem"
 	pkgVersion "github.com/hashicorp/nomad-pack/internal/pkg/version"

--- a/internal/pkg/cache/pack.go
+++ b/internal/pkg/cache/pack.go
@@ -73,10 +73,6 @@ func invalidPackDefinition(provider cacheOperationProvider) *Pack {
 		Ref: provider.AtRef(),
 		Pack: &pack.Pack{
 			Metadata: &pack.Metadata{
-				App: &pack.MetadataApp{
-					URL:    "",
-					Author: "",
-				},
 				Pack: &pack.MetadataPack{
 					Name:        provider.ForPackName(),
 					Description: "",

--- a/internal/pkg/loader/loader.go
+++ b/internal/pkg/loader/loader.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclsimple"
+
 	"github.com/hashicorp/nomad-pack/sdk/pack"
 )
 

--- a/sdk/pack/metadata.go
+++ b/sdk/pack/metadata.go
@@ -24,8 +24,12 @@ type MetadataApp struct {
 	// quick reference to the documentation and help pages.
 	URL string `hcl:"url"`
 
-	// ExtraKeysHCL is used by hcl to surface unexpected keys.
-	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
+	// Author is an identifier to the author and maintainer of the pack such as
+	// HashiCorp or James Rasell
+	//
+	// Deprecated: Nomad Pack tech preview 4 removes this field, we keep it here for
+	// backwards compatibility only.
+	Author string `hcl:"author"`
 
 	// TODO: Add Version here, may need to be a block or series of entries to
 	// support packs that contain multiple apps.

--- a/sdk/pack/metadata.go
+++ b/sdk/pack/metadata.go
@@ -24,10 +24,6 @@ type MetadataApp struct {
 	// quick reference to the documentation and help pages.
 	URL string `hcl:"url"`
 
-	// Author is an identifier to the author and maintainer of the pack such as
-	// HashiCorp or James Rasell
-	Author string `hcl:"author"`
-
 	// TODO: Add Version here, may need to be a block or series of entries to
 	// support packs that contain multiple apps.
 }
@@ -59,8 +55,7 @@ func (md *Metadata) ConvertToMapInterface() map[string]interface{} {
 	return map[string]interface{}{
 		"nomad_pack": map[string]interface{}{
 			"app": map[string]interface{}{
-				"url":    md.App.URL,
-				"author": md.App.Author,
+				"url": md.App.URL,
 			},
 			"pack": map[string]interface{}{
 				"name":        md.Pack.Name,
@@ -78,8 +73,7 @@ func (md *Metadata) ConvertToMapInterface() map[string]interface{} {
 func (md *Metadata) AddToInterfaceMap(m map[string]interface{}) map[string]interface{} {
 	m["nomad_pack"] = map[string]interface{}{
 		"app": map[string]interface{}{
-			"url":    md.App.URL,
-			"author": md.App.Author,
+			"url": md.App.URL,
 		},
 		"pack": map[string]interface{}{
 			"name":        md.Pack.Name,

--- a/sdk/pack/metadata.go
+++ b/sdk/pack/metadata.go
@@ -24,6 +24,11 @@ type MetadataApp struct {
 	// quick reference to the documentation and help pages.
 	URL string `hcl:"url"`
 
+	// OBSOLETED in nomad pack beta!
+	// Author is an identifier to the author and maintainer of the pack such as
+	// HashiCorp or James Rasell
+	Author string `hcl:"author"`
+
 	// TODO: Add Version here, may need to be a block or series of entries to
 	// support packs that contain multiple apps.
 }

--- a/sdk/pack/metadata.go
+++ b/sdk/pack/metadata.go
@@ -24,9 +24,7 @@ type MetadataApp struct {
 	// quick reference to the documentation and help pages.
 	URL string `hcl:"url"`
 
-	// OBSOLETED in nomad pack beta!
-	// Author is an identifier to the author and maintainer of the pack such as
-	// HashiCorp or James Rasell
+	// ExtraKeysHCL is used by hcl to surface unexpected keys.
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 
 	// TODO: Add Version here, may need to be a block or series of entries to

--- a/sdk/pack/metadata.go
+++ b/sdk/pack/metadata.go
@@ -27,7 +27,7 @@ type MetadataApp struct {
 	// OBSOLETED in nomad pack beta!
 	// Author is an identifier to the author and maintainer of the pack such as
 	// HashiCorp or James Rasell
-	Author string `hcl:"author"`
+	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 
 	// TODO: Add Version here, may need to be a block or series of entries to
 	// support packs that contain multiple apps.

--- a/sdk/pack/metadata.go
+++ b/sdk/pack/metadata.go
@@ -29,7 +29,7 @@ type MetadataApp struct {
 	//
 	// Deprecated: Nomad Pack tech preview 4 removes this field, we keep it here for
 	// backwards compatibility only.
-	Author string `hcl:"author"`
+	Author string `hcl:"author,optional"`
 
 	// TODO: Add Version here, may need to be a block or series of entries to
 	// support packs that contain multiple apps.

--- a/sdk/pack/metadata_test.go
+++ b/sdk/pack/metadata_test.go
@@ -68,26 +68,6 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 			},
 			name: "some metadata values populated",
 		},
-		{
-			inputMetadata: &Metadata{
-				App: &MetadataApp{
-					URL:    "https://example.com",
-					Author: "The Nomad Team",
-				},
-				Pack: &MetadataPack{},
-			},
-			expectedOutput: map[string]interface{}{
-				"nomad_pack": map[string]interface{}{
-					"app": map[string]interface{}{
-						"url": "https://example.com",
-					},
-					"pack": map[string]interface{}{"name": "", "description": "", "url": "", "version": ""},
-				},
-			},
-			// TODO test added to cover graceful failure while we're in the process of
-			// retiring "Author" metadata field. Can be removed later.
-			name: "author field ignored gracefully",
-		},
 	}
 
 	for _, tc := range testCases {

--- a/sdk/pack/metadata_test.go
+++ b/sdk/pack/metadata_test.go
@@ -18,8 +18,7 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 		{
 			inputMetadata: &Metadata{
 				App: &MetadataApp{
-					URL:    "https://example.com",
-					Author: "Timothy J. Berners-Lee",
+					URL: "https://example.com",
 				},
 				Pack: &MetadataPack{
 					Name:        "Example",
@@ -31,8 +30,7 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 			expectedOutput: map[string]interface{}{
 				"nomad_pack": map[string]interface{}{
 					"app": map[string]interface{}{
-						"url":    "https://example.com",
-						"author": "Timothy J. Berners-Lee",
+						"url": "https://example.com",
 					},
 					"pack": map[string]interface{}{
 						"name":        "Example",
@@ -58,8 +56,7 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 			expectedOutput: map[string]interface{}{
 				"nomad_pack": map[string]interface{}{
 					"app": map[string]interface{}{
-						"url":    "https://example.com",
-						"author": "",
+						"url": "https://example.com",
 					},
 					"pack": map[string]interface{}{
 						"name":        "Example",
@@ -88,8 +85,7 @@ func TestMetadata_Validate(t *testing.T) {
 		{
 			inputMetadata: &Metadata{
 				App: &MetadataApp{
-					URL:    "https://example.com",
-					Author: "Timothy J. Berners-Lee",
+					URL: "https://example.com",
 				},
 				Pack: &MetadataPack{
 					Name:        "Example",

--- a/sdk/pack/metadata_test.go
+++ b/sdk/pack/metadata_test.go
@@ -68,6 +68,26 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 			},
 			name: "some metadata values populated",
 		},
+		{
+			inputMetadata: &Metadata{
+				App: &MetadataApp{
+					URL:    "https://example.com",
+					Author: "The Nomad Team",
+				},
+				Pack: &MetadataPack{},
+			},
+			expectedOutput: map[string]interface{}{
+				"nomad_pack": map[string]interface{}{
+					"app": map[string]interface{}{
+						"url": "https://example.com",
+					},
+					"pack": map[string]interface{}{"name": "", "description": "", "url": "", "version": ""},
+				},
+			},
+			// TODO test added to cover graceful failure while we're in the process of
+			// retiring "Author" metadata field. Can be removed later.
+			name: "author field ignored gracefully",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**Description**

This PR removes the `Author` field from pack metadata. 

Resolves #300 
Relates to #308 

**Reminders**

- [x] Add `CHANGELOG.md` entry
