### PR TITLE
pack: separate registry list and pack list commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ IMPROVEMENTS:
 
 * cli: Add `generate var-file` command [[GH-333](https://github.com/hashicorp/nomad-pack/pull/333)]
 * cli: `registry list` command now shows git refs to repositories present in the cache [[GH-318](https://github.com/hashicorp/nomad-pack/pull/318)]
+* cli: `registry list` command now shows only registries, and a new command `list` shows packs [[GH-337](https://github.com/hashicorp/nomad-pack/pull/337)]
 * deps: Update the Nomad OpenAPI dependency; require Go 1.18 as a build dependency [[GH-288](https://github.com/hashicorp/nomad-pack/pull/288)]
 * pack: Author field no longer supported in pack metadata [[GH-317](https://github.com/hashicorp/nomad-pack/pull/317)]
 * pack: URL field no longer supported in pack metadata [[GH-343](https://github.com/hashicorp/nomad-pack/pull/343)]

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -65,7 +65,7 @@ func TestCLI_CreateTestRegistry(t *testing.T) {
 
 	result := runPackCmd(t, []string{"registry", "list"})
 	out := result.cmdOut.String()
-	regex := regexp.MustCompile(`(?m)^ +` + reg.Name + ` +\| (\w+) +\| (\w+) +\| ` + reg.Source + ` +\|[^\n]+?$`)
+	regex := regexp.MustCompile(`(?m)^ +` + reg.Name + ` +\| (\w+) +\| (\w+) +\| ` + reg.Source + ` +[^\n]+?$`)
 	matches := regex.FindAllString(out, -1)
 	for i, match := range matches {
 		t.Logf("match %v:  %v\n", i, match)
@@ -860,7 +860,12 @@ func createTestRegistry(t *testing.T) (*cache.Registry, string) {
 
 	// Put a sample metadata.json in the test registry
 	metaPath := filepath.Join(regDir, "metadata.json")
-	registry := &cache.Registry{Name: registryName, Source: "github.com/hashicorp/test-registry", Ref: testRef, LocalRef: testRef}
+	registry := &cache.Registry{
+		Name:     registryName,
+		Source:   "github.com/hashicorp/nomad-pack-test-registry",
+		Ref:      testRef,
+		LocalRef: testRef,
+	}
 	b, _ := json.Marshal(registry)
 	os.WriteFile(metaPath, b, 0644)
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -8,20 +8,19 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path"
 	"runtime"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/nomad-pack/internal/pkg/cache"
-	flag "github.com/hashicorp/nomad-pack/internal/pkg/flag"
-	"github.com/hashicorp/nomad-pack/internal/pkg/variable"
-	"github.com/hashicorp/nomad-pack/terminal"
 	"github.com/hashicorp/nomad/api"
 	"github.com/mitchellh/go-wordwrap"
 	"github.com/posener/complete"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/hashicorp/nomad-pack/internal/pkg/cache"
+	flag "github.com/hashicorp/nomad-pack/internal/pkg/flag"
+	"github.com/hashicorp/nomad-pack/internal/pkg/variable"
+	"github.com/hashicorp/nomad-pack/terminal"
 )
 
 // baseCommand is embedded in all commands to provide common logic and data.
@@ -215,7 +214,7 @@ func (c *baseCommand) Init(opts ...Option) error {
 
 func (c *baseCommand) ensureCache() error {
 	// Creates global cache
-	globalCache, err := cache.NewCache(&cache.CacheConfig{
+	_, err := cache.NewCache(&cache.CacheConfig{
 		Path:   cache.DefaultCachePath(),
 		Logger: c.ui,
 	})
@@ -223,21 +222,6 @@ func (c *baseCommand) ensureCache() error {
 		return err
 	}
 
-	// Check if default registry exists
-	_, err = os.Stat(path.Join(cache.DefaultCachePath(), cache.DefaultRegistryName))
-	// If it does not error, then the registry already exists
-	if err == nil {
-		return nil
-	}
-
-	// Add the registry or registry target to the global cache
-	_, err = globalCache.Add(&cache.AddOpts{
-		RegistryName: cache.DefaultRegistryName,
-		Source:       cache.DefaultRegistrySource,
-	})
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -114,7 +114,7 @@ func packRow(cachedRegistry *cache.Registry, cachedPack *cache.Pack) []terminal.
 		},
 		// CachedRegistry name  user defined alias or registry URL slug
 		{
-			Value: cachedRegistry.Name,
+			Value: fmt.Sprintf("%s@%s", cachedRegistry.Name, cachedRegistry.LocalRef),
 		},
 		// TODO: The app version
 	}

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -51,6 +51,10 @@ func registryTable() *terminal.Table {
 	return terminal.NewTable("REGISTRY NAME", "REF", "LOCAL_REF", "REGISTRY_URL")
 }
 
+func registryPackTable() *terminal.Table {
+	return terminal.NewTable("PACK NAME", "REF", "LOCAL_REF", "METADATA VERSION", "REGISTRY NAME", "REGISTRY_URL")
+}
+
 func packTable() *terminal.Table {
 	return terminal.NewTable("PACK NAME", "METADATA VERSION", "REGISTRY NAME")
 }

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -48,36 +48,27 @@ func generatePackManager(c *baseCommand, client *api.Client, packCfg *cache.Pack
 }
 
 func registryTable() *terminal.Table {
-	return terminal.NewTable("PACK NAME", "REF", "LOCAL_REF", "METADATA VERSION", "REGISTRY", "REGISTRY_URL")
+	return terminal.NewTable("REGISTRY NAME", "REF", "LOCAL_REF", "REGISTRY_URL")
 }
 
-func emptyRegistryTableRow(cachedRegistry *cache.Registry) []terminal.TableEntry {
+func packTable() *terminal.Table {
+	return terminal.NewTable("PACK NAME", "METADATA VERSION", "REGISTRY NAME")
+}
+
+func registryTableRow(cachedRegistry *cache.Registry) []terminal.TableEntry {
 	return []terminal.TableEntry{
-		// blank pack name
-		{
-			Value: "",
-		},
-		// blank revision
-		{
-			Value: "",
-		},
-		// blank local ref
-		{
-			Value: "",
-		},
-		// blank metadata version
-		{
-			Value: "",
-		},
-		// CachedRegistry name - user defined alias or registry URL slug
 		{
 			Value: cachedRegistry.Name,
 		},
-		// The cachedRegistry URL from where the registryPack was cloned
+		{
+			Value: cachedRegistry.Ref,
+		},
+		{
+			Value: cachedRegistry.LocalRef,
+		},
 		{
 			Value: cachedRegistry.Source,
 		},
-		// TODO: The app version
 	}
 }
 
@@ -99,13 +90,31 @@ func registryPackRow(cachedRegistry *cache.Registry, cachedPack *cache.Pack) []t
 		{
 			Value: cachedPack.Metadata.Pack.Version,
 		},
-		// CachedRegistry name - user defined alias or registry URL slug
+		// CachedRegistry name  user defined alias or registry URL slug
 		{
 			Value: cachedRegistry.Name,
 		},
 		// The cachedRegistry URL from where the registryPack was cloned
 		{
 			Value: cachedRegistry.Source,
+		},
+		// TODO: The app version
+	}
+}
+
+func packRow(cachedRegistry *cache.Registry, cachedPack *cache.Pack) []terminal.TableEntry {
+	return []terminal.TableEntry{
+		// The Name of the registryPack
+		{
+			Value: cachedPack.Name(),
+		},
+		// The metadata version
+		{
+			Value: cachedPack.Metadata.Pack.Version,
+		},
+		// CachedRegistry name  user defined alias or registry URL slug
+		{
+			Value: cachedRegistry.Name,
 		},
 		// TODO: The app version
 	}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -42,22 +42,22 @@ func (c *ListCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Initialize a table for a nice glint UI rendering
-	table := packTable()
-
 	// Iterate over the registries and build a table row for each cachedRegistry/pack
 	// entry at each ref. Hierarchically, this should equate to the default
 	// cachedRegistry and all its peers.
-	for _, cachedRegistry := range globalCache.Registries() {
-		for _, registryPack := range cachedRegistry.Packs {
-			tableRow := packRow(cachedRegistry, registryPack)
-			// append table row
-			table.Rows = append(table.Rows, tableRow)
+	if len(globalCache.Registries()) > 0 {
+		table := packTable()
+		for _, cachedRegistry := range globalCache.Registries() {
+			for _, registryPack := range cachedRegistry.Packs {
+				tableRow := packRow(cachedRegistry, registryPack)
+				table.Rows = append(table.Rows, tableRow)
+			}
 		}
+		// Display output table
+		c.ui.Table(table)
+	} else {
+		c.ui.Output("No packs present in the cache.")
 	}
-
-	// Display output table
-	c.ui.Table(table)
 
 	return 0
 }

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -9,13 +9,13 @@ import (
 	"github.com/posener/complete"
 )
 
-// RegistryListCommand lists all registries and pack that have been downloaded
+// ListCommand lists all registries and pack that have been downloaded
 // to the current machine.
-type RegistryListCommand struct {
+type ListCommand struct {
 	*baseCommand
 }
 
-func (c *RegistryListCommand) Run(args []string) int {
+func (c *ListCommand) Run(args []string) int {
 	c.cmdKey = "registry list"
 	// Initialize. If we fail, we just exit since Init handles the UI.
 	if err := c.Init(
@@ -43,14 +43,15 @@ func (c *RegistryListCommand) Run(args []string) int {
 	}
 
 	// Initialize a table for a nice glint UI rendering
-	table := registryTable()
+	table := packTable()
 
 	// Iterate over the registries and build a table row for each cachedRegistry/pack
 	// entry at each ref. Hierarchically, this should equate to the default
 	// cachedRegistry and all its peers.
-	if len(globalCache.Registries()) >= 0 {
-		for _, registry := range globalCache.Registries() {
-			tableRow := registryTableRow(registry)
+	for _, cachedRegistry := range globalCache.Registries() {
+		for _, registryPack := range cachedRegistry.Packs {
+			tableRow := packRow(cachedRegistry, registryPack)
+			// append table row
 			table.Rows = append(table.Rows, tableRow)
 		}
 	}
@@ -61,31 +62,31 @@ func (c *RegistryListCommand) Run(args []string) int {
 	return 0
 }
 
-func (c *RegistryListCommand) Flags() *flag.Sets {
+func (c *ListCommand) Flags() *flag.Sets {
 	return c.flagSet(0, nil)
 }
 
-func (c *RegistryListCommand) AutocompleteArgs() complete.Predictor {
+func (c *ListCommand) AutocompleteArgs() complete.Predictor {
 	return complete.PredictNothing
 }
 
-func (c *RegistryListCommand) AutocompleteFlags() complete.Flags {
+func (c *ListCommand) AutocompleteFlags() complete.Flags {
 	return c.Flags().Completions()
 }
 
-func (c *RegistryListCommand) Synopsis() string {
-	return "List registries and packs available in the local environment."
+func (c *ListCommand) Synopsis() string {
+	return "List packs available in the local environment."
 }
 
-func (c *RegistryListCommand) Help() string {
+func (c *ListCommand) Help() string {
 	c.Example = `
-	# List all available registries and their packs
-	nomad-pack registry list
+	# List all available packs
+	nomad-pack list
 	`
 	return formatHelp(`
-	Usage: nomad-pack registry list
+	Usage: nomad-pack list
 
-	List nomad pack registries.
+	List nomad packs.
 
 ` + c.GetExample() + c.Flags().Help())
 }

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -142,6 +142,11 @@ func Commands(
 				baseCommand: baseCommand,
 			}, nil
 		},
+		"list": func() (cli.Command, error) {
+			return &ListCommand{
+				baseCommand: baseCommand,
+			}, nil
+		},
 		"stop": func() (cli.Command, error) {
 			return &StopCommand{
 				baseCommand: baseCommand,

--- a/internal/cli/registry_list.go
+++ b/internal/cli/registry_list.go
@@ -43,21 +43,19 @@ func (c *RegistryListCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Initialize a table for a nice glint UI rendering
-	table := registryTable()
-
 	// Iterate over the registries and build a table row for each cachedRegistry/pack
 	// entry at each ref. Hierarchically, this should equate to the default
 	// cachedRegistry and all its peers.
 	if len(globalCache.Registries()) > 0 {
+		table := registryTable()
 		for _, registry := range globalCache.Registries() {
 			tableRow := registryTableRow(registry)
 			table.Rows = append(table.Rows, tableRow)
 		}
+		c.ui.Table(table)
+	} else {
+		c.ui.Output("No registries present in the cache.")
 	}
-
-	// Display output table
-	c.ui.Table(table)
 
 	return 0
 }

--- a/internal/cli/registry_list.go
+++ b/internal/cli/registry_list.go
@@ -4,9 +4,10 @@
 package cli
 
 import (
+	"github.com/posener/complete"
+
 	"github.com/hashicorp/nomad-pack/internal/pkg/cache"
 	"github.com/hashicorp/nomad-pack/internal/pkg/flag"
-	"github.com/posener/complete"
 )
 
 // RegistryListCommand lists all registries and pack that have been downloaded
@@ -48,7 +49,7 @@ func (c *RegistryListCommand) Run(args []string) int {
 	// Iterate over the registries and build a table row for each cachedRegistry/pack
 	// entry at each ref. Hierarchically, this should equate to the default
 	// cachedRegistry and all its peers.
-	if len(globalCache.Registries()) >= 0 {
+	if len(globalCache.Registries()) > 0 {
 		for _, registry := range globalCache.Registries() {
 			tableRow := registryTableRow(registry)
 			table.Rows = append(table.Rows, tableRow)

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -17,11 +17,10 @@ import (
 )
 
 const (
-	DefaultRegistryName   = "default"
-	DefaultRegistrySource = "github.com/hashicorp/nomad-pack-community-registry"
-	DefaultRef            = "latest"
-	DevRegistryName       = "<<local folder>>"
-	DevRef                = "<<none>>"
+	DefaultRegistryName = "default"
+	DefaultRef          = "latest"
+	DevRegistryName     = "<<local folder>>"
+	DevRef              = "<<none>>"
 )
 
 // NewCache instantiates a new cache instance with the specified config. If no

--- a/internal/pkg/cache/cache_test.go
+++ b/internal/pkg/cache/cache_test.go
@@ -179,6 +179,7 @@ func TestAddRegistryWithSHA(t *testing.T) {
 	expectedRegistryMetadata := &Registry{
 		Name:     "with-sha",
 		Source:   tReg.SourceURL(),
+		Ref:      tReg.Ref1(),
 		LocalRef: tReg.Ref1(),
 	}
 	must.Eq(t, expectedRegistryMetadata, r)

--- a/internal/pkg/cache/get.go
+++ b/internal/pkg/cache/get.go
@@ -31,6 +31,7 @@ func (c *Cache) Get(opts *GetOpts) (registry *Registry, err error) {
 	// If no errors, allocate the instance
 	registry = &Registry{
 		Name:  opts.RegistryName,
+		Ref:   opts.Ref,
 		Packs: make([]*Pack, 0),
 	}
 

--- a/internal/pkg/cache/registry.go
+++ b/internal/pkg/cache/registry.go
@@ -68,6 +68,7 @@ func (r *Registry) get(opts *GetOpts, cache *Cache) error {
 			}
 			r.LocalRef = cachedRegistry.LocalRef
 			r.Source = cachedRegistry.Source
+			r.Ref = cachedRegistry.Ref
 			continue
 		}
 


### PR DESCRIPTION
**Description**

This PR changes `nomad-pack registry list` command to display a list of registries, i.e.:
```
$ nomad-pack registry list
  REGISTRY NAME |  REF   | LOCAL REF |                    REGISTRY URL
----------------+--------+-----------+-----------------------------------------------------
  community     | latest | bd48167   | github.com/hashicorp/nomad-pack-community-registry
```
and adds a new `nomad-pack list` command that lists only packs:
```
$ nomad-pack list
          PACK NAME          | METADATA VERSION |   REGISTRY NAME
-----------------------------+------------------+--------------------
  alertmanager               | 0.0.1            | community@bd48167
  aws_efs_csi                | 0.0.1            | community@bd48167
  boundary                   | 0.0.1            | community@bd48167
  chaotic_ngine              | 0.0.1            | community@bd48167
  csi_openstack_cinder       | 0.0.1            | community@bd48167
  drone                      | 0.0.1            | community@bd48167
  faasd                      | 0.0.1            | community@bd48167
  fabio                      | 0.0.1            | community@bd48167
  grafana                    | 0.1.0            | community@bd48167
  haproxy                    | 0.0.1            | community@bd48167
  hashicups                  | 0.0.1            | community@bd48167
  hello_world                | 0.0.1            | community@bd48167
  influxdb                   | 0.0.1            | community@bd48167
  jaeger                     | 0.0.1            | community@bd48167
  jenkins                    | 0.0.1            | community@bd48167
  kibana                     | 0.0.1            | community@bd48167
  loki                       | 0.0.1            | community@bd48167
  nextcloud                  | 0.0.1            | community@bd48167
  nginx                      | 0.0.1            | community@bd48167
  nomad_autoscaler           | 0.0.1            | community@bd48167
  nomad_ingress_nginx        | 0.0.1            | community@bd48167
  opentelemetry_collector    | 0.0.1            | community@bd48167
  outline                    | 0.0.1            | community@bd48167
  prometheus                 | 0.0.1            | community@bd48167
  prometheus_consul_exporter | 0.0.1            | community@bd48167
  prometheus_node_exporter   | 0.0.1            | community@bd48167
  prometheus_snmp_exporter   | 0.0.1            | community@bd48167
  promtail                   | 0.0.1            | community@bd48167
  rabbitmq                   | 0.0.1            | community@bd48167
  redis                      | 0.0.1            | community@bd48167
  simple_service             | 0.0.1            | community@bd48167
  sonarqube                  | 0.0.1            | community@bd48167
  tempo                      | 0.0.1            | community@bd48167
  tfc_agent                  | 0.1.0            | community@bd48167
  traefik                    | 0.1.0            | community@bd48167
  vector                     | 0.0.1            | community@bd48167
  wordpress                  | 0.0.1            | community@bd48167
```

Resolves #354. 

**Reminders**

- [x] Add `CHANGELOG.md` entry
