### PR TITLE
[copywrite] Ignore creator fixtures

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,15 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2023
+
+  # (OPTIONAL) A list of globs that should not have copyright/license headers.
+  # Supports doublestar glob patterns for more flexibility in defining which
+  # files or folders should be ignored
+  header_ignore = [
+    "internal/creator/templates/**"
+    # "vendor/**",
+    # "**autogen**",
+  ]
+}


### PR DESCRIPTION
**Description**

Add a `copywrite` configuration that ignores the `internal/creator/templates` files, since they are stub pages intended for end-user content.  Once we merge this, we need to have the bot rerun PR #433