### PR TITLE
[chore] ignore `nomad-pack` binaries in the project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ bin/*
 *.so
 *.dylib
 
+# binary when created in the project root with go build .
+./nomad-pack
+
 # Test binary, built with `go test -c`
 *.test
 


### PR DESCRIPTION
**Description**

Ignore `nomad-pack` binaries in the project root, which might have been created by running `go build .`
