### PR TITLE
feat: allow dependencies to be pinned to a git ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ IMPROVEMENTS:
 * cli: `registry list` command now shows only registries, and a new command `list` shows packs [[GH-337](https://github.com/hashicorp/nomad-pack/pull/337)], [[GH-373](https://github.com/hashicorp/nomad-pack/pull/373)]
 * cli: `deps vendor` command [[GH-367](https://github.com/hashicorp/nomad-pack/pull/367)]
 * cli: `generate pack` command now supports `--overwrite` flag [[GH-380](https://github.com/hashicorp/nomad-pack/pull/380)]
+* cli: `deps vendor` command now allows dependencies to be pinned [[GH-447](https://github.com/hashicorp/nomad-pack/pull/447)]
 * deps: Update the Nomad OpenAPI dependency; require Go 1.18 as a build dependency [[GH-288](https://github.com/hashicorp/nomad-pack/pull/288)]
 * pack: Author field no longer supported in pack metadata [[GH-317](https://github.com/hashicorp/nomad-pack/pull/317)]
 * pack: URL field no longer supported in pack metadata [[GH-343](https://github.com/hashicorp/nomad-pack/pull/343)]

--- a/internal/creator/templates/pack_metadata.hcl
+++ b/internal/creator/templates/pack_metadata.hcl
@@ -11,5 +11,5 @@ pack {
 
 // dependency "demo_dep" {
 //   alias  = "demo_dep"
-//   source = "git://source.git/packs/demo_dependency_pack"
+//   source = "git://source.git//packs/demo_dependency_pack"
 // }

--- a/internal/pkg/deps/vendor.go
+++ b/internal/pkg/deps/vendor.go
@@ -32,10 +32,18 @@ func Vendor(ctx context.Context, ui terminal.UI, targetPath string) error {
 
 	for _, d := range metadata.Dependencies {
 		targetDir := path.Join(targetPath, "deps", d.Name)
+		url := d.Source
+
+		if !d.IsLatest() {
+			url = fmt.Sprintf("%s?ref=%s", url, d.Ref)
+		} else {
+			// Attempt to shallow clone the constructed url
+			url = fmt.Sprintf("%s?depth=1", url)
+		}
 
 		// download each dependency
 		ui.Info(fmt.Sprintf("downloading %v pack to %v...", d.Name, targetDir))
-		if err := gg.Get(targetDir, fmt.Sprintf(d.Source), gg.WithContext(ctx)); err != nil {
+		if err := gg.Get(targetDir, url, gg.WithContext(ctx)); err != nil {
 			return fmt.Errorf("error downloading dependency: %v", err)
 		}
 		ui.Success("...success!")

--- a/sdk/pack/dependency.go
+++ b/sdk/pack/dependency.go
@@ -20,6 +20,10 @@ type Dependency struct {
 	// variable values.
 	Alias string `hcl:"alias,optional"`
 
+	// Ref is the git reference of the pack at which to add. Ignored if not
+	// specifying a git source. Defaults to latest.
+	Ref string `hcl:"ref,optional"`
+
 	// Source is the remote source where the pack can be fetched. This string
 	// can follow any format as supported by go-getter or be a local path
 	// indicating the pack has already been downloaded.
@@ -43,6 +47,11 @@ func (d *Dependency) AliasOrName() string {
 // which implements the Stringer interface
 func (d *Dependency) ID() ID {
 	return ID(d.AliasOrName())
+}
+
+// IsLatest works out if the user requested the HEAD of the dependency
+func (d *Dependency) IsLatest() bool {
+	return d.Ref == "" || d.Ref == "latest"
 }
 
 // validate the Dependency object to ensure it meets requirements and doesn't


### PR DESCRIPTION
**Description**

We would prefer our dependencies to be pinned so that rerunning `nomad-pack deps vendor` would always yield the same result.

Also a small fix for the template, the current proposed source string errors out. This also includes the shallow cloning patch as applied in #444 for registries as a whole

**Reminders**

- [x] Add `CHANGELOG.md` entry
