### PR TITLE
fix: add nomad as test dependency to fix failing CLI tests

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -40,10 +40,10 @@ jobs:
       # install nomad
       - name: Install nomad
         run : |
-          apt -y install wget gpg coreutils
+          sudo apt -y install wget gpg coreutils
           wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
-          apt update && apt -y install nomad
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt update && sudo apt -y install nomad
           
 
       # Run tests with nice formatting. Save the original log in /tmp/gotest.log

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -38,7 +38,7 @@ jobs:
           make test-certs
 
       # install nomad
-      - name: Install nomad
+      - name: Install Nomad
         run : |
           sudo apt -y install wget gpg coreutils
           wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -35,8 +35,16 @@ jobs:
       - name: Install test dependencies
         run: |
           go install gotest.tools/gotestsum@latest
-          go install github.com/hashicorp/nomad@v1.5.6
           make test-certs
+
+      # install nomad
+      - name: Install nomad
+        run : |
+          apt -y install wget gpg coreutils
+          wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
+          apt update && apt -y install nomad
+          
 
       # Run tests with nice formatting. Save the original log in /tmp/gotest.log
       - name: Run tests

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Install test dependencies
         run: |
           go install gotest.tools/gotestsum@latest
+          go install github.com/hashicorp/nomad@v1.5.6
           make test-certs
 
       # Run tests with nice formatting. Save the original log in /tmp/gotest.log


### PR DESCRIPTION
Since [upgrading Nomad API to 1.5](https://github.com/hashicorp/nomad-pack/pull/383), we require `nomad` binary present to run CLI tests. This is due to the fact that Nomad 1.5+ [sandboxes go-getter](https://github.com/hashicorp/nomad/pull/15328) and thus using the taskrunner in tests requires an actual Nomad binary. 