### PR TITLE
Tweaks helpers and auto-generated pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ bin/*
 *.dylib
 
 # binary when created in the project root with go build .
-./nomad-pack
+nomad-pack
 
 # Test binary, built with `go test -c`
 *.test

--- a/fixtures/v1/test_registry/packs/simple_docker/metadata.hcl
+++ b/fixtures/v1/test_registry/packs/simple_docker/metadata.hcl
@@ -11,9 +11,19 @@ pack {
   version     = ""
 }
 
-// Optional dependency information. This block can be repeated.
+# Optional dependency information. This block can be repeated.
 
-// dependency {
-//   name   = "demo_dependency_pack_name"
-//   source = "git://source.git/packs/demo_dependency_pack"
-// }
+# dependency "demo_dep" {
+#   alias  = "demo_dep"
+#   source = "git://source.git/packs/demo_dep"
+# }
+
+# Declared dependencies will be downloaded from their source
+# using "nomad-pack vendor deps" and added to ./deps directory.
+
+# Dependencies in active development can by symlinked in
+# the ./deps directory
+
+# Example dependency source values:
+# - "git::https://github.com/org-name/repo-name.git//packs/demo_dep"
+# - "git@github.com:org-name/repo-name.git/packs/demo_dep"

--- a/fixtures/v1/test_registry/packs/simple_docker/templates/_helpers.tpl
+++ b/fixtures/v1/test_registry/packs/simple_docker/templates/_helpers.tpl
@@ -34,6 +34,7 @@
         name = [[ $service.service_name | quote ]]
         port = [[ $service.service_port_label | quote ]]
         tags = [[ $service.service_tags | toStringList ]]
+        provider = [[ $service.service_provider | quote ]]
         [[- if gt (len $service.upstreams) 0 ]]
         connect {
           sidecar_service {
@@ -66,26 +67,6 @@
         [[- range $idx, $var := . ]]
         [[ $var.key ]] = [[ $var.value | quote ]]
         [[- end ]]
-[[- end ]]
-
-
-// Generic mount template
-[[ define "mounts" -]]
-[[- range $idx, $mount := . ]]
-        mount {
-          type = [[ $mount.type | quote ]]
-          target = [[ $mount.target | quote ]]
-          source = [[ $mount.source | quote ]]
-          readonly = [[ $mount.readonly ]]
-          [[- if gt (len $mount.bind_options) 0 ]]
-          bind_options {
-            [[- range $idx, $opt := $mount.bind_options ]]
-            [[ $opt.name ]] = [[ $opt.value | quote ]]
-            [[- end ]]
-          }
-          [[- end ]]
-        }
-[[- end ]]
 [[- end ]]
 
 // Generic resources template

--- a/fixtures/v2/test_registry/packs/simple_docker/templates/_helpers.tpl
+++ b/fixtures/v2/test_registry/packs/simple_docker/templates/_helpers.tpl
@@ -34,6 +34,7 @@
         name = [[ $service.service_name | quote ]]
         port = [[ $service.service_port_label | quote ]]
         tags = [[ $service.service_tags | toStringList ]]
+        provider = [[ $service.service_provider | quote ]]
         [[- if gt (len $service.upstreams) 0 ]]
         connect {
           sidecar_service {
@@ -66,26 +67,6 @@
         [[- range $idx, $var := . ]]
         [[ $var.key ]] = [[ $var.value | quote ]]
         [[- end ]]
-[[- end ]]
-
-
-// Generic mount template
-[[ define "mounts" -]]
-[[- range $idx, $mount := . ]]
-        mount {
-          type = [[ $mount.type | quote ]]
-          target = [[ $mount.target | quote ]]
-          source = [[ $mount.source | quote ]]
-          readonly = [[ $mount.readonly ]]
-          [[- if gt (len $mount.bind_options) 0 ]]
-          bind_options {
-            [[- range $idx, $opt := $mount.bind_options ]]
-            [[ $opt.name ]] = [[ $opt.value | quote ]]
-            [[- end ]]
-          }
-          [[- end ]]
-        }
-[[- end ]]
 [[- end ]]
 
 // Generic resources template

--- a/internal/creator/templates/pack_helpers.tpl
+++ b/internal/creator/templates/pack_helpers.tpl
@@ -68,7 +68,7 @@ This helper creates Nomad constraint blocks from a value of type
 ```
   list(
     object(
-      service_name string, service_port_label string, service_tags list(string),
+      service_name string, service_port_label string, service_provider string, service_tags list(string),
       upstreams list(object(name string, port number))
       check_type string, check_path string, check_interval string, check_timeout string
     )
@@ -86,6 +86,7 @@ template.
         name = [[ $service.service_name | quote ]]
         port = [[ $service.service_port_label | quote ]]
         tags = [[ $service.service_tags | toStringList ]]
+        provider = [[ $service.service_provider | quote ]]
         [[- if $service.upstreams ]]
         connect {
           sidecar_service {
@@ -123,47 +124,6 @@ This helper formats maps as key and quoted value pairs.
         [[- range $idx, $var := . ]]
         [[ $var.key ]] = [[ $var.value | quote ]]
         [[- end ]]
-[[- end ]]
-
-[[- /*
-
-## `mounts` helper
-
-```
-  list(
-    object(
-      type string, target string, source string,
-      readonly bool,
-      bind_options map(string)
-    )
-  )
-```
-
-This helper is extremely similar to the `services` helper. It uses several
-alternative syntax choices and leverages the fact that range provides the
-current iteratee as the current template context inside of it's scope.
-
-Additional notes:
-  "", 0, false, nil, and empty slices all evaluate to false for `if`
-  "", 0, false, nil, and empty slices all evaluate to empty for `range`
-
-*/ -]]
-[[ define "mounts" -]]
-[[- range . ]]
-        mount {
-          type = [[ quote .type  ]]
-          target = [[ quote .target ]]
-          source = [[ quote .source ]]
-          readonly = [[ .readonly ]]
-          [[- if .bind_options ]]
-          bind_options {
-            [[- range .bind_options ]]
-            [[ .name ]] = [[ quote .value ]]
-            [[- end ]]
-          }
-          [[- end ]]
-        }
-[[- end ]]
 [[- end ]]
 
 [[- /*

--- a/internal/creator/templates/pack_jobspec.tpl
+++ b/internal/creator/templates/pack_jobspec.tpl
@@ -12,10 +12,11 @@ job [[ template "job_name" . ]] {
       }
     }
 
-    [[ if var "register_consul_service" . ]]
+    [[ if var "register_service" . ]]
     service {
-      name = "[[ var "consul_service_name" . ]]"
-      tags = [[ var "consul_service_tags" . | toStringList ]]
+      name = "[[ var "service_name" . ]]"
+      tags = [[ var "service_tags" . | toStringList ]]
+      provider = "nomad"
       port = "http"
       check {
         name     = "alive"

--- a/internal/creator/templates/pack_metadata.hcl
+++ b/internal/creator/templates/pack_metadata.hcl
@@ -7,9 +7,19 @@ pack {
   version     = ""
 }
 
-// Optional dependency information. This block can be repeated.
+# Optional dependency information. This block can be repeated.
 
-// dependency "demo_dep" {
-//   alias  = "demo_dep"
-//   source = "git://source.git/packs/demo_dependency_pack"
-// }
+# dependency "demo_dep" {
+#   alias  = "demo_dep"
+#   source = "git://source.git/packs/demo_dep"
+# }
+
+# Declared dependencies will be downloaded from their source
+# using "nomad-pack vendor deps" and added to ./deps directory.
+
+# Dependencies in active development can by symlinked in
+# the ./deps directory
+
+# Example dependency source values:
+# - "git::https://github.com/org-name/repo-name.git//packs/demo_dep"
+# - "git@github.com:org-name/repo-name.git/packs/demo_dep"

--- a/internal/creator/templates/pack_readme.md
+++ b/internal/creator/templates/pack_readme.md
@@ -21,24 +21,6 @@ nomad-pack run {{.PackName}} --var message="Hola Mundo!"
 This tells Nomad Pack to tweak the `MESSAGE` environment variable that the
 service reads from.
 
-### Consul Service and Load Balancer Integration
-
-Optionally, it can configure a Consul service.
-
-If the `register_consul_service` is unset or set to true, the Consul service
-will be registered.
-
-Several load balancers in the [Nomad Pack Community Registry][pack-registry]
-are configured to connect to this service by default.
-
-The [NGINX][pack-nginx] and [HAProxy][pack-haproxy] packs are configured to
-balance the Consul service `{{.PackName}}-service`, which is the default value
-for the `consul_service_name` variable.
-
-The [Fabio][pack-fabio] and [Traefik][pack-traefik] packs are configured to
-search for Consul services with the tags found in the default value of the
-`consul_service_tags` variable.
-
 ## Variables
 
 <!-- Include information on the variables from your pack -->
@@ -47,18 +29,12 @@ search for Consul services with the tags found in the default value of the
 - `count` (number:2) - The number of app instances to deploy
 - `job_name` (string) - The name to use as the job name which overrides using
   the pack name
-- `datacenters` (list of strings:["dc1"]) - A list of datacenters in the region which
+- `datacenters` (list of strings:["*"]) - A list of datacenters in the region which
   are eligible for task placement
 - `region` (string) - The region where jobs will be deployed
-- `register_consul_service` (bool: true) - If you want to register a Consul service
+- `register_service` (bool: true) - If you want to register a Nomad service
   for the job
-- `consul_service_tags` (list of string) - The Consul service name for the
-  {{.PackName}} application
-- `consul_service_name` (string) - The Consul service name for the {{.PackName}}
-  application
+- `service_tags` (list of string) - The service tags for the {{.PackName}} application
+- `service_name` (string) - The service name for the {{.PackName}} application
 
 [pack-registry]: https://github.com/hashicorp/nomad-pack-community-registry
-[pack-nginx]: https://github.com/hashicorp/nomad-pack-community-registry/tree/main/packs/nginx/README.md
-[pack-haproxy]: https://github.com/hashicorp/nomad-pack-community-registry/tree/main/packs/haproxy/README.md
-[pack-fabio]: https://github.com/hashicorp/nomad-pack-community-registry/tree/main/packs/fabio/README.md
-[pack-traefik]: https://github.com/hashicorp/nomad-pack-community-registry/tree/main/packs/traefik/traefik/README.md

--- a/internal/creator/templates/pack_variables.hcl
+++ b/internal/creator/templates/pack_variables.hcl
@@ -14,7 +14,7 @@ variable "region" {
 variable "datacenters" {
   description = "A list of datacenters in the region which are eligible for task placement"
   type        = list(string)
-  default     = ["dc1"]
+  default     = ["*"]
 }
 
 variable "count" {
@@ -29,22 +29,22 @@ variable "message" {
   default     = "Hello World!"
 }
 
-variable "register_consul_service" {
-  description = "If you want to register a Consul service for the job"
+variable "register_service" {
+  description = "If you want to register a Nomad service for the job"
   type        = bool
   default     = true
 }
 
-variable "consul_service_name" {
-  description = "The Consul service name for the {{.PackName}} application"
+variable "service_name" {
+  description = "The service name for the {{.PackName}} application"
   type        = string
   default     = "webapp"
 }
 
-variable "consul_service_tags" {
-  description = "The Consul service name for the {{.PackName}} application"
+variable "service_tags" {
+  description = "The service tags for the {{.PackName}} application"
   type        = list(string)
-  # The default value is shaped to integrate with Fabio or Traefik
+  # The default value is shaped to integrate with Traefik
   # This routes at the root path "/", to route to this service from
   # another path, change "urlprefix-/" to "urlprefix-/<PATH>" and
   # "traefik.http.routers.http.rule=Path(∫/∫)" to


### PR DESCRIPTION
**Description**

Removes the mounts helper. There are already "complex" examples for helpers and this is probably too in the weeds and distracting for new users.

Also adds type to service helper since "nomad" is an option

Also adds dependency information into the metadata template

**Reminders**

- [ ] Add `CHANGELOG.md` entry
