### PR TITLE
[bug] Fix nested pack map key creation error

### DIFF
--- a/internal/pkg/variable/parser/parser_v2.go
+++ b/internal/pkg/variable/parser/parser_v2.go
@@ -285,7 +285,7 @@ func (p *ParserV2) parseVariableImpl(name, rawVal string, tgt variables.PackIDKe
 		// TODO: This is another part that needs to be smart about parsing into the
 		// names so we could potentially set a value inside of an object.
 		varPID = p.cfg.ParentPack.ID().Join(
-			pack.ID("." + strings.Join(splitName[0:len(splitName)-1], ".")),
+			pack.ID(strings.Join(splitName[0:len(splitName)-1], ".")),
 		)
 		varVID = variables.ID(splitName[len(splitName)-1])
 	} else {


### PR DESCRIPTION
**Description**
When building the fully-qualified pack name an additional dot was being included causing the flag-provided values to never match their corresponding pack 

Fixes #448

**Reminders**

- ~[ ] Add `CHANGELOG.md` entry~ Since this error was introduced and removed in the same version, I think we can omit the changelog line.
