### PR TITLE
[chore] bump golang-ci

### DIFF
--- a/.github/workflows/golang-ci-lint.yml
+++ b/.github/workflows/golang-ci-lint.yml
@@ -21,5 +21,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
-          version: v1.53
+          version: v1.54
           skip-cache: true

--- a/.github/workflows/golang-ci-lint.yml
+++ b/.github/workflows/golang-ci-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: hashicorp/setup-golang@v1
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
-          version: v1.51.2
+          version: v1.53
           skip-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,13 +29,19 @@ linters:
     - gocritic
     - misspell
     - govet
-    - deadcode
-    - varcheck
     - ineffassign
-    - structcheck
     - unconvert
     - gofmt
     - gosimple
-    - depguard
     - staticcheck
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - dogsled
+    - durationcheck
+    # - errchkjson (todo)
+    # - errorlint (todo)
+    - exportloopref
+    - usestdlibvars
   fast: false


### PR DESCRIPTION
Older golangci-lint complains about new built-in functions introduced in Go 1.21. 