### PR TITLE
pack: URL field no longer supported in pack metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ IMPROVEMENTS:
 * cli: `registry list` command now shows git refs to repositories present in the cache [[GH-318](https://github.com/hashicorp/nomad-pack/pull/318)]
 * deps: Update the Nomad OpenAPI dependency; require Go 1.18 as a build dependency [[GH-288](https://github.com/hashicorp/nomad-pack/pull/288)]
 * pack: Author field no longer supported in pack metadata [[GH-317](https://github.com/hashicorp/nomad-pack/pull/317)]
+* pack: URL field no longer supported in pack metadata [[GH-343](https://github.com/hashicorp/nomad-pack/pull/343)]
 * template: Render templates other than Nomad job specifications inside `templates/` [[GH-303](https://github.com/hashicorp/nomad-pack/pull/303)]
 * template: Automatically format templates before outputting [[GH-311](https://github.com/hashicorp/nomad-pack/pull/311)]
 * template: Skip templates that would render to just whitespace [[GH-313](https://github.com/hashicorp/nomad-pack/pull/313)]

--- a/docs/writing-packs.md
+++ b/docs/writing-packs.md
@@ -50,7 +50,6 @@ The `metadata.hcl` file contains important key value information regarding the p
 - "app {url}" - The HTTP(S) url to the homepage of the application to provide a quick reference to the documentation and help pages.
 - "pack {name}" - The name of the pack.
 - "pack {description}" - A small overview of the application that is deployed by the pack.
-- "pack {url}" - The source URL for the pack itself.
 - "pack {version}" - The version of the pack.
 - "dependency {name}" - The dependencies that the pack has on other packs. Multiple dependencies can be supplied.
 - "dependency {source}" - The source URL for this dependency.
@@ -65,7 +64,6 @@ app {
 pack {
   name = "hello_world"
   description = "This pack contains a single job that renders hello world, or a different greeting, to the screen."
-  url = "https://github.com/hashicorp/nomad-pack-community-registry/hello_world"
   version = "0.3.2"
 }
 ```
@@ -243,7 +241,6 @@ app {
 pack {
   name = "simple_service"
   description = "This pack contains a simple service job, and depends on another pack."
-  url = "https://github.com/hashicorp/nomad-pack-community-registry/simple_service"
   version = "0.2.1"
 }
 

--- a/fixtures/bad_pack/metadata.hcl
+++ b/fixtures/bad_pack/metadata.hcl
@@ -8,6 +8,5 @@ app {
 pack {
   name        = "simple_service"
   description = "This deploys a simple service job to Nomad that runs a docker container."
-  url         = "https://github.com/hashicorp/nomad-pack-community-registry/simple_service"
   version     = "0.0.1"
 }

--- a/fixtures/test_registry/packs/my_alias_test/deps/child1/metadata.hcl
+++ b/fixtures/test_registry/packs/my_alias_test/deps/child1/metadata.hcl
@@ -8,6 +8,5 @@ app {
 pack {
   name        = "child1"
   description = "render-only child dependency"
-  url         = "github.com/hashicorp/nomad-pack/fixtures/test_registry/packs/simple-raw-exec"
   version     = "0.0.1"
 }

--- a/fixtures/test_registry/packs/my_alias_test/deps/child2/metadata.hcl
+++ b/fixtures/test_registry/packs/my_alias_test/deps/child2/metadata.hcl
@@ -8,6 +8,5 @@ app {
 pack {
   name        = "child2"
   description = "render-only child dependency"
-  url         = "github.com/hashicorp/nomad-pack/fixtures/test_registry/packs/simple-raw-exec"
   version     = "0.0.1"
 }

--- a/fixtures/test_registry/packs/simple_raw_exec/metadata.hcl
+++ b/fixtures/test_registry/packs/simple_raw_exec/metadata.hcl
@@ -9,6 +9,6 @@ app {
 pack {
   name        = "simple_raw_exec"
   description = "This is a test fixture pack used because all platforms support raw_exec"
-  url         = "github.com/hashicorp/nomad-pack/fixtures/test_registry/packs/simple-raw-exec"
+  url         = "github.com/hashicorp/nomad-pack/fixtures/test_registry/packs/simple-raw-exec" # url field deprecated, left here to make sure we don't panic and fail gracefully
   version     = "0.0.1"
 }

--- a/fixtures/variable_test/variable_test/metadata.hcl
+++ b/fixtures/variable_test/variable_test/metadata.hcl
@@ -8,6 +8,5 @@ app {
 pack {
   name        = "variable_test_pack"
   description = "This pack tests variable overrides"
-  url         = ""
   version     = "0.0.1"
 }

--- a/internal/pkg/cache/pack.go
+++ b/internal/pkg/cache/pack.go
@@ -76,7 +76,6 @@ func invalidPackDefinition(provider cacheOperationProvider) *Pack {
 				Pack: &pack.MetadataPack{
 					Name:        provider.ForPackName(),
 					Description: "",
-					URL:         "",
 					Version:     "Invalid pack definition",
 				},
 			},

--- a/sdk/pack/metadata.go
+++ b/sdk/pack/metadata.go
@@ -48,7 +48,10 @@ type MetadataPack struct {
 
 	// URL is the HTTP(S) url of the pack which is acts as a convenience when
 	// managing packs within a registry.
-	URL string `hcl:"url"`
+	//
+	// Deprecated: Nomad Pack tech preview 4 removes this field, we keep it here for
+	// backwards compatibility only.
+	URL string `hcl:"url,optional"`
 
 	// Version is the version of the pack which is acts as a convenience when
 	// managing packs within a registry.
@@ -67,7 +70,6 @@ func (md *Metadata) ConvertToMapInterface() map[string]interface{} {
 			"pack": map[string]interface{}{
 				"name":        md.Pack.Name,
 				"description": md.Pack.Description,
-				"url":         md.Pack.URL,
 				"version":     md.Pack.Version,
 			},
 		},
@@ -85,7 +87,6 @@ func (md *Metadata) AddToInterfaceMap(m map[string]interface{}) map[string]inter
 		"pack": map[string]interface{}{
 			"name":        md.Pack.Name,
 			"description": md.Pack.Description,
-			"url":         md.Pack.URL,
 			"version":     md.Pack.Version,
 		},
 	}

--- a/sdk/pack/metadata_test.go
+++ b/sdk/pack/metadata_test.go
@@ -23,7 +23,6 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 				Pack: &MetadataPack{
 					Name:        "Example",
 					Description: "The most basic, yet awesome, example",
-					URL:         "https://example.com",
 					Version:     "v0.0.1",
 				},
 			},
@@ -35,7 +34,6 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 					"pack": map[string]interface{}{
 						"name":        "Example",
 						"description": "The most basic, yet awesome, example",
-						"url":         "https://example.com",
 						"version":     "v0.0.1",
 					},
 				},
@@ -61,7 +59,6 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 					"pack": map[string]interface{}{
 						"name":        "Example",
 						"description": "",
-						"url":         "https://example.com",
 						"version":     "v0.0.1",
 					},
 				},
@@ -74,19 +71,21 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 					URL:    "https://example.com",
 					Author: "The Nomad Team",
 				},
-				Pack: &MetadataPack{},
+				Pack: &MetadataPack{
+					URL: "https://example.com",
+				},
 			},
 			expectedOutput: map[string]interface{}{
 				"nomad_pack": map[string]interface{}{
 					"app": map[string]interface{}{
 						"url": "https://example.com",
 					},
-					"pack": map[string]interface{}{"name": "", "description": "", "url": "", "version": ""},
+					"pack": map[string]interface{}{"name": "", "description": "", "version": ""},
 				},
 			},
 			// TODO test added to cover graceful failure while we're in the process of
-			// retiring "Author" metadata field. Can be removed later.
-			name: "author field ignored gracefully",
+			// retiring "Author" and "URL" metadata fields. Can be removed in the future.
+			name: "author and url fields ignored gracefully",
 		},
 	}
 


### PR DESCRIPTION
**Description**

This PR removes the URL field from pack metadata.

Relates to https://github.com/hashicorp/nomad-pack/issues/308 and https://github.com/hashicorp/nomad-pack/issues/170

**Reminders**

- [x] Add `CHANGELOG.md` entry
- [x] #318 **must be merged before** this PR can be merged
