### PR TITLE
[cli] Shorten registry names in `list` output

### DIFF
--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -130,7 +130,7 @@ func packRow(cachedRegistry *cache.Registry, cachedPack *cache.Pack) []terminal.
 		},
 		// CachedRegistry name  user defined alias or registry URL slug
 		{
-			Value: fmt.Sprintf("%s@%s", cachedRegistry.Name, cachedRegistry.LocalRef),
+			Value: registryName(cachedRegistry),
 		},
 		// TODO: The app version
 	}

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -106,6 +106,17 @@ func registryPackRow(cachedRegistry *cache.Registry, cachedPack *cache.Pack) []t
 		// TODO: The app version
 	}
 }
+func registryName(cr *cache.Registry) string {
+	if cr.Ref == cr.LocalRef {
+		return fmt.Sprintf("%s@%s", cr.Name, formatSHA1Reference(cr.LocalRef))
+	}
+	// While it is completely unexpected to encounter a case where the Ref is a
+	// SHA1 hash and the LocalRef doesn't match, we can safely run the Ref through
+	// the formatSHA1Reference func since it will return non-SHA values unmodified
+	// and if somehow the mismatched SHA case does happen, the output will not
+	// become ridiculous.
+	return fmt.Sprintf("%s@%s (%s)", cr.Name, formatSHA1Reference(cr.Ref), formatSHA1Reference(cr.LocalRef))
+}
 
 func packRow(cachedRegistry *cache.Registry, cachedPack *cache.Pack) []terminal.TableEntry {
 	return []terminal.TableEntry{


### PR DESCRIPTION
**Description**
The entire SHA is overly verbose in the Pack list output. This PR:
- Adds a helper to nicely format a cache.Registry name
- Replaces registry name in pack list command with the formatted version

<img width="677" alt="Screenshot 2023-10-27 at 10 43 16 AM" src="https://github.com/hashicorp/nomad-pack/assets/464492/bf0c046d-17dc-456e-be46-8f6d96a3ba72">

**Reminders**

- [ ] Add `CHANGELOG.md` entry
