### PR TITLE
[chore] sdk package should be independent

### DIFF
--- a/sdk/pack/dependency.go
+++ b/sdk/pack/dependency.go
@@ -3,8 +3,6 @@
 
 package pack
 
-import "github.com/hashicorp/nomad-pack/internal/pkg/helper/pointer"
-
 // Dependency is a single dependency of a pack. A pack can have multiple and
 // each dependency represents an individual pack. A pack can be used as a
 // dependency multiple times. This allows helper pack to define jobspec blocks
@@ -35,7 +33,7 @@ func (d *Dependency) validate() error {
 	}
 
 	if d.Enabled == nil {
-		d.Enabled = pointer.Of(true)
+		d.Enabled = pointerOf(true)
 	}
 	return nil
 }

--- a/sdk/pack/dependency_test.go
+++ b/sdk/pack/dependency_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/shoenig/test/must"
-
-	"github.com/hashicorp/nomad-pack/internal/pkg/helper/pointer"
 )
 
 func TestDependency_Validate(t *testing.T) {
@@ -26,7 +24,7 @@ func TestDependency_Validate(t *testing.T) {
 			expectedOutputDependency: &Dependency{
 				Name:    "example",
 				Source:  "git://example.com/example",
-				Enabled: pointer.Of(true),
+				Enabled: pointerOf(true),
 			},
 			name: "nil enabled input",
 		},
@@ -34,12 +32,12 @@ func TestDependency_Validate(t *testing.T) {
 			inputDependency: &Dependency{
 				Name:    "example",
 				Source:  "git://example.com/example",
-				Enabled: pointer.Of(false),
+				Enabled: pointerOf(false),
 			},
 			expectedOutputDependency: &Dependency{
 				Name:    "example",
 				Source:  "git://example.com/example",
-				Enabled: pointer.Of(false),
+				Enabled: pointerOf(false),
 			},
 			name: "false enabled input",
 		},
@@ -47,12 +45,12 @@ func TestDependency_Validate(t *testing.T) {
 			inputDependency: &Dependency{
 				Name:    "example",
 				Source:  "git://example.com/example",
-				Enabled: pointer.Of(true),
+				Enabled: pointerOf(true),
 			},
 			expectedOutputDependency: &Dependency{
 				Name:    "example",
 				Source:  "git://example.com/example",
-				Enabled: pointer.Of(true),
+				Enabled: pointerOf(true),
 			},
 			name: "false enabled input",
 		},

--- a/sdk/pack/pointer.go
+++ b/sdk/pack/pointer.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package pack
+
+// pointerOf returns a pointer to a.
+func pointerOf[A any](a A) *A {
+	return &a
+}


### PR DESCRIPTION
`sdk` should be independent from nomad-pack internal packages. Eliminates a warning from `make check`, too. 