### PR TITLE
Typo `manage` -> `managed` in conflict.go

### DIFF
--- a/internal/runner/job/conflict.go
+++ b/internal/runner/job/conflict.go
@@ -78,7 +78,7 @@ type ErrExistsNonPack struct {
 }
 
 func (e ErrExistsNonPack) Error() string {
-	return fmt.Sprintf("job with id %q already exists and is not manage by nomad pack", e.JobID)
+	return fmt.Sprintf("job with id %q already exists and is not managed by nomad pack", e.JobID)
 }
 
 type ErrExistsInDeployment struct {


### PR DESCRIPTION
**Description**
Fix for a super small typo.

**Reminders**

- [ ] Add `CHANGELOG.md` entry
