### PR TITLE
[renderer] Fix variable handling in output templates

### DIFF
--- a/fixtures/v2/test_registry/packs/deps_test_1/outputs.tpl
+++ b/fixtures/v2/test_registry/packs/deps_test_1/outputs.tpl
@@ -1,0 +1,7 @@
+{
+  "job_name": [[ var "job_name" . | quote ]],
+  "child1.job_name": [[ var "job_name" .child1 | quote ]],
+  "child1.gc.job_name": [[ var "job_name" .child1.gc | quote ]],
+  "child2.job_name": [[ var "job_name" .child2 | quote ]],
+  "child2.gc.job_name": [[ var "job_name" .child2.gc | quote ]]
+}

--- a/fixtures/v2/test_registry/packs/my_alias_test/outputs.tpl
+++ b/fixtures/v2/test_registry/packs/my_alias_test/outputs.tpl
@@ -1,0 +1,1 @@
+[[var "job_name" .]],[[var "job_name" .child1]],[[var "job_name" .child2]]

--- a/internal/pkg/renderer/renderer.go
+++ b/internal/pkg/renderer/renderer.go
@@ -182,8 +182,9 @@ func (r *Renderer) RenderOutput() (string, error) {
 		return "", err
 	}
 
+	ptc, _ := r.pv.ToPackTemplateContext(r.pack)
 	var buf strings.Builder
-	if err := r.tpl.ExecuteTemplate(&buf, r.pack.OutputTemplateFile.Name, r.pv); err != nil {
+	if err := r.tpl.ExecuteTemplate(&buf, r.pack.OutputTemplateFile.Name, ptc); err != nil {
 		return "", fmt.Errorf("failed to render %s: %v", r.pack.OutputTemplateFile.Name, err)
 	}
 


### PR DESCRIPTION
**Description**
Fix condition where the v2 parser was not properly converting the ParsedVariables to a PackTemplateContext before being passing them to go template when rendering the output template.

- Add test for bug; add outputs to fixtures with deps
- Get a PackTemplateContext from renderer's parsedVariables

**Reminders**

- ~[ ] Add `CHANGELOG.md` entry~
