### PR TITLE
Migrate CRT configuration to 'prepare' workflow

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -18,173 +18,19 @@ project "nomad-pack" {
   }
 }
 
-event "merge" {
-  // "entrypoint" to use if build is not run automatically
-  // i.e. send "merge" complete signal to orchestrator to trigger build
-}
+event "build" {}
 
-event "build" {
-  depends = ["merge"]
-  action "build" {
-    organization = "hashicorp"
-    repository   = "nomad-pack"
-    workflow     = "build"
-  }
-}
-
-event "upload-dev" {
+event "prepare" {
   depends = ["build"]
-  action "upload-dev" {
+  action "prepare" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
-    workflow     = "upload-dev"
+    workflow     = "prepare"
     depends      = ["build"]
   }
 
   notification {
     on = "fail"
-  }
-}
-
-event "security-scan-binaries" {
-  depends = ["upload-dev"]
-  action "security-scan-binaries" {
-    organization = "hashicorp"
-    repository   = "crt-workflows-common"
-    workflow     = "security-scan-binaries"
-    config       = "security-scan.hcl"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "security-scan-containers" {
-  depends = ["security-scan-binaries"]
-  action "security-scan-containers" {
-    organization = "hashicorp"
-    repository   = "crt-workflows-common"
-    workflow     = "security-scan-containers"
-    config       = "security-scan.hcl"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-darwin-amd64" {
-  depends = ["security-scan-containers"]
-  action "notarize-darwin-amd64" {
-    organization = "hashicorp"
-    repository   = "crt-workflows-common"
-    workflow     = "notarize-darwin-amd64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-darwin-arm64" {
-  depends = ["notarize-darwin-amd64"]
-  action "notarize-darwin-arm64" {
-    organization = "hashicorp"
-    repository   = "crt-workflows-common"
-    workflow     = "notarize-darwin-arm64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-windows-amd64" {
-  depends = ["notarize-darwin-arm64"]
-  action "notarize-windows-amd64" {
-    organization = "hashicorp"
-    repository   = "crt-workflows-common"
-    workflow     = "notarize-windows-amd64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-windows-arm64" {
-  depends = ["notarize-windows-amd64"]
-  action "notarize-windows-arm64" {
-    organization = "hashicorp"
-    repository   = "crt-workflows-common"
-    workflow     = "notarize-windows-arm64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "sign" {
-  depends = ["notarize-windows-arm64"]
-  action "sign" {
-    organization = "hashicorp"
-    repository   = "crt-workflows-common"
-    workflow     = "sign"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "sign-linux-rpms" {
-  depends = ["sign"]
-  action "sign-linux-rpms" {
-    organization = "hashicorp"
-    repository   = "crt-workflows-common"
-    workflow     = "sign-linux-rpms"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "verify" {
-  depends = ["sign-linux-rpms"]
-  action "verify" {
-    organization = "hashicorp"
-    repository   = "crt-workflows-common"
-    workflow     = "verify"
-  }
-
-  notification {
-    on = "always"
-  }
-}
-
-event "promote-dev-docker" {
-  depends = ["verify"]
-  action "promote-dev-docker" {
-    organization = "hashicorp"
-    repository   = "crt-workflows-common"
-    workflow     = "promote-dev-docker"
-    depends      = ["verify"]
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "fossa-scan" {
-  depends = ["promote-dev-docker"]
-  action "fossa-scan" {
-    organization = "hashicorp"
-    repository   = "crt-workflows-common"
-    workflow     = "fossa-scan"
   }
 }
 


### PR DESCRIPTION
This replaces the explicit configuration enumerating each step in the common release tooling process with a single step that encapsulates all organizational requirements (signing, notarization, etc.).

