### PR TITLE
[tests] Update cache tests

### DIFF
--- a/fixtures/test_registry/packs/simple_docker/CHANGELOG.md
+++ b/fixtures/test_registry/packs/simple_docker/CHANGELOG.md
@@ -1,0 +1,4 @@
+## Version v0.0.1 (Unreleased)
+
+Initial Release
+

--- a/fixtures/test_registry/packs/simple_docker/README.md
+++ b/fixtures/test_registry/packs/simple_docker/README.md
@@ -1,0 +1,64 @@
+# simple_docker
+
+<!-- Include a brief description of your pack -->
+
+This pack is a simple Nomad job that runs as a service and can be accessed via
+HTTP.
+
+## Pack Usage
+
+<!-- Include information about how to use your pack -->
+
+### Changing the Message
+
+To change the message this server responds with, change the "message" variable
+when running the pack.
+
+```
+nomad-pack run simple_docker --var message="Hola Mundo!"
+```
+
+This tells Nomad Pack to tweak the `MESSAGE` environment variable that the
+service reads from.
+
+### Consul Service and Load Balancer Integration
+
+Optionally, it can configure a Consul service.
+
+If the `register_consul_service` is unset or set to true, the Consul service
+will be registered.
+
+Several load balancers in the [Nomad Pack Community Registry][pack-registry]
+are configured to connect to this service by default.
+
+The [NGINX][pack-nginx] and [HAProxy][pack-haproxy] packs are configured to
+balance the Consul service `simple_docker-service`, which is the default value
+for the `consul_service_name` variable.
+
+The [Fabio][pack-fabio] and [Traefik][pack-traefik] packs are configured to
+search for Consul services with the tags found in the default value of the
+`consul_service_tags` variable.
+
+## Variables
+
+<!-- Include information on the variables from your pack -->
+
+- `message` (string) - The message your application will respond with
+- `count` (number) - The number of app instances to deploy
+- `job_name` (string) - The name to use as the job name which overrides using
+  the pack name
+- `datacenters` (list of strings) - A list of datacenters in the region which
+  are eligible for task placement
+- `region` (string) - The region where jobs will be deployed
+- `register_consul_service` (bool) - If you want to register a consul service
+  for the job
+- `consul_service_tags` (list of string) - The consul service name for the
+  simple_docker application
+- `consul_service_name` (string) - The consul service name for the simple_docker
+  application
+
+[pack-registry]: https://github.com/hashicorp/nomad-pack-community-registry
+[pack-nginx]: https://github.com/hashicorp/nomad-pack-community-registry/tree/main/packs/nginx/README.md
+[pack-haproxy]: https://github.com/hashicorp/nomad-pack-community-registry/tree/main/packs/haproxy/README.md
+[pack-fabio]: https://github.com/hashicorp/nomad-pack-community-registry/tree/main/packs/fabio/README.md
+[pack-traefik]: https://github.com/hashicorp/nomad-pack-community-registry/tree/main/packs/traefik/traefik/README.md

--- a/fixtures/test_registry/packs/simple_docker/metadata.hcl
+++ b/fixtures/test_registry/packs/simple_docker/metadata.hcl
@@ -1,0 +1,19 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+app {
+  url = ""
+}
+pack {
+  name        = "simple_docker"
+  description = ""
+  url         = ""
+  version     = ""
+}
+
+// Optional dependency information. This block can be repeated.
+
+// dependency {
+//   name   = "demo_dependency_pack_name"
+//   source = "git://source.git/packs/demo_dependency_pack"
+// }

--- a/fixtures/test_registry/packs/simple_docker/outputs.tpl
+++ b/fixtures/test_registry/packs/simple_docker/outputs.tpl
@@ -1,0 +1,1 @@
+Congrats! You deployed the simple_docker pack on Nomad.

