### PR TITLE
[bug] Handle nil `Subject` in `Diags` wrapper

### DIFF
--- a/internal/pkg/errors/wrapped_context.go
+++ b/internal/pkg/errors/wrapped_context.go
@@ -45,7 +45,9 @@ func HCLDiagsToWrappedUIContext(diags hcl.Diagnostics) []*WrappedUIContext {
 			Subject: diag.Summary,
 			Context: NewUIErrorContext(),
 		}
-		wrapped[i].Context.Add(UIContextPrefixHCLRange, diag.Subject.String())
+		if diag.Subject != nil {
+			wrapped[i].Context.Add(UIContextPrefixHCLRange, diag.Subject.String())
+		}
 	}
 	return wrapped
 }


### PR DESCRIPTION
**Description**
It is possible to receive an `hcl.Diagnostic` that does not have `Subject` set, which causes the existing code to panic. Added a nil check around it
