### PR TITLE
[cli] Fixed default printing for string flags

### DIFF
--- a/internal/pkg/flag/flag_var.go
+++ b/internal/pkg/flag/flag_var.go
@@ -77,7 +77,11 @@ func (f *Set) VarFlagP(i *VarFlagP) {
 	}
 
 	if i.Default != "" {
-		usage += fmt.Sprintf(" Defaults to %s.", i.Default)
+		if i.Value.Type() == "string" {
+			usage += fmt.Sprintf(" Defaults to %q.", i.Default)
+		} else {
+			usage += fmt.Sprintf(" Defaults to %s.", i.Default)
+		}
 	}
 
 	if i.EnvVar != "" {

--- a/internal/pkg/flag/set.go
+++ b/internal/pkg/flag/set.go
@@ -232,7 +232,7 @@ func printFlagDetail(w io.Writer, f *flag.Flag) {
 
 	if !defaultIsZeroValue(f) {
 		if f.Value.Type() == "string" {
-			fmt.Fprintf(w, " (default %q", f.DefValue)
+			fmt.Fprintf(w, " (default %q)", f.DefValue)
 		} else {
 			fmt.Fprintf(w, " (default %s)", f.DefValue)
 		}


### PR DESCRIPTION
The special case for printing out the default for a string flag was missing a closing parenthesis. Updated the long-form version to quote the default value as well.
