### PR TITLE
[cli] Make argument errors consistent across commands

### DIFF
--- a/internal/cli/deps_vendor.go
+++ b/internal/cli/deps_vendor.go
@@ -31,7 +31,8 @@ func (d *depsVendorCommand) Run(args []string) int {
 		WithNoConfig(),
 		WithClient(false),
 	); err != nil {
-		d.ui.ErrorWithContext(err, "error parsing args or flags")
+		d.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		d.ui.Info(d.helpUsageMessage())
 		return 1
 	}
 
@@ -58,8 +59,8 @@ func (d *depsVendorCommand) Flags() *flag.Sets {
 			Name:    "path",
 			Target:  &d.targetPath,
 			Default: "",
-			Usage: `Full path to the pack which contains dependencies to be 
-				    vendored. All the dependencies will then be downloaded 
+			Usage: `Full path to the pack which contains dependencies to be
+				    vendored. All the dependencies will then be downloaded
 				    into a 'deps/' subdirectory of that path. `,
 		})
 

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -21,10 +21,8 @@ func (c *DestroyCommand) Run(args []string) int {
 		WithFlags(c.Flags()),
 		WithNoConfig(),
 	); err != nil {
-
 		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
 		c.ui.Info(c.helpUsageMessage())
-
 		return 1
 	} else {
 		// This needs to be in an else block so that it doesn't try to run while

--- a/internal/cli/generate_pack.go
+++ b/internal/cli/generate_pack.go
@@ -29,7 +29,8 @@ func (c *GeneratePackCommand) Run(args []string) int {
 		WithNoConfig(),
 		WithClient(false),
 	); err != nil {
-		c.ui.ErrorWithContext(err, "error parsing args or flags")
+		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		c.ui.Info(c.helpUsageMessage())
 		return 1
 	}
 

--- a/internal/cli/generate_registry.go
+++ b/internal/cli/generate_registry.go
@@ -28,7 +28,8 @@ func (c *GenerateRegistryCommand) Run(args []string) int {
 		WithNoConfig(),
 		WithClient(false),
 	); err != nil {
-		c.ui.ErrorWithContext(err, "error parsing args or flags")
+		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		c.ui.Info(c.helpUsageMessage())
 		return 1
 	}
 

--- a/internal/cli/generate_varfile.go
+++ b/internal/cli/generate_varfile.go
@@ -116,10 +116,8 @@ func (c *generateVarFileCommand) Run(args []string) int {
 		WithExactArgs(1, args),
 		WithFlags(c.Flags()),
 		WithNoConfig()); err != nil {
-
 		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
 		c.ui.Info(c.helpUsageMessage())
-
 		return 1
 	}
 

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -28,10 +28,8 @@ func (c *InfoCommand) Run(args []string) int {
 		WithFlags(c.Flags()),
 		WithNoConfig(),
 	); err != nil {
-
 		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
 		c.ui.Info(c.helpUsageMessage())
-
 		return 1
 	}
 

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -27,6 +27,8 @@ func (c *ListCommand) Run(args []string) int {
 		WithNoConfig(),
 		WithClient(false),
 	); err != nil {
+		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		c.ui.Info(c.helpUsageMessage())
 		return 1
 	}
 

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -35,7 +35,7 @@ func (c *PlanCommand) Run(args []string) int {
 	); err != nil {
 		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
 		c.ui.Info(c.helpUsageMessage())
-		return 255
+		return c.exitCodeError
 	}
 
 	c.packConfig.Name = c.args[0]

--- a/internal/cli/registry_add.go
+++ b/internal/cli/registry_add.go
@@ -35,7 +35,8 @@ func (c *RegistryAddCommand) Run(args []string) int {
 		WithNoConfig(),
 		WithClient(false),
 	); err != nil {
-		c.ui.ErrorWithContext(err, "error parsing args or flags")
+		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		c.ui.Info(c.helpUsageMessage())
 		return 1
 	}
 

--- a/internal/cli/registry_delete.go
+++ b/internal/cli/registry_delete.go
@@ -32,7 +32,8 @@ func (c *RegistryDeleteCommand) Run(args []string) int {
 		WithNoConfig(),
 		WithClient(false),
 	); err != nil {
-		c.ui.ErrorWithContext(err, "error parsing args or flags")
+		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		c.ui.Info(c.helpUsageMessage())
 		return 1
 	}
 

--- a/internal/cli/registry_list.go
+++ b/internal/cli/registry_list.go
@@ -18,12 +18,14 @@ type RegistryListCommand struct {
 
 func (c *RegistryListCommand) Run(args []string) int {
 	c.cmdKey = "registry list"
-	// Initialize. If we fail, we just exit since Init handles the UI.
+
 	if err := c.Init(
 		WithNoArgs(args),
 		WithNoConfig(),
 		WithClient(false),
 	); err != nil {
+		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
+		c.ui.Info(c.helpUsageMessage())
 		return 1
 	}
 

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -252,11 +252,10 @@ func (c *RenderCommand) Run(args []string) int {
 	if err := c.Init(
 		WithExactArgs(1, args),
 		WithFlags(c.Flags()),
-		WithNoConfig()); err != nil {
-
+		WithNoConfig(),
+	); err != nil {
 		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
 		c.ui.Info(c.helpUsageMessage())
-
 		return 1
 	}
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -23,12 +23,10 @@ type RunCommand struct {
 }
 
 func (c *RunCommand) Run(args []string) int {
-	var err error
-
 	c.cmdKey = "run" // Add cmdKey here to print out helpUsageMessage on Init error
 
 	// Initialize. If we fail, we just exit since Init handles the UI.
-	if err = c.Init(
+	if err := c.Init(
 		WithExactArgs(1, args),
 		WithFlags(c.Flags()),
 		WithNoConfig(),

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -18,7 +18,12 @@ func (c *VersionCommand) Run(args []string) int {
 	c.cmdKey = "version"
 
 	// Initialize. If we fail, we just exit since Init handles the UI.
-	if err := c.Init(WithNoArgs(args), WithFlags(flagSet), WithNoConfig(), WithClient(false)); err != nil {
+	if err := c.Init(
+		WithNoArgs(args),
+		WithFlags(flagSet),
+		WithNoConfig(),
+		WithClient(false),
+	); err != nil {
 		c.ui.ErrorWithContext(err, ErrParsingArgsOrFlags)
 		c.ui.Info(c.helpUsageMessage())
 		return 1


### PR DESCRIPTION
**Description**
Make the "argument error" messages consistent across all commands by using the error string constant and by printing the usage helper after the error message prints out.
