### PR TITLE
[ui] Reshorten refs for output

### DIFF
--- a/internal/cli/formatters.go
+++ b/internal/cli/formatters.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"strings"
 	"time"
 
 	"github.com/ryanuber/columnize"
@@ -33,4 +34,17 @@ func formatTime(t time.Time) string {
 // E.g. formatTimeDifference(first=1m22s33ms, second=1m28s55ms, time.Second) -> 6s
 func formatTimeDifference(first, second time.Time, d time.Duration) string {
 	return second.Truncate(d).Sub(first.Truncate(d)).String()
+}
+
+func formatSHA1Reference(in string) string {
+	// a SHA1 hash is 20 bytes written as a hexadecimal string (40 chars)
+	if len(in) != 40 && len(strings.Trim(strings.ToLower(in), "0123456789abcdef")) != 0 {
+		// if it can't be a sha1, return it unchanged
+		return in
+	}
+	l := 8
+	if len(in) < l {
+		l = len(in)
+	}
+	return in[:l]
 }

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -65,10 +65,10 @@ func registryTableRow(cachedRegistry *cache.Registry) []terminal.TableEntry {
 			Value: cachedRegistry.Name,
 		},
 		{
-			Value: cachedRegistry.Ref,
+			Value: formatSHA1Reference(cachedRegistry.Ref),
 		},
 		{
-			Value: cachedRegistry.LocalRef,
+			Value: formatSHA1Reference(cachedRegistry.LocalRef),
 		},
 		{
 			Value: cachedRegistry.Source,
@@ -84,11 +84,11 @@ func registryPackRow(cachedRegistry *cache.Registry, cachedPack *cache.Pack) []t
 		},
 		// The revision from where the registryPack was cloned
 		{
-			Value: cachedPack.Ref,
+			Value: formatSHA1Reference(cachedPack.Ref),
 		},
 		// The canonical revision from where the registryPack was cloned
 		{
-			Value: cachedRegistry.LocalRef,
+			Value: formatSHA1Reference(cachedRegistry.LocalRef),
 		},
 		// The metadata version
 		{


### PR DESCRIPTION
**Description**
In #404, I made a drive-by change to use the full version of the localRef—typically a SHA1 hash. This caused the output of the `nomad-pack list` command to become extremely wide. This PR adds a helper function to reduce them back to 8 characters when printed.
