### PR TITLE
[actions] Disable caching for the golangci-lint action

### DIFF
--- a/.github/workflows/golang-ci-lint.yml
+++ b/.github/workflows/golang-ci-lint.yml
@@ -20,4 +20,4 @@ jobs:
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
         with:
           version: v1.51.2
-          skip-cache: ${{ env.ACT == 'true' }}
+          skip-cache: true

--- a/.github/workflows/golang-ci-lint.yml
+++ b/.github/workflows/golang-ci-lint.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
+
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
**Description**
The `hashicorp/setup-golang` automatically uses a cache for artifacts. This appears to conflict with the caching behavior of the `golangci/golangci-lint-action`
