### PR TITLE
[chore] Convert `interface{}` to `any`

### DIFF
--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -260,7 +260,7 @@ func getPackJobsByDeploy(c *api.Client, cfg *cache.PackConfig, deploymentName st
 
 // TODO: Needs code review. Will likely move if we decide to move client management
 // out of CLI commands.
-func generateRunner(client *api.Client, packType, cliCfg interface{}, runnerCfg *runner.Config) (runner.Runner, error) {
+func generateRunner(client *api.Client, packType, cliCfg any, runnerCfg *runner.Config) (runner.Runner, error) {
 
 	var (
 		err          error

--- a/internal/pkg/flag/flag_bool.go
+++ b/internal/pkg/flag/flag_bool.go
@@ -103,7 +103,7 @@ func (b *boolValue) Set(s string) error {
 	return nil
 }
 
-func (b *boolValue) Get() interface{} { return *b.target }
+func (b *boolValue) Get() any         { return *b.target }
 func (b *boolValue) String() string   { return strconv.FormatBool(*b.target) }
 func (b *boolValue) Example() string  { return "" }
 func (b *boolValue) Hidden() bool     { return b.hidden }

--- a/internal/pkg/flag/flag_enum.go
+++ b/internal/pkg/flag/flag_enum.go
@@ -102,8 +102,8 @@ parts:
 	return nil
 }
 
-func (s *enumValue) Get() interface{} { return *s.target }
-func (s *enumValue) String() string   { return strings.Join(*s.target, ",") }
-func (s *enumValue) Example() string  { return "string" }
-func (s *enumValue) Hidden() bool     { return s.hidden }
-func (s *enumValue) Type() string     { return "enum" }
+func (s *enumValue) Get() any        { return *s.target }
+func (s *enumValue) String() string  { return strings.Join(*s.target, ",") }
+func (s *enumValue) Example() string { return "string" }
+func (s *enumValue) Hidden() bool    { return s.hidden }
+func (s *enumValue) Type() string    { return "enum" }

--- a/internal/pkg/flag/flag_enum_single.go
+++ b/internal/pkg/flag/flag_enum_single.go
@@ -92,8 +92,8 @@ func (s *enumSingleValue) Set(val string) error {
 	return fmt.Errorf("'%s' not valid. Must be one of: %s", val, strings.Join(s.ev.Values, ", "))
 }
 
-func (s *enumSingleValue) Get() interface{} { return *s.target }
-func (s *enumSingleValue) String() string   { return *s.target }
-func (s *enumSingleValue) Example() string  { return "string" }
-func (s *enumSingleValue) Hidden() bool     { return s.hidden }
-func (s *enumSingleValue) Type() string     { return "EnumSingle" }
+func (s *enumSingleValue) Get() any        { return *s.target }
+func (s *enumSingleValue) String() string  { return *s.target }
+func (s *enumSingleValue) Example() string { return "string" }
+func (s *enumSingleValue) Hidden() bool    { return s.hidden }
+func (s *enumSingleValue) Type() string    { return "EnumSingle" }

--- a/internal/pkg/flag/flag_float.go
+++ b/internal/pkg/flag/flag_float.go
@@ -84,8 +84,8 @@ func (f *float64Value) Set(s string) error {
 	return nil
 }
 
-func (f *float64Value) Get() interface{} { return *f.target }
-func (f *float64Value) String() string   { return strconv.FormatFloat(*f.target, 'g', -1, 64) }
-func (f *float64Value) Example() string  { return "float" }
-func (f *float64Value) Hidden() bool     { return f.hidden }
-func (f *float64Value) Type() string     { return "float64" }
+func (f *float64Value) Get() any        { return *f.target }
+func (f *float64Value) String() string  { return strconv.FormatFloat(*f.target, 'g', -1, 64) }
+func (f *float64Value) Example() string { return "float" }
+func (f *float64Value) Hidden() bool    { return f.hidden }
+func (f *float64Value) Type() string    { return "float64" }

--- a/internal/pkg/flag/flag_int.go
+++ b/internal/pkg/flag/flag_int.go
@@ -92,11 +92,11 @@ func (i *intValue) Set(s string) error {
 	return nil
 }
 
-func (i *intValue) Get() interface{} { return *i.target }
-func (i *intValue) String() string   { return strconv.Itoa(*i.target) }
-func (i *intValue) Example() string  { return "int" }
-func (i *intValue) Hidden() bool     { return i.hidden }
-func (i *intValue) Type() string     { return "int" }
+func (i *intValue) Get() any        { return *i.target }
+func (i *intValue) String() string  { return strconv.Itoa(*i.target) }
+func (i *intValue) Example() string { return "int" }
+func (i *intValue) Hidden() bool    { return i.hidden }
+func (i *intValue) Type() string    { return "int" }
 
 // -- Int64Var and int64Value
 type Int64Var struct {
@@ -180,11 +180,11 @@ func (i *int64Value) Set(s string) error {
 	return nil
 }
 
-func (i *int64Value) Get() interface{} { return *i.target }
-func (i *int64Value) String() string   { return strconv.FormatInt(*i.target, 10) }
-func (i *int64Value) Example() string  { return "int" }
-func (i *int64Value) Hidden() bool     { return i.hidden }
-func (i *int64Value) Type() string     { return "int64" }
+func (i *int64Value) Get() any        { return *i.target }
+func (i *int64Value) String() string  { return strconv.FormatInt(*i.target, 10) }
+func (i *int64Value) Example() string { return "int" }
+func (i *int64Value) Hidden() bool    { return i.hidden }
+func (i *int64Value) Type() string    { return "int64" }
 
 // -- UintVar && uintValue
 type UintVar struct {
@@ -268,11 +268,11 @@ func (i *uintValue) Set(s string) error {
 	return nil
 }
 
-func (i *uintValue) Get() interface{} { return uint64(*i.target) }
-func (i *uintValue) String() string   { return strconv.FormatUint(uint64(*i.target), 10) }
-func (i *uintValue) Example() string  { return "uint" }
-func (i *uintValue) Hidden() bool     { return i.hidden }
-func (i *uintValue) Type() string     { return "uint" }
+func (i *uintValue) Get() any        { return uint64(*i.target) }
+func (i *uintValue) String() string  { return strconv.FormatUint(uint64(*i.target), 10) }
+func (i *uintValue) Example() string { return "uint" }
+func (i *uintValue) Hidden() bool    { return i.hidden }
+func (i *uintValue) Type() string    { return "uint" }
 
 // -- Uint64Var and uint64Value
 type Uint64Var struct {
@@ -356,8 +356,8 @@ func (i *uint64Value) Set(s string) error {
 	return nil
 }
 
-func (i *uint64Value) Get() interface{} { return *i.target }
-func (i *uint64Value) String() string   { return strconv.FormatUint(*i.target, 10) }
-func (i *uint64Value) Example() string  { return "uint" }
-func (i *uint64Value) Hidden() bool     { return i.hidden }
-func (i *uint64Value) Type() string     { return "uint64" }
+func (i *uint64Value) Get() any        { return *i.target }
+func (i *uint64Value) String() string  { return strconv.FormatUint(*i.target, 10) }
+func (i *uint64Value) Example() string { return "uint" }
+func (i *uint64Value) Hidden() bool    { return i.hidden }
+func (i *uint64Value) Type() string    { return "uint64" }

--- a/internal/pkg/flag/flag_string.go
+++ b/internal/pkg/flag/flag_string.go
@@ -84,8 +84,8 @@ func (s *stringValue) Set(val string) error {
 	return nil
 }
 
-func (s *stringValue) Get() interface{} { return *s.target }
-func (s *stringValue) String() string   { return *s.target }
-func (s *stringValue) Example() string  { return "string" }
-func (s *stringValue) Hidden() bool     { return s.hidden }
-func (s *stringValue) Type() string     { return "string" }
+func (s *stringValue) Get() any        { return *s.target }
+func (s *stringValue) String() string  { return *s.target }
+func (s *stringValue) Example() string { return "string" }
+func (s *stringValue) Hidden() bool    { return s.hidden }
+func (s *stringValue) Type() string    { return "string" }

--- a/internal/pkg/flag/flag_string_map.go
+++ b/internal/pkg/flag/flag_string_map.go
@@ -81,11 +81,11 @@ func (s *stringMapValue) Set(val string) error {
 	return nil
 }
 
-func (s *stringMapValue) Get() interface{} { return *s.target }
-func (s *stringMapValue) String() string   { return mapToKV(*s.target) }
-func (s *stringMapValue) Example() string  { return "key=value" }
-func (s *stringMapValue) Hidden() bool     { return s.hidden }
-func (s *stringMapValue) Type() string     { return "StringMap" }
+func (s *stringMapValue) Get() any        { return *s.target }
+func (s *stringMapValue) String() string  { return mapToKV(*s.target) }
+func (s *stringMapValue) Example() string { return "key=value" }
+func (s *stringMapValue) Hidden() bool    { return s.hidden }
+func (s *stringMapValue) Type() string    { return "StringMap" }
 
 func mapToKV(m map[string]string) string {
 	list := make([]string, 0, len(m))

--- a/internal/pkg/flag/flag_string_slice.go
+++ b/internal/pkg/flag/flag_string_slice.go
@@ -87,8 +87,8 @@ func (s *stringSliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *stringSliceValue) Get() interface{} { return *s.target }
-func (s *stringSliceValue) String() string   { return strings.Join(*s.target, ",") }
-func (s *stringSliceValue) Example() string  { return "string" }
-func (s *stringSliceValue) Hidden() bool     { return s.hidden }
-func (s *stringSliceValue) Type() string     { return "StringSlice" }
+func (s *stringSliceValue) Get() any        { return *s.target }
+func (s *stringSliceValue) String() string  { return strings.Join(*s.target, ",") }
+func (s *stringSliceValue) Example() string { return "string" }
+func (s *stringSliceValue) Hidden() bool    { return s.hidden }
+func (s *stringSliceValue) Type() string    { return "StringSlice" }

--- a/internal/pkg/flag/flag_time.go
+++ b/internal/pkg/flag/flag_time.go
@@ -84,11 +84,11 @@ func (d *durationValue) Set(s string) error {
 	return nil
 }
 
-func (d *durationValue) Get() interface{} { return *d.target }
-func (d *durationValue) String() string   { return d.target.String() }
-func (d *durationValue) Example() string  { return "duration" }
-func (d *durationValue) Hidden() bool     { return d.hidden }
-func (d *durationValue) Type() string     { return "duration" }
+func (d *durationValue) Get() any        { return *d.target }
+func (d *durationValue) String() string  { return d.target.String() }
+func (d *durationValue) Example() string { return "duration" }
+func (d *durationValue) Hidden() bool    { return d.hidden }
+func (d *durationValue) Type() string    { return "duration" }
 
 // appendDurationSuffix is used as a backwards-compat tool for assuming users
 // meant "seconds" when they do not provide a suffixed duration value.

--- a/internal/pkg/logging/logger.go
+++ b/internal/pkg/logging/logger.go
@@ -76,7 +76,7 @@ func Default() *FmtLogger {
 }
 
 type TestLogger struct {
-	log func(args ...interface{})
+	log func(args ...any)
 }
 
 // Debug logs at the DEBUG log level
@@ -116,7 +116,7 @@ func (l *TestLogger) Warning(message string) {
 }
 
 // NewTestLogger returns a test logger suitable for use with the go testing.T log function.
-func NewTestLogger(log func(args ...interface{})) *TestLogger {
+func NewTestLogger(log func(args ...any)) *TestLogger {
 	return &TestLogger{
 		log: log,
 	}

--- a/internal/pkg/renderer/funcs.go
+++ b/internal/pkg/renderer/funcs.go
@@ -84,7 +84,7 @@ func nomadRegions(client *api.Client) func() ([]string, error) {
 
 // toStringList takes a list of string and returns the HCL equivalent which is
 // useful when templating jobs and params such as datacenters.
-func toStringList(l []interface{}) (string, error) {
+func toStringList(l []any) (string, error) {
 	var out string
 	for i := range l {
 		if i > 0 && i < len(l) {
@@ -96,47 +96,47 @@ func toStringList(l []interface{}) (string, error) {
 }
 
 // Spew helper funcs
-func withIndent(in string, s *spew.ConfigState) interface{} {
+func withIndent(in string, s *spew.ConfigState) any {
 	s.Indent = in
 	return s
 }
 
-func withMaxDepth(in int, s *spew.ConfigState) interface{} {
+func withMaxDepth(in int, s *spew.ConfigState) any {
 	s.MaxDepth = in
 	return s
 }
 
-func withDisableMethods(s *spew.ConfigState) interface{} {
+func withDisableMethods(s *spew.ConfigState) any {
 	s.DisableMethods = true
 	return s
 }
 
-func withDisablePointerMethods(s *spew.ConfigState) interface{} {
+func withDisablePointerMethods(s *spew.ConfigState) any {
 	s.DisablePointerMethods = true
 	return s
 }
 
-func withDisablePointerAddresses(s *spew.ConfigState) interface{} {
+func withDisablePointerAddresses(s *spew.ConfigState) any {
 	s.DisablePointerAddresses = true
 	return s
 }
 
-func withDisableCapacities(s *spew.ConfigState) interface{} {
+func withDisableCapacities(s *spew.ConfigState) any {
 	s.DisableCapacities = true
 	return s
 }
 
-func withContinueOnMethod(s *spew.ConfigState) (interface{}, error) {
+func withContinueOnMethod(s *spew.ConfigState) (any, error) {
 	s.ContinueOnMethod = true
 	return s, nil
 }
 
-func withSortKeys(s *spew.ConfigState) interface{} {
+func withSortKeys(s *spew.ConfigState) any {
 	s.SortKeys = true
 	return s
 }
 
-func withSpewKeys(s *spew.ConfigState) interface{} {
+func withSpewKeys(s *spew.ConfigState) any {
 	s.SpewKeys = true
 	return s
 }

--- a/internal/pkg/renderer/funcs_test.go
+++ b/internal/pkg/renderer/funcs_test.go
@@ -13,19 +13,19 @@ import (
 
 func Test_toStringList(t *testing.T) {
 	testCases := []struct {
-		input          []interface{}
+		input          []any
 		expectedOutput string
 	}{
 		{
-			input:          []interface{}{"dc1", "dc2", "dc3", "dc4"},
+			input:          []any{"dc1", "dc2", "dc3", "dc4"},
 			expectedOutput: `["dc1", "dc2", "dc3", "dc4"]`,
 		},
 		{
-			input:          []interface{}{"dc1"},
+			input:          []any{"dc1"},
 			expectedOutput: `["dc1"]`,
 		},
 		{
-			input:          []interface{}{},
+			input:          []any{},
 			expectedOutput: `[]`,
 		},
 	}
@@ -86,11 +86,11 @@ func TestSpewHelpersInTemplate(t *testing.T) {
 
 	type Foo struct {
 		unexportedField Bar
-		ExportedField   map[interface{}]interface{}
+		ExportedField   map[any]any
 	}
 	var a uint = 100
 	bar := Bar{&a}
-	s1 := Foo{bar, map[interface{}]interface{}{"one": true}}
+	s1 := Foo{bar, map[any]any{"one": true}}
 
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {

--- a/internal/pkg/renderer/renderer.go
+++ b/internal/pkg/renderer/renderer.go
@@ -39,7 +39,7 @@ type Renderer struct {
 	// stores the pack information, variables and tpl, so we can perform the
 	// output template rendering after pack deployment.
 	pack      *pack.Pack
-	variables map[string]interface{}
+	variables map[string]any
 	tpl       *template.Template
 }
 
@@ -47,7 +47,7 @@ type Renderer struct {
 // variables.
 type toRender struct {
 	content   string
-	variables map[string]interface{}
+	variables map[string]any
 }
 
 const (
@@ -57,7 +57,7 @@ const (
 
 // Render is responsible for iterating the pack and rendering each defined
 // template using the parsed variable map.
-func (r *Renderer) Render(p *pack.Pack, variables map[string]interface{}) (*Rendered, error) {
+func (r *Renderer) Render(p *pack.Pack, variables map[string]any) (*Rendered, error) {
 
 	// filesToRender stores all the templates and auxiliary files that should be
 	// rendered
@@ -170,11 +170,11 @@ func (r *Renderer) RenderOutput() (string, error) {
 // correspond.
 func prepareFiles(p *pack.Pack,
 	files map[string]toRender,
-	variables map[string]interface{},
+	variables map[string]any,
 	renderAuxFiles bool,
 ) {
 
-	newVars := make(map[string]interface{})
+	newVars := make(map[string]any)
 
 	// If the pack is a dependency, it only has access to its namespaced
 	// variables. If the pack is the parent/root pack, then it has access to

--- a/internal/pkg/spinner/spinner.go
+++ b/internal/pkg/spinner/spinner.go
@@ -176,19 +176,19 @@ type Spinner struct {
 	ctx        context.Context
 	cancel     func()
 	done       chan struct{}
-	mu         *sync.RWMutex                 //
-	Delay      time.Duration                 // Delay is the speed of the indicator
-	chars      []string                      // chars holds the chosen character set
-	Prefix     string                        // Prefix is the text preppended to the indicator
-	Suffix     string                        // Suffix is the text appended to the indicator
-	FinalMSG   string                        // string displayed after Stop() is called
-	lastOutput string                        // last character(set) written
-	color      func(a ...interface{}) string // default color is white
-	Writer     io.Writer                     // to make testing better, exported so users have access. Use `WithWriter` to update after initialization.
-	active     bool                          // active holds the state of the spinner
-	HideCursor bool                          // hideCursor determines if the cursor is visible
-	PreUpdate  func(s *Spinner)              // will be triggered before every spinner update
-	PostUpdate func(s *Spinner)              // will be triggered after every spinner update
+	mu         *sync.RWMutex         //
+	Delay      time.Duration         // Delay is the speed of the indicator
+	chars      []string              // chars holds the chosen character set
+	Prefix     string                // Prefix is the text preppended to the indicator
+	Suffix     string                // Suffix is the text appended to the indicator
+	FinalMSG   string                // string displayed after Stop() is called
+	lastOutput string                // last character(set) written
+	color      func(a ...any) string // default color is white
+	Writer     io.Writer             // to make testing better, exported so users have access. Use `WithWriter` to update after initialization.
+	active     bool                  // active holds the state of the spinner
+	HideCursor bool                  // hideCursor determines if the cursor is visible
+	PreUpdate  func(s *Spinner)      // will be triggered before every spinner update
+	PostUpdate func(s *Spinner)      // will be triggered after every spinner update
 }
 
 // New provides a pointer to an instance of Spinner with the supplied options.

--- a/internal/pkg/variable/convert.go
+++ b/internal/pkg/variable/convert.go
@@ -11,7 +11,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func convertCtyToInterface(val cty.Value) (interface{}, error) {
+func convertCtyToInterface(val cty.Value) (any, error) {
 
 	if val.IsNull() {
 		return nil, nil
@@ -43,7 +43,7 @@ func convertCtyToInterface(val cty.Value) (interface{}, error) {
 			panic("unsupported primitive type")
 		}
 	case isCollectionOfMaps(t):
-		result := []map[string]interface{}{}
+		result := []map[string]any{}
 
 		it := val.ElementIterator()
 		for it.Next() {
@@ -52,11 +52,11 @@ func convertCtyToInterface(val cty.Value) (interface{}, error) {
 			if err != nil {
 				return nil, err
 			}
-			result = append(result, evi.(map[string]interface{}))
+			result = append(result, evi.(map[string]any))
 		}
 		return result, nil
 	case t.IsListType(), t.IsSetType(), t.IsTupleType():
-		result := []interface{}{}
+		result := []any{}
 
 		it := val.ElementIterator()
 		for it.Next() {
@@ -69,7 +69,7 @@ func convertCtyToInterface(val cty.Value) (interface{}, error) {
 		}
 		return result, nil
 	case t.IsMapType():
-		result := map[string]interface{}{}
+		result := map[string]any{}
 		it := val.ElementIterator()
 		for it.Next() {
 			ek, ev := it.Element()
@@ -84,7 +84,7 @@ func convertCtyToInterface(val cty.Value) (interface{}, error) {
 		}
 		return result, nil
 	case t.IsObjectType():
-		result := map[string]interface{}{}
+		result := map[string]any{}
 
 		for k := range t.AttributeTypes() {
 			av := val.GetAttr(k)
@@ -105,7 +105,7 @@ func convertCtyToInterface(val cty.Value) (interface{}, error) {
 	}
 }
 
-func smallestNumber(b *big.Float) interface{} {
+func smallestNumber(b *big.Float) any {
 	if v, acc := b.Int64(); acc == big.Exact {
 		// check if it fits in int
 		if int64(int(v)) == v {

--- a/internal/pkg/variable/convert_test.go
+++ b/internal/pkg/variable/convert_test.go
@@ -46,10 +46,10 @@ func TestConvertCtyToInterface(t *testing.T) {
 		resListOfList, err := convertCtyToInterface(testListOfList)
 		must.NoError(t, err)
 
-		tempList, ok := resListOfList.([]interface{})
+		tempList, ok := resListOfList.([]any)
 		must.True(t, ok)
 
-		_, ok = tempList[0].([]interface{})
+		_, ok = tempList[0].([]any)
 		must.True(t, ok)
 	})
 
@@ -64,7 +64,7 @@ func TestConvertCtyToInterface(t *testing.T) {
 		resListOfMaps, err := convertCtyToInterface(testListOfMaps)
 		must.NoError(t, err)
 
-		_, ok := resListOfMaps.([]map[string]interface{})
+		_, ok := resListOfMaps.([]map[string]any)
 		must.True(t, ok)
 	})
 
@@ -77,10 +77,10 @@ func TestConvertCtyToInterface(t *testing.T) {
 		restMapOfMaps, err := convertCtyToInterface(testMapOfMaps)
 		must.NoError(t, err)
 
-		tempMapOfMaps, ok := restMapOfMaps.(map[string]interface{})
+		tempMapOfMaps, ok := restMapOfMaps.(map[string]any)
 		must.True(t, ok)
 
-		_, ok = tempMapOfMaps["test"].(map[string]interface{})
+		_, ok = tempMapOfMaps["test"].(map[string]any)
 		must.True(t, ok)
 	})
 }

--- a/internal/pkg/variable/variable.go
+++ b/internal/pkg/variable/variable.go
@@ -111,10 +111,10 @@ type ParsedVariables struct {
 // Even though parsing the variable went without error, it is highly possible
 // that conversion to native go types can incur an error. If an error is
 // returned, it should be considered terminal.
-func (p *ParsedVariables) ConvertVariablesToMapInterface() (map[string]interface{}, hcl.Diagnostics) {
+func (p *ParsedVariables) ConvertVariablesToMapInterface() (map[string]any, hcl.Diagnostics) {
 
 	// Create our output; no matter what we return something.
-	out := make(map[string]interface{})
+	out := make(map[string]any)
 
 	// Errors can occur when performing the translation. We want to capture all
 	// of these and return them to the user. This allows them to fix problems
@@ -125,7 +125,7 @@ func (p *ParsedVariables) ConvertVariablesToMapInterface() (map[string]interface
 	for packName, variables := range p.Vars {
 
 		// packVar collects all variables associated to a pack.
-		packVar := map[string]interface{}{}
+		packVar := map[string]any{}
 
 		// Convert each variable and add this to the pack map.
 		for variableName, variable := range variables {
@@ -147,7 +147,7 @@ func (p *ParsedVariables) ConvertVariablesToMapInterface() (map[string]interface
 func (v Variable) String() string         { return asJSON(v) }
 func (vf ParsedVariables) String() string { return asJSON(vf) }
 
-func asJSON(a interface{}) string {
+func asJSON(a any) string {
 	return func() string { b, _ := json.MarshalIndent(a, "", "  "); return string(b) }()
 }
 

--- a/internal/runner/job/job.go
+++ b/internal/runner/job/job.go
@@ -91,7 +91,7 @@ func (r *Runner) CanonicalizeTemplates() []*errors.WrappedUIContext {
 
 // ParsedTemplates satisfies the GetParsedTemplates function of the
 // runner.Runner interface.
-func (r *Runner) ParsedTemplates() interface{} { return r.parsedTemplates }
+func (r *Runner) ParsedTemplates() any { return r.parsedTemplates }
 
 // Name satisfies the Name function of the runner.Runner interface.
 func (r *Runner) Name() string { return "job" }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -64,7 +64,7 @@ type Runner interface {
 	// ParsedTemplates returns the parsed and canonicalized templates to the
 	// caller whose responsibility it is to assert the mapping type expected
 	// based on the deployer implementation.
-	ParsedTemplates() interface{}
+	ParsedTemplates() any
 
 	// Name returns the name of the deployer which indicates the Nomad object
 	// it is designed to handle.

--- a/internal/testui/main.go
+++ b/internal/testui/main.go
@@ -44,7 +44,7 @@ func (ui *nonInteractiveTestUI) Interactive() bool {
 }
 
 // Output implements UI
-func (ui *nonInteractiveTestUI) Output(msg string, raw ...interface{}) {
+func (ui *nonInteractiveTestUI) Output(msg string, raw ...any) {
 	ui.mu.Lock()
 	defer ui.mu.Unlock()
 	msg, style, _ := terminal.Interpret(msg, raw...)
@@ -83,7 +83,7 @@ func (ui *nonInteractiveTestUI) Output(msg string, raw ...interface{}) {
 }
 
 // TODO: Added purely for compilation purposes. Untested
-func (ui *nonInteractiveTestUI) AppendToRow(msg string, raw ...interface{}) {
+func (ui *nonInteractiveTestUI) AppendToRow(msg string, raw ...any) {
 	ui.mu.Lock()
 	defer ui.mu.Unlock()
 	msg, style, _ := terminal.Interpret(msg, raw...)
@@ -276,7 +276,7 @@ type nonInteractiveStepGroup struct {
 }
 
 // Start a step in the output
-func (f *nonInteractiveStepGroup) Add(str string, args ...interface{}) terminal.Step {
+func (f *nonInteractiveStepGroup) Add(str string, args ...any) terminal.Step {
 	// Build our step
 	step := &nonInteractiveStep{mu: f.mu}
 
@@ -318,7 +318,7 @@ func (f *nonInteractiveStep) TermOutput() io.Writer {
 	return &stripAnsiWriter{Next: color.Output}
 }
 
-func (f *nonInteractiveStep) Update(str string, args ...interface{}) {
+func (f *nonInteractiveStep) Update(str string, args ...any) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	fmt.Fprintln(color.Output, "-> "+fmt.Sprintf(str, args...))

--- a/sdk/pack/metadata.go
+++ b/sdk/pack/metadata.go
@@ -87,47 +87,47 @@ type MetadataIntegration struct {
 	Name string `hcl:"name,optional"`
 }
 
-// ConvertToMapInterface returns a map[string]interface{} representation of the
+// ConvertToMapInterface returns a map[string]any representation of the
 // metadata object. The conversion doesn't take into account empty values and
 // will add them.
-func (md *Metadata) ConvertToMapInterface() map[string]interface{} {
-	innerMap := map[string]interface{}{
-		"app": map[string]interface{}{
+func (md *Metadata) ConvertToMapInterface() map[string]any {
+	innerMap := map[string]any{
+		"app": map[string]any{
 			"url": md.App.URL,
 		},
-		"pack": map[string]interface{}{
+		"pack": map[string]any{
 			"name":        md.Pack.Name,
 			"description": md.Pack.Description,
 			"version":     md.Pack.Version,
 		},
 	}
 	if md.Integration != nil {
-		innerMap["integration"] = map[string]interface{}{
+		innerMap["integration"] = map[string]any{
 			"identifier": md.Integration.Identifier,
 			"flags":      md.Integration.Flags,
 			"name":       md.Integration.Name,
 		}
 	}
 
-	return map[string]interface{}{"nomad_pack": innerMap}
+	return map[string]any{"nomad_pack": innerMap}
 }
 
 // AddToInterfaceMap adds the metadata information to the provided map as a new
 // entry under the "nomad_pack" key. This is useful for adding this information
 // to the template rendering data.
-func (md *Metadata) AddToInterfaceMap(m map[string]interface{}) map[string]interface{} {
-	innerMap := map[string]interface{}{
-		"app": map[string]interface{}{
+func (md *Metadata) AddToInterfaceMap(m map[string]any) map[string]any {
+	innerMap := map[string]any{
+		"app": map[string]any{
 			"url": md.App.URL,
 		},
-		"pack": map[string]interface{}{
+		"pack": map[string]any{
 			"name":        md.Pack.Name,
 			"description": md.Pack.Description,
 			"version":     md.Pack.Version,
 		},
 	}
 	if md.Integration != nil {
-		innerMap["integration"] = map[string]interface{}{
+		innerMap["integration"] = map[string]any{
 			"identifier": md.Integration.Identifier,
 			"flags":      md.Integration.Flags,
 			"name":       md.Integration.Name,

--- a/sdk/pack/metadata_test.go
+++ b/sdk/pack/metadata_test.go
@@ -12,7 +12,7 @@ import (
 func TestMetadata_ConvertToMapInterface(t *testing.T) {
 	testCases := []struct {
 		inputMetadata  *Metadata
-		expectedOutput map[string]interface{}
+		expectedOutput map[string]any
 		name           string
 	}{
 		{
@@ -34,17 +34,17 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 					},
 				},
 			},
-			expectedOutput: map[string]interface{}{
-				"nomad_pack": map[string]interface{}{
-					"app": map[string]interface{}{
+			expectedOutput: map[string]any{
+				"nomad_pack": map[string]any{
+					"app": map[string]any{
 						"url": "https://example.com",
 					},
-					"pack": map[string]interface{}{
+					"pack": map[string]any{
 						"name":        "Example",
 						"description": "The most basic, yet awesome, example",
 						"version":     "v0.0.1",
 					},
-					"integration": map[string]interface{}{
+					"integration": map[string]any{
 						"identifier": "nomad/hashicorp/example",
 						"flags": []string{
 							"foo",
@@ -68,17 +68,17 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 				},
 				Integration: &MetadataIntegration{},
 			},
-			expectedOutput: map[string]interface{}{
-				"nomad_pack": map[string]interface{}{
-					"app": map[string]interface{}{
+			expectedOutput: map[string]any{
+				"nomad_pack": map[string]any{
+					"app": map[string]any{
 						"url": "https://example.com",
 					},
-					"pack": map[string]interface{}{
+					"pack": map[string]any{
 						"name":        "Example",
 						"description": "",
 						"version":     "v0.0.1",
 					},
-					"integration": map[string]interface{}{
+					"integration": map[string]any{
 						"identifier": "",
 						"flags":      []string(nil),
 						"name":       "",
@@ -98,11 +98,11 @@ func TestMetadata_ConvertToMapInterface(t *testing.T) {
 				},
 				Integration: &MetadataIntegration{},
 			},
-			expectedOutput: map[string]interface{}{
-				"nomad_pack": map[string]interface{}{
-					"app":         map[string]interface{}{"url": "https://example.com"},
-					"pack":        map[string]interface{}{"name": "", "description": "", "version": ""},
-					"integration": map[string]interface{}{"identifier": "", "flags": []string(nil), "name": ""},
+			expectedOutput: map[string]any{
+				"nomad_pack": map[string]any{
+					"app":         map[string]any{"url": "https://example.com"},
+					"pack":        map[string]any{"name": "", "description": "", "version": ""},
+					"integration": map[string]any{"identifier": "", "flags": []string(nil), "name": ""},
 				},
 			},
 			// TODO test added to cover graceful failure while we're in the process of

--- a/terminal/basic.go
+++ b/terminal/basic.go
@@ -97,7 +97,7 @@ func (ui *basicUI) Interactive() bool {
 }
 
 // Output implements UI
-func (ui *basicUI) Output(msg string, raw ...interface{}) {
+func (ui *basicUI) Output(msg string, raw ...any) {
 	msg, style, w := Interpret(msg, raw...)
 
 	switch style {

--- a/terminal/display.go
+++ b/terminal/display.go
@@ -300,7 +300,7 @@ func (e *DisplayEntry) SetStatus(status string) {
 	e.status = status
 }
 
-func (e *DisplayEntry) Update(str string, args ...interface{}) {
+func (e *DisplayEntry) Update(str string, args ...any) {
 	e.d.mu.Lock()
 	e.text = fmt.Sprintf(str, args...)
 	e.d.mu.Unlock()
@@ -376,7 +376,7 @@ func (t *Term) MoveCursor(p state.Pos) error {
 	return nil
 }
 
-func (t *Term) SetTermProp(attr state.TermAttr, val interface{}) error {
+func (t *Term) SetTermProp(attr state.TermAttr, val any) error {
 	// Ignore it.
 	return nil
 }

--- a/terminal/glint.go
+++ b/terminal/glint.go
@@ -89,7 +89,7 @@ func (ui *glintUI) Interactive() bool {
 }
 
 // Output implements UI
-func (ui *glintUI) Output(msg string, raw ...interface{}) {
+func (ui *glintUI) Output(msg string, raw ...any) {
 	// Render row and reset
 	// This will still respect new lines (i.e. it won't turn several lines of text
 	// into one massively long single line of text)
@@ -181,7 +181,7 @@ func (ui *glintUI) Output(msg string, raw ...interface{}) {
 // Because there's no way to know if the row is complete within this
 // method, this relies on Output being called after the final call
 // to AppendToRow to force rendering of the row.
-func (ui *glintUI) AppendToRow(msg string, raw ...interface{}) {
+func (ui *glintUI) AppendToRow(msg string, raw ...any) {
 	msg, style, _ := Interpret(msg, raw...)
 
 	var cs []glint.StyleOption

--- a/terminal/glint_step_group.go
+++ b/terminal/glint_step_group.go
@@ -24,7 +24,7 @@ type glintStepGroup struct {
 }
 
 // Start a step in the output
-func (f *glintStepGroup) Add(str string, args ...interface{}) Step {
+func (f *glintStepGroup) Add(str string, args ...any) Step {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -98,7 +98,7 @@ func (f *glintStep) TermOutput() io.Writer {
 	return f.term
 }
 
-func (f *glintStep) Update(str string, args ...interface{}) {
+func (f *glintStep) Update(str string, args ...any) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.msg = fmt.Sprintf(str, args...)

--- a/terminal/glint_term.go
+++ b/terminal/glint_term.go
@@ -96,7 +96,7 @@ func (t *glintTerm) MoveCursor(p state.Pos) error {
 	return nil
 }
 
-func (t *glintTerm) SetTermProp(attr state.TermAttr, val interface{}) error {
+func (t *glintTerm) SetTermProp(attr state.TermAttr, val any) error {
 	// Ignore it.
 	return nil
 }

--- a/terminal/noninteractive.go
+++ b/terminal/noninteractive.go
@@ -38,7 +38,7 @@ func (ui *nonInteractiveUI) Interactive() bool {
 }
 
 // Output implements UI
-func (ui *nonInteractiveUI) Output(msg string, raw ...interface{}) {
+func (ui *nonInteractiveUI) Output(msg string, raw ...any) {
 	ui.mu.Lock()
 	defer ui.mu.Unlock()
 	msg, style, w := Interpret(msg, raw...)
@@ -77,7 +77,7 @@ func (ui *nonInteractiveUI) Output(msg string, raw ...interface{}) {
 }
 
 // TODO: Added purely for compilation purposes. Untested
-func (ui *nonInteractiveUI) AppendToRow(msg string, raw ...interface{}) {
+func (ui *nonInteractiveUI) AppendToRow(msg string, raw ...any) {
 	ui.mu.Lock()
 	defer ui.mu.Unlock()
 	msg, style, w := Interpret(msg, raw...)
@@ -281,7 +281,7 @@ type nonInteractiveStepGroup struct {
 }
 
 // Start a step in the output
-func (f *nonInteractiveStepGroup) Add(str string, args ...interface{}) Step {
+func (f *nonInteractiveStepGroup) Add(str string, args ...any) Step {
 	// Build our step
 	step := &nonInteractiveStep{mu: f.mu}
 
@@ -323,7 +323,7 @@ func (f *nonInteractiveStep) TermOutput() io.Writer {
 	return &stripAnsiWriter{Next: color.Output}
 }
 
-func (f *nonInteractiveStep) Update(str string, args ...interface{}) {
+func (f *nonInteractiveStep) Update(str string, args ...any) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	fmt.Fprintln(color.Output, "-> "+fmt.Sprintf(str, args...))

--- a/terminal/step.go
+++ b/terminal/step.go
@@ -26,7 +26,7 @@ type fancyStepGroup struct {
 }
 
 // Start a step in the output
-func (f *fancyStepGroup) Add(str string, args ...interface{}) Step {
+func (f *fancyStepGroup) Add(str string, args ...any) Step {
 	f.steps++
 
 	ent := f.display.NewStatus(0)
@@ -85,7 +85,7 @@ func (f *fancyStep) TermOutput() io.Writer {
 	return f.term
 }
 
-func (f *fancyStep) Update(str string, args ...interface{}) {
+func (f *fancyStep) Update(str string, args ...any) {
 	f.ent.Update(str, args...)
 }
 

--- a/terminal/ui.go
+++ b/terminal/ui.go
@@ -19,7 +19,7 @@ var ErrNonInteractive = errors.New("noninteractive UI doesn't support this opera
 // Passed to UI.NamedValues to provide a nicely formatted key: value output
 type NamedValue struct {
 	Name  string
-	Value interface{}
+	Value any
 }
 
 // UI is the primary interface for interacting with a user via the CLI.
@@ -41,11 +41,11 @@ type UI interface {
 	// Output outputs a message directly to the terminal. The remaining
 	// arguments should be interpolations for the format string. After the
 	// interpolations you may add Options.
-	Output(string, ...interface{})
+	Output(string, ...any)
 
 	// AppendToRow appends a message to a row of output. Used for applying multiple
 	// styles to a single row of text.
-	AppendToRow(string, ...interface{})
+	AppendToRow(string, ...any)
 
 	// NamedValues outputs data as a table of data. Each entry is a row which will be output
 	// with the columns lined up nicely.
@@ -104,7 +104,7 @@ type UI interface {
 // StepGroup is a group of steps (that may be concurrent).
 type StepGroup interface {
 	// Start a step in the output with the arguments making up the initial message
-	Add(string, ...interface{}) Step
+	Add(string, ...any) Step
 
 	// Wait for all steps to finish. This allows a StepGroup to be used like
 	// a sync.WaitGroup with each step being run in a separate goroutine.
@@ -120,7 +120,7 @@ type Step interface {
 	TermOutput() io.Writer
 
 	// Change the Steps displayed message
-	Update(string, ...interface{})
+	Update(string, ...any)
 
 	// Update the status of the message. Supported values are in status.go.
 	Status(status string)
@@ -136,9 +136,9 @@ type Step interface {
 }
 
 // Interpret decomposes the msg and arguments into the message, style, and writer
-func Interpret(msg string, raw ...interface{}) (string, string, io.Writer) {
+func Interpret(msg string, raw ...any) (string, string, io.Writer) {
 	// Build our args and options
-	var args []interface{}
+	var args []any
 	var opts []Option
 	for _, r := range raw {
 		if opt, ok := r.(Option); ok {


### PR DESCRIPTION
**Description**
Using go 1.18's `any` identifier versus the classic `interface{}` improves readability for some of the more complex map cases.