### PR TITLE
[bug] Missing nil check for err when PackPath exists.

### DIFF
--- a/internal/pkg/cache/add.go
+++ b/internal/pkg/cache/add.go
@@ -195,7 +195,7 @@ func (c *Cache) processPackEntry(opts *AddOpts, packEntry os.DirEntry) error {
 
 	// Check if folder exists
 	_, err := os.Stat(opts.PackPath())
-	if !errors.Is(err, fs.ErrNotExist) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		logger.ErrorWithContext(err, "error checking pack directory", c.ErrorContext.GetAll()...)
 		return err
 	}


### PR DESCRIPTION
**Description**
When the pack path exists err is nil, however we didn't check for that causing us to slide into the error pathway 
and return a nil error that makes other things sad later.


**Reminders**

- [ ] ~Add `CHANGELOG.md` entry~ Since this bug never shipped in a versioned release, will omit CL entry
