### PR TITLE
[chore] Run hclfmt on fixtures

### DIFF
--- a/fixtures/test_registry/packs/my_alias_test/deps/child2/variables.hcl
+++ b/fixtures/test_registry/packs/my_alias_test/deps/child2/variables.hcl
@@ -13,7 +13,7 @@ variable "complex" {
     name    = string
     address = string
     ids     = list(string)
-    lookup  = map(object({
+    lookup = map(object({
       a = number
       b = string
     }))

--- a/fixtures/test_registry/packs/my_alias_test/variables.hcl
+++ b/fixtures/test_registry/packs/my_alias_test/variables.hcl
@@ -40,7 +40,7 @@ variable "command" {
 variable "env" {
   type        = map(string)
   description = "environment variable collection"
-  default     = {"FOO" = "bar", "BAZ" = "QUX"}
+  default     = { "FOO" = "bar", "BAZ" = "QUX" }
 }
 
 variable "test_name" {


### PR DESCRIPTION
**Description**
hclfmt the fixture HCL files.  Not sure why it chose to delete that space after `lookup`, but if we don't take the change the lint steps will complain. 
