### PR TITLE
[chore] Update Makefile to use `go install`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -69,10 +69,16 @@ hclfmt: ## Format HCL files with hclfmt
 
 .PHONY: dev
 dev:
+ifneq (,$(shell echo ${PACK_INSTALL_DEV}))
+	@echo "==> Building and installing nomad-pack..."
+	@CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o ./bin/nomad-pack
+	@CGO_ENABLED=0 go install -ldflags $(GO_LDFLAGS)
+	@echo "==> Done"
+else
 	@echo "==> Building nomad-pack..."
 	@CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o ./bin/nomad-pack
-	@CGO_ENABLED=0 go install -ldflags $(GO_LDFLAGS) .
 	@echo "==> Done"
+endif
 
 pkg/%/nomad-pack: GO_OUT ?= $@
 pkg/windows_%/nomad-pack: GO_OUT = $@.exe

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -68,12 +68,10 @@ hclfmt: ## Format HCL files with hclfmt
 	@if (git status -s | grep -q -e '\.hcl$$' -e '\.nomad$$' -e '\.tf$$'); then echo the following HCL files are out of sync; git status -s | grep -e '\.hcl$$' -e '\.nomad$$' -e '\.tf$$'; exit 1; fi
 
 .PHONY: dev
-dev: GOPATH=$(shell go env GOPATH)
 dev:
 	@echo "==> Building nomad-pack..."
 	@CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o ./bin/nomad-pack
-	@rm -f $(GOPATH)/bin/nomad-pack
-	@cp ./bin/nomad-pack $(GOPATH)/bin/nomad-pack
+	@CGO_ENABLED=0 go install -ldflags $(GO_LDFLAGS) .
 	@echo "==> Done"
 
 pkg/%/nomad-pack: GO_OUT ?= $@


### PR DESCRIPTION
**Description**
This PR replaces the homemade binary install process from the `make dev` target and replaces it with a call to `go install`.  Added a check for `PACK_INSTALL_DEV` around the install behavior to prevent surprising community contributors by overwriting their installed version of `nomad-pack` with a dev version upon running `make dev`.

Fixes #319

**Changes**
- Use `go install` to place dev binaries
- consult envvar for auto-install on dev target
