### PR TITLE
Integration stanza support

### DIFF
--- a/sdk/pack/metadata.go
+++ b/sdk/pack/metadata.go
@@ -101,6 +101,11 @@ func (md *Metadata) ConvertToMapInterface() map[string]interface{} {
 				"description": md.Pack.Description,
 				"version":     md.Pack.Version,
 			},
+			"integration": map[string]interface{}{
+				"identifier": md.Integration.Identifier,
+				"flags":      md.Integration.Flags,
+				"name":       md.Integration.Name,
+			},
 		},
 	}
 }
@@ -117,6 +122,11 @@ func (md *Metadata) AddToInterfaceMap(m map[string]interface{}) map[string]inter
 			"name":        md.Pack.Name,
 			"description": md.Pack.Description,
 			"version":     md.Pack.Version,
+		},
+		"integration": map[string]interface{}{
+			"identifier": md.Integration.Identifier,
+			"flags":      md.Integration.Flags,
+			"name":       md.Integration.Name,
 		},
 	}
 	return m

--- a/sdk/pack/metadata.go
+++ b/sdk/pack/metadata.go
@@ -11,9 +11,10 @@ import (
 // high-level information about the pack which is useful for operators and is
 // also exposed as template variables during rendering.
 type Metadata struct {
-	App          *MetadataApp  `hcl:"app,block"`
-	Pack         *MetadataPack `hcl:"pack,block"`
-	Dependencies []*Dependency `hcl:"dependency,block"`
+	App          *MetadataApp         `hcl:"app,block"`
+	Pack         *MetadataPack        `hcl:"pack,block"`
+	Integration  *MetadataIntegration `hcl:"integration,block,optional"`
+	Dependencies []*Dependency        `hcl:"dependency,block"`
 }
 
 // MetadataApp contains information regarding the application that the pack is
@@ -56,6 +57,34 @@ type MetadataPack struct {
 	// Version is the version of the pack which is acts as a convenience when
 	// managing packs within a registry.
 	Version string `hcl:"version"`
+}
+
+// MetadataIntegration contains information pertaining to the HashiCorp
+// Developer (https://developer.hashicorp.com/) Integrations Library.
+// This block is only needed for packs that are to be displayed in the
+// integrations library.
+//
+// Note: Currently, the integrations library is in closed beta, so you
+// will not be able to register an integration without support from a
+// HashiCorp team member. Furthermore, you may not be able to access
+// some of the links specified below in this structs documentation.
+type MetadataIntegration struct {
+
+	// Identifier is a unique identifier that points to a specific integration
+	// registered in the HashiCorp Developer Integrations Library.
+	Identifier string `hcl:"identifier"`
+
+	// Flags is an array of strings referencing various booleans you
+	// can enable for your pack as it will display in the integrations
+	// library. All flag options are specified within this file:
+	// https://github.com/hashicorp/integrations/blob/main/flags.hcl
+	Flags []string `hcl:"flags,optional"`
+
+	// You can optionally override the pack.name value here to adjust
+	// the name that will be displayed in HashiCorp Developer. For example,
+	// your pack name may be "hello_world", whereas on HashiCorp Developer
+	// you would like the name to render as "Hello World".
+	Name string `hcl:"name,optional"`
 }
 
 // ConvertToMapInterface returns a map[string]interface{} representation of the


### PR DESCRIPTION
**Description**
Adds in support for an integration stanza, as to allow for the registration of nomad packs into our upcoming Nomad integrations library (ex: [waypoint's library](https://developer.hashicorp.com/waypoint/integrations))