--- a/fixtures/test_registry/packs/simple_docker/templates/_helpers.tpl
+++ b/fixtures/test_registry/packs/simple_docker/templates/_helpers.tpl
@@ -1,0 +1,98 @@
+// allow nomad-pack to set the job name
+[[ define "job_name" ]]
+[[- if eq .my.job_name "" -]]
+[[- .nomad_pack.pack.name | quote -]]
+[[- else -]]
+[[- .my.job_name | quote -]]
+[[- end ]]
+[[- end ]]
+
+// only deploys to a region if specified
+[[ define "region" -]]
+[[- if not (eq .my.region "") -]]
+  region = [[ .my.region | quote]]
+[[- end -]]
+[[- end -]]
+
+// Generic constraint
+[[ define "constraints" -]]
+[[ range $idx, $constraint := . ]]
+  constraint {
+    attribute = [[ $constraint.attribute | quote ]]
+    [[ if $constraint.operator -]]
+    operator  = [[ $constraint.operator | quote ]]
+    [[ end -]]
+    value     = [[ $constraint.value | quote ]]
+  }
+[[ end -]]
+[[- end -]]
+
+// Generic "service" block template
+[[ define "service" -]]
+[[ $service := . ]]
+      service {
+        name = [[ $service.service_name | quote ]]
+        port = [[ $service.service_port_label | quote ]]
+        tags = [[ $service.service_tags | toStringList ]]
+        [[- if gt (len $service.upstreams) 0 ]]
+        connect {
+          sidecar_service {
+            proxy {
+              [[- if gt (len $service.upstreams) 0 ]]
+              [[- range $upstream := $service.upstreams ]]
+              upstreams {
+                destination_name = [[ $upstream.name | quote ]]
+                local_bind_port  = [[ $upstream.port ]]
+              }
+              [[- end ]]
+              [[- end ]]
+            }
+          }
+        }
+        [[- end ]]
+        check {
+          type     = [[ $service.check_type | quote ]]
+          [[- if $service.check_path]]
+          path     = [[ $service.check_path | quote ]]
+          [[- end]]
+          interval = [[ $service.check_interval | quote ]]
+          timeout  = [[ $service.check_timeout | quote ]]
+        }
+      }
+[[- end ]]
+
+// Generic env_vars template
+[[ define "env_vars" -]]
+        [[- range $idx, $var := . ]]
+        [[ $var.key ]] = [[ $var.value | quote ]]
+        [[- end ]]
+[[- end ]]
+
+
+// Generic mount template
+[[ define "mounts" -]]
+[[- range $idx, $mount := . ]]
+        mount {
+          type = [[ $mount.type | quote ]]
+          target = [[ $mount.target | quote ]]
+          source = [[ $mount.source | quote ]]
+          readonly = [[ $mount.readonly ]]
+          [[- if gt (len $mount.bind_options) 0 ]]
+          bind_options {
+            [[- range $idx, $opt := $mount.bind_options ]]
+            [[ $opt.name ]] = [[ $opt.value | quote ]]
+            [[- end ]]
+          }
+          [[- end ]]
+        }
+[[- end ]]
+[[- end ]]
+
+// Generic resources template
+[[ define "resources" -]]
+[[- $resources := . ]]
+      resources {
+        cpu    = [[ $resources.cpu ]]
+        memory = [[ $resources.memory ]]
+      }
+[[- end ]]

