### PR TITLE
runner: submit template when running the job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ IMPROVEMENTS:
 * deps: Update the Nomad OpenAPI dependency; require Go 1.18 as a build dependency [[GH-288](https://github.com/hashicorp/nomad-pack/pull/288)]
 * pack: Author field no longer supported in pack metadata [[GH-317](https://github.com/hashicorp/nomad-pack/pull/317)]
 * pack: URL field no longer supported in pack metadata [[GH-343](https://github.com/hashicorp/nomad-pack/pull/343)]
+* runner: Submit the job spec to Nomad while running pack [[GH-375](https://github.com/hashicorp/nomad-pack/pull/375)]
 * template: Render templates other than Nomad job specifications inside `templates/` [[GH-303](https://github.com/hashicorp/nomad-pack/pull/303)]
 * template: Automatically format templates before outputting [[GH-311](https://github.com/hashicorp/nomad-pack/pull/311)]
 * template: Skip templates that would render to just whitespace [[GH-313](https://github.com/hashicorp/nomad-pack/pull/313)]

--- a/internal/runner/job/job.go
+++ b/internal/runner/job/job.go
@@ -107,11 +107,25 @@ func (r *Runner) Deploy(ui terminal.UI, errorContext *errors.UIErrorContext) *er
 		tplErrorContext := errorContext.Copy()
 		tplErrorContext.Add(errors.UIContextPrefixTemplateName, tplName)
 
+		templateFormat := func() string {
+			if r.cfg.RunConfig.HCL1 {
+				return "hcl1"
+			}
+			return "hcl2"
+		}()
+
+		// submit the source of the job to Nomad, too
+		submission := &api.JobSubmission{
+			Source: r.rawTemplates[tplName],
+			Format: templateFormat,
+		}
+
 		registerOpts := api.RegisterOptions{
 			EnforceIndex:   r.cfg.RunConfig.CheckIndex > 0,
 			ModifyIndex:    r.cfg.RunConfig.CheckIndex,
 			PolicyOverride: r.cfg.RunConfig.PolicyOverride,
 			PreserveCounts: r.cfg.RunConfig.PreserveCounts,
+			Submission:     submission,
 		}
 
 		// Submit the job


### PR DESCRIPTION
**Description**

This PR adds support for the new [job submission API](https://github.com/hashicorp/nomad/pull/16763) in Nomad 1.6. 

Resolves #371 

**Reminders**

- [x] Add `CHANGELOG.md` entry
