### PR TITLE
[generator] Fix generated job spec bug

### DIFF
--- a/internal/creator/templates/pack_jobspec.tpl
+++ b/internal/creator/templates/pack_jobspec.tpl
@@ -12,7 +12,7 @@ job [[ template "job_name" . ]] {
       }
     }
 
-    [[ if .register_consul_service ]]
+    [[ if var "register_consul_service" . ]]
     service {
       name = "[[ var "consul_service_name" . ]]"
       tags = [[ var "consul_service_tags" . | toStringList ]]


### PR DESCRIPTION
**Description**

While updating the creator package's templates, I missed one of the variable references so as it stands the sample job will never be able to be Consul-enabled. 

**Reminders**

- [ ] Add `CHANGELOG.md` entry