--- a/fixtures/test_registry/packs/simple_docker/templates/simple_docker.nomad.tpl
+++ b/fixtures/test_registry/packs/simple_docker/templates/simple_docker.nomad.tpl
@@ -1,0 +1,50 @@
+job [[ template "job_name" . ]] {
+  [[ template "region" . ]]
+  datacenters = [[ .my.datacenters  | toStringList ]]
+  type = "service"
+
+  group "app" {
+    count = [[ .my.count ]]
+
+    network {
+      port "http" {
+        to = 8000
+      }
+    }
+
+    [[ if .my.register_consul_service ]]
+    service {
+      name = "[[ .my.consul_service_name ]]"
+      tags = [[ .my.consul_service_tags | toStringList ]]
+      port = "http"
+      check {
+        name     = "alive"
+        type     = "http"
+        path     = "/"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+    [[ end ]]
+
+    restart {
+      attempts = 2
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image = "mnomitch/hello_world_server"
+        ports = ["http"]
+      }
+
+      env {
+        MESSAGE = [[.my.message | quote]]
+      }
+    }
+  }
+}

--- a/fixtures/test_registry/packs/simple_docker/variables.hcl
+++ b/fixtures/test_registry/packs/simple_docker/variables.hcl
@@ -1,0 +1,60 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "job_name" {
+  description = "The name to use as the job name which overrides using the pack name"
+  type        = string
+  // If "", the pack name will be used
+  default = ""
+}
+
+variable "region" {
+  description = "The region where jobs will be deployed"
+  type        = string
+  default     = ""
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement"
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+variable "count" {
+  description = "The number of app instances to deploy"
+  type        = number
+  default     = 2
+}
+
+variable "message" {
+  description = "The message your application will render"
+  type        = string
+  default     = "Hello World!"
+}
+
+variable "register_consul_service" {
+  description = "If you want to register a consul service for the job"
+  type        = bool
+  default     = true
+}
+
+variable "consul_service_name" {
+  description = "The consul service name for the simple_docker application"
+  type        = string
+  default     = "webapp"
+}
+
+variable "consul_service_tags" {
+  description = "The consul service name for the simple_docker application"
+  type        = list(string)
+  // defaults to integrate with Fabio or Traefik
+  // This routes at the root path "/", to route to this service from
+  // another path, change "urlprefix-/" to "urlprefix-/<PATH>" and
+  // "traefik.http.routers.http.rule=Path(∫/∫)" to
+  // "traefik.http.routers.http.rule=Path(∫/<PATH>∫)"
+  default = [
+    "urlprefix-/",
+    "traefik.enable=true",
+    "traefik.http.routers.http.rule=Path(`/`)",
+  ]
+}

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/pflag v1.0.5
 	github.com/zclconf/go-cty v1.13.2
+	golang.org/x/exp v0.0.0-20230728194245-b0cb94b80691
 	golang.org/x/term v0.10.0
 	golang.org/x/text v0.11.0
 )
@@ -263,7 +264,6 @@ require (
 	go.etcd.io/bbolt v1.3.7 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.11.0 // indirect
-	golang.org/x/exp v0.0.0-20230728194245-b0cb94b80691 // indirect
 	golang.org/x/mod v0.11.0 // indirect
 	golang.org/x/net v0.13.0 // indirect
 	golang.org/x/oauth2 v0.4.0 // indirect

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -238,5 +238,5 @@ func getGitHeadRef(clonePath string) (string, error) {
 		return "n/a", fmt.Errorf("could not get ref of a cloned repository: %v", err)
 	}
 
-	return head.Hash().String()[:7], nil
+	return head.Hash().String(), nil
 }

--- a/internal/pkg/cache/cache_test.go
+++ b/internal/pkg/cache/cache_test.go
@@ -575,7 +575,7 @@ func makeTestRegRepo(tReg *TestGithubRegistry) {
 	if err != nil {
 		panic(fmt.Errorf("could not get ref of test git repo: %v", err))
 	}
-	tReg.ref1 = head.Hash().String()[:7]
+	tReg.ref1 = head.Hash().String()
 
 	commitOptions.AllowEmptyCommits = true
 	_, err = w.Commit("Second Commit", commitOptions)

--- a/internal/pkg/cache/cache_test.go
+++ b/internal/pkg/cache/cache_test.go
@@ -671,15 +671,24 @@ func (p packtuples) PacksWithRefs() []string {
 func (p packtuples) Packs() []string {
 	out := make([]string, len(p))
 	for i, p := range p {
-		out[i] = p.name[:strings.Index(p.name, "@")]
+		name := p.name
+		atIdx := strings.Index(name, "@")
+		if atIdx >= 0 {
+			name = name[:atIdx]
+		}
+		out[i] = name
 	}
 	return out
 }
 
 // String returns a packtuple in `«reg»@«ref»/«packname»` form
 func (p packtuple) String() string {
-	return fmt.Sprintf("%s@%s/%s", p.reg, p.ref,
-		p.name[:strings.Index(p.name, "@")])
+	name := p.name
+	atIdx := strings.Index(name, "@")
+	if atIdx >= 0 {
+		name = name[:atIdx]
+	}
+	return fmt.Sprintf("%s@%s/%s", p.reg, p.ref, name)
 }
 
 // listAllTestPacks is a test helper that uses the filesystem


### PR DESCRIPTION
**Description**
Found that adding a pack to the fixtures/test_registry broke the cache tests. This PR adds test helpers to more accurately assess what is in the test cache directories.

**Commits**
- Adding a pack to the registry breaks tests
- Remove shortening from refs
- Refactor `testPackCount` into `listAllTestPacks` and helper funcs
