### PR TITLE
[cli] Validate name arg on `generate pack` command 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ into a `deps/` subdirectory.
 
 BUG FIXES:
 * cli: `generate registry` command creates registry in properly named folder [[GH-445](https://github.com/hashicorp/nomad-pack/pull/445)]
+* cli: `generate pack` validates name argument [[GH-460](https://github.com/hashicorp/nomad-pack/pull/460)]
 
 IMPROVEMENTS:
 

--- a/internal/pkg/errors/ui_context.go
+++ b/internal/pkg/errors/ui_context.go
@@ -16,6 +16,8 @@ var ErrNoTemplatesRendered = newError("no templates were rendered by the rendere
 // UI errors outputs. If a prefix is used more than once, it should have a
 // const created.
 const (
+	UIContextErrorDetail          = "Detail: "
+	UIContextErrorSuggestion      = "Suggestion: "
 	UIContextPrefixGitRegistryURL = "Git Registry URL: "
 	UIContextPrefixPackName       = "Pack Name: "
 	UIContextPrefixPackPath       = "Pack Path: "

--- a/sdk/pack/pack.go
+++ b/sdk/pack/pack.go
@@ -5,8 +5,19 @@ package pack
 
 import (
 	"errors"
+	"regexp"
 	"strings"
 )
+
+func IsValidName(name string) bool {
+	// \p{L}  - Letters
+	// \p{M}  - Marks
+	// \p{N}  - Numbers
+	// \p{Pc} - Punctuation, connecting
+	var re = regexp.MustCompile(`(?m)^[\p{L}\p{M}\p{N}\p{Pc}]+$`)
+
+	return re.MatchString(name)
+}
 
 type ID string
 

--- a/sdk/pack/pack_test.go
+++ b/sdk/pack/pack_test.go
@@ -135,3 +135,25 @@ func TestPack_RootVariableFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestPack_IsValidName(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+		valid bool
+	}{
+		{name: "empty", input: "", valid: false},
+		{name: "slashes", input: "foo/bar", valid: false},
+		{name: "dashes", input: "foo-bar", valid: false},
+		{name: "dots", input: "foo.bar", valid: false},
+		{name: "underscore", input: "foo_bar", valid: true},
+		{name: "alphanum", input: "f00bar", valid: true},
+		{name: "hiragana", input: "チャーリー", valid: true},
+		{name: "emoji", input: "🗯️", valid: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			must.Eq(t, IsValidName(tc.input), tc.valid)
+		})
+	}
+}


### PR DESCRIPTION
**Description**
The `generate pack` command takes a name for the pack to be generated. In user testing, we observed that if given a path-like value it would generate broken output. This PR adds a IsValidName func to the pack SDK and uses it to validate the argument passed to the `generate pack` command. It also adds two contextual fields to the error that contain a detailed explanation and a suggestion to the user for cases where they did intend to put the pack in a specific directory.

<img width="1400" alt="Screenshot 2023-10-27 at 10 07 06 AM" src="https://github.com/hashicorp/nomad-pack/assets/464492/5aeb16bc-729e-431d-836d-ef7dd44e2922">

- Add ErrorContext constants for Detail and Suggestion
- Add a valid name func for packs


**Reminders**

- [x] Add `CHANGELOG.md` entry
