### PR TITLE
fix: handle empty integration block

### DIFF
--- a/sdk/pack/metadata.go
+++ b/sdk/pack/metadata.go
@@ -72,7 +72,7 @@ type MetadataIntegration struct {
 
 	// Identifier is a unique identifier that points to a specific integration
 	// registered in the HashiCorp Developer Integrations Library.
-	Identifier string `hcl:"identifier,optional"`
+	Identifier string `hcl:"identifier"`
 
 	// Flags is an array of strings referencing various booleans you
 	// can enable for your pack as it will display in the integrations
@@ -91,30 +91,7 @@ type MetadataIntegration struct {
 // metadata object. The conversion doesn't take into account empty values and
 // will add them.
 func (md *Metadata) ConvertToMapInterface() map[string]interface{} {
-	return map[string]interface{}{
-		"nomad_pack": map[string]interface{}{
-			"app": map[string]interface{}{
-				"url": md.App.URL,
-			},
-			"pack": map[string]interface{}{
-				"name":        md.Pack.Name,
-				"description": md.Pack.Description,
-				"version":     md.Pack.Version,
-			},
-			"integration": map[string]interface{}{
-				"identifier": md.Integration.Identifier,
-				"flags":      md.Integration.Flags,
-				"name":       md.Integration.Name,
-			},
-		},
-	}
-}
-
-// AddToInterfaceMap adds the metadata information to the provided map as a new
-// entry under the "nomad_pack" key. This is useful for adding this information
-// to the template rendering data.
-func (md *Metadata) AddToInterfaceMap(m map[string]interface{}) map[string]interface{} {
-	m["nomad_pack"] = map[string]interface{}{
+	innerMap := map[string]interface{}{
 		"app": map[string]interface{}{
 			"url": md.App.URL,
 		},
@@ -123,12 +100,40 @@ func (md *Metadata) AddToInterfaceMap(m map[string]interface{}) map[string]inter
 			"description": md.Pack.Description,
 			"version":     md.Pack.Version,
 		},
-		"integration": map[string]interface{}{
+	}
+	if md.Integration != nil {
+		innerMap["integration"] = map[string]interface{}{
 			"identifier": md.Integration.Identifier,
 			"flags":      md.Integration.Flags,
 			"name":       md.Integration.Name,
+		}
+	}
+
+	return map[string]interface{}{"nomad_pack": innerMap}
+}
+
+// AddToInterfaceMap adds the metadata information to the provided map as a new
+// entry under the "nomad_pack" key. This is useful for adding this information
+// to the template rendering data.
+func (md *Metadata) AddToInterfaceMap(m map[string]interface{}) map[string]interface{} {
+	innerMap := map[string]interface{}{
+		"app": map[string]interface{}{
+			"url": md.App.URL,
+		},
+		"pack": map[string]interface{}{
+			"name":        md.Pack.Name,
+			"description": md.Pack.Description,
+			"version":     md.Pack.Version,
 		},
 	}
+	if md.Integration != nil {
+		innerMap["integration"] = map[string]interface{}{
+			"identifier": md.Integration.Identifier,
+			"flags":      md.Integration.Flags,
+			"name":       md.Integration.Name,
+		}
+	}
+	m["nomad_pack"] = innerMap
 	return m
 }
 

--- a/sdk/pack/metadata_test.go
+++ b/sdk/pack/metadata_test.go
@@ -25,10 +25,10 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 					Description: "The most basic, yet awesome, example",
 					Version:     "v0.0.1",
 				},
-				Integration: &Integration{
+				Integration: &MetadataIntegration{
 					Name:       "Example",
 					Identifier: "nomad/hashicorp/example",
-					flags: []string{
+					Flags: []string{
 						"foo",
 						"bar",
 					},
@@ -45,12 +45,12 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 						"version":     "v0.0.1",
 					},
 					"integration": map[string]interface{}{
-						"identifier": "Example",
+						"identifier": "nomad/hashicorp/example",
 						"flags": []string{
 							"foo",
 							"bar",
 						},
-						"name": "nomad/hashicorp/example",
+						"name": "Example",
 					},
 				},
 			},
@@ -66,7 +66,7 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 					URL:     "https://example.com",
 					Version: "v0.0.1",
 				},
-				Integration: &Integration{},
+				Integration: &MetadataIntegration{},
 			},
 			expectedOutput: map[string]interface{}{
 				"nomad_pack": map[string]interface{}{
@@ -80,7 +80,7 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 					},
 					"integration": map[string]interface{}{
 						"identifier": "",
-						"flags":      []string{},
+						"flags":      []string(nil),
 						"name":       "",
 					},
 				},
@@ -96,19 +96,13 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 				Pack: &MetadataPack{
 					URL: "https://example.com",
 				},
-				Integration: &Integration{},
+				Integration: &MetadataIntegration{},
 			},
 			expectedOutput: map[string]interface{}{
 				"nomad_pack": map[string]interface{}{
-					"app": map[string]interface{}{
-						"url": "https://example.com",
-					},
-					"pack": map[string]interface{}{"name": "", "description": "", "version": ""},
-					"integration": map[string]interface{}{
-						"identifier": "",
-						"flags":      []string{},
-						"name":       "",
-					},
+					"app":         map[string]interface{}{"url": "https://example.com"},
+					"pack":        map[string]interface{}{"name": "", "description": "", "version": ""},
+					"integration": map[string]interface{}{"identifier": "", "flags": []string(nil), "name": ""},
 				},
 			},
 			// TODO test added to cover graceful failure while we're in the process of
@@ -138,7 +132,7 @@ func TestMetadata_Validate(t *testing.T) {
 					Name:        "Example",
 					Description: "The most basic, yet awesome, example",
 				},
-				Integration: &Integration{},
+				Integration: &MetadataIntegration{},
 			},
 			expectError: false,
 			name:        "valid metadata",


### PR DESCRIPTION
`Integration` metadata introduced in https://github.com/hashicorp/nomad-pack/pull/351 (currently in closed beta) should be handled correctly when present in the HCL file or not. 