### PR TITLE
cli: add an overwrite flag for generate pack cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ IMPROVEMENTS:
 * cli: `registry list` command now shows git refs to repositories present in the cache [[GH-318](https://github.com/hashicorp/nomad-pack/pull/318)]
 * cli: `registry list` command now shows only registries, and a new command `list` shows packs [[GH-337](https://github.com/hashicorp/nomad-pack/pull/337)], [[GH-373](https://github.com/hashicorp/nomad-pack/pull/373)]
 * cli: `deps vendor` command [[GH-367](https://github.com/hashicorp/nomad-pack/pull/367)]
+* cli: `generate pack` command now supports `--overwrite` flag [[GH-380](https://github.com/hashicorp/nomad-pack/pull/380)]
 * deps: Update the Nomad OpenAPI dependency; require Go 1.18 as a build dependency [[GH-288](https://github.com/hashicorp/nomad-pack/pull/288)]
 * pack: Author field no longer supported in pack metadata [[GH-317](https://github.com/hashicorp/nomad-pack/pull/317)]
 * pack: URL field no longer supported in pack metadata [[GH-343](https://github.com/hashicorp/nomad-pack/pull/343)]

--- a/internal/cli/generate_pack.go
+++ b/internal/cli/generate_pack.go
@@ -4,11 +4,14 @@
 package cli
 
 import (
+	"os"
+
+	"github.com/posener/complete"
+
 	"github.com/hashicorp/nomad-pack/internal/config"
 	"github.com/hashicorp/nomad-pack/internal/creator"
 	"github.com/hashicorp/nomad-pack/internal/pkg/errors"
 	"github.com/hashicorp/nomad-pack/internal/pkg/flag"
-	"github.com/posener/complete"
 )
 
 // GeneratePackCommand adds a registry to the global cache.
@@ -53,14 +56,30 @@ func (c *GeneratePackCommand) Flags() *flag.Sets {
 		c.cfg = config.PackConfig{}
 		f := set.NewSet("Output Options")
 
+		// use absolute paths, otherwise we get problems down the road
+		outPath, err := os.Getwd()
+		if err != nil {
+			panic(err)
+		}
+
 		f.StringVarP(&flag.StringVarP{
 			StringVar: &flag.StringVar{
 				Name:    "to-dir",
 				Target:  &c.cfg.OutPath,
 				Usage:   `Path to write generated pack to.`,
-				Default: ".",
+				Default: outPath,
 			},
 			Shorthand: "o",
+		})
+
+		f.BoolVarP(&flag.BoolVarP{
+			BoolVar: &flag.BoolVar{
+				Name:    "overwrite",
+				Target:  &c.cfg.Overwrite,
+				Usage:   `If the output directory is not empty, should we overwrite?`,
+				Default: false,
+			},
+			Shorthand: "f",
 		})
 	})
 }

--- a/internal/cli/generate_pack.go
+++ b/internal/cli/generate_pack.go
@@ -4,8 +4,6 @@
 package cli
 
 import (
-	"os"
-
 	"github.com/posener/complete"
 
 	"github.com/hashicorp/nomad-pack/internal/config"
@@ -56,18 +54,12 @@ func (c *GeneratePackCommand) Flags() *flag.Sets {
 		c.cfg = config.PackConfig{}
 		f := set.NewSet("Output Options")
 
-		// use absolute paths, otherwise we get problems down the road
-		outPath, err := os.Getwd()
-		if err != nil {
-			panic(err)
-		}
-
 		f.StringVarP(&flag.StringVarP{
 			StringVar: &flag.StringVar{
 				Name:    "to-dir",
 				Target:  &c.cfg.OutPath,
 				Usage:   `Path to write generated pack to.`,
-				Default: outPath,
+				Default: "",
 			},
 			Shorthand: "o",
 		})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,9 @@ type PackConfig struct {
 	OutPath      string
 	AutoApproved bool
 
+	// If the directory we output to is not empty, should we overwrite?
+	Overwrite bool
+
 	// Used for the "registry generate" command
 	CreateSamplePack bool
 

--- a/internal/creator/pack.go
+++ b/internal/creator/pack.go
@@ -43,11 +43,13 @@ func CreatePack(c config.PackConfig) error {
 		}
 	}
 
-	_, err = os.Stat(outPath)
+	_, err = os.Stat(path.Join(outPath, c.PackName))
 	if err == nil && !c.Overwrite {
 		return newCreatePackError(
-			fmt.Errorf("%s appears to be non-empty, re-run the command with --overwrite to overwrite", outPath),
-		)
+			fmt.Errorf(
+				"%s appears to be non-empty, re-run the command with --overwrite to overwrite",
+				path.Join(outPath, c.PackName),
+			))
 	}
 	ui.Output("Creating %q Pack in %q...\n", c.PackName, outPath)
 

--- a/internal/creator/pack.go
+++ b/internal/creator/pack.go
@@ -34,23 +34,27 @@ type packCreator struct {
 func CreatePack(c config.PackConfig) error {
 	ui := c.GetUI()
 
+	var outPath string
+	var err error
 	if c.OutPath == "" {
-		// This should never happen
-		return newCreatePackError(fmt.Errorf("failed to parse output path for pack"))
+		outPath, err = os.Getwd()
+		if err != nil {
+			newCreatePackError(err)
+		}
 	}
 
-	_, err := os.Stat(c.OutPath)
+	_, err = os.Stat(outPath)
 	if err == nil && !c.Overwrite {
 		return newCreatePackError(
-			fmt.Errorf("%s appears to be non-empty, re-run the command with --overwrite to overwrite", c.OutPath),
+			fmt.Errorf("%s appears to be non-empty, re-run the command with --overwrite to overwrite", outPath),
 		)
 	}
-	ui.Output("Creating %q Pack in %q...\n", c.PackName, c.OutPath)
+	ui.Output("Creating %q Pack in %q...\n", c.PackName, outPath)
 
 	pc := packCreator{
 		name:    c.PackName,
-		path:    path.Join(c.OutPath, c.PackName),
-		tplPath: path.Join(c.OutPath, c.PackName, "templates"),
+		path:    path.Join(outPath, c.PackName),
+		tplPath: path.Join(outPath, c.PackName, "templates"),
 	}
 
 	err = os.MkdirAll(pc.tplPath, cache.DefaultDirPerms)


### PR DESCRIPTION
**Description**

This PR adds an `--overwrite` flag for `generate pack` command (defaults to `false`). This way we avoid accidentally overwriting files. 

Resolves #376 

**Reminders**

- [x] Add `CHANGELOG.md` entry
