### PR TITLE
[cli] Fix `generate registry` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ the pack to their cluster.
 
 * **Vendoring Dependencies** - With `nomad-pack deps vendor`, you can
 automatically download all the dependencies listed in the `metadata.hcl` file
-into a `deps/` subdirectory. 
+into a `deps/` subdirectory.
+
+BUG FIXES:
+* cli: `generate registry` command creates registry in properly named folder [[GH-445](https://github.com/hashicorp/nomad-pack/pull/445)]
 
 IMPROVEMENTS:
 

--- a/internal/cli/generate_registry.go
+++ b/internal/cli/generate_registry.go
@@ -32,12 +32,12 @@ func (c *GenerateRegistryCommand) Run(args []string) int {
 		return 1
 	}
 
-	c.cfg.PackName = c.args[0]
+	c.cfg.RegistryName = c.args[0]
 
 	// Generate our UI error context.
 	errorContext := errors.NewUIErrorContext()
 
-	errorContext.Add(errors.UIContextPrefixRegistryName, c.cfg.PackName)
+	errorContext.Add(errors.UIContextPrefixRegistryName, c.cfg.RegistryName)
 	errorContext.Add(errors.UIContextPrefixOutputPath, c.cfg.OutPath)
 
 	err := creator.CreateRegistry(c.cfg)
@@ -89,7 +89,6 @@ func (c *GenerateRegistryCommand) Help() string {
 	c.Example = `
 	# Create a new registry named "my-new-registry" in the current directory.
 	nomad-pack generate registry my-new-registry
-
 	`
 	return formatHelp(`
 	Usage: nomad-pack generate registry <name>

--- a/internal/creator/pack.go
+++ b/internal/creator/pack.go
@@ -34,9 +34,9 @@ type packCreator struct {
 func CreatePack(c config.PackConfig) error {
 	ui := c.GetUI()
 
-	var outPath string
+	outPath := c.OutPath
 	var err error
-	if c.OutPath == "" {
+	if outPath == "" {
 		outPath, err = os.Getwd()
 		if err != nil {
 			newCreatePackError(err)


### PR DESCRIPTION
**Description**

The argument for the `generate registry` command is improperly read causing the command to emit the generated files into the current folder rather than a folder having the name of the registry.

**Reminders**

- [x] Add `CHANGELOG.md` entry
