### PR TITLE
[chore] fix nightly-release.yml

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -38,7 +38,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             try {
-                await github.git.deleteRef({
+                await github.rest.git.deleteRef({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   ref: "tags/nightly"
@@ -46,7 +46,7 @@ jobs:
             } catch (e) {
               console.log("Warning: The nightly tag doesn't exist yet, so there's nothing to do. Trace: " + e)
             }
-            await github.git.createRef({
+            await github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "refs/tags/nightly",
@@ -121,3 +121,5 @@ jobs:
           # the slack webhook url links to #feed-nomad-releases
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+permissions:
+  contents: write


### PR DESCRIPTION
The github-script action v6.4.1 introduced breaking changes from v3, and the script itself was not updated to reflect them causing nightly builds to fail.

This commit also downscopes the generated github token.

I have manually triggered a run [Nightly Release #425](https://github.com/hashicorp/nomad-pack/actions/runs/5694867288) using this version of the action and it was successful.