### PR TITLE
Promote Details and Suggestions to top level display

### DIFF
--- a/internal/pkg/errors/template_errors.go
+++ b/internal/pkg/errors/template_errors.go
@@ -55,10 +55,10 @@ func ParseTemplateError(tplCtx parser.PackTemplateContext, err error) *PackTempl
 // display to the CLI
 func (p *PackTemplateError) ToWrappedUIContext() *WrappedUIContext {
 	errCtx := NewUIErrorContext()
-	errCtx.Add("Details: ", p.Details)
-	errCtx.Add("Filename: ", p.Filename)
-	errCtx.Add("Position: ", p.pos())
-	errCtx.Add("Suggestions: ", strings.Join(p.Suggestions, "; "))
+	errCtx.Add(UIContextErrorDetail, p.Details)
+	errCtx.Add(UIContextErrorFilename, p.Filename)
+	errCtx.Add(UIContextErrorPosition, p.pos())
+	errCtx.Add(UIContextErrorSuggestion, strings.Join(p.Suggestions, "; "))
 	return &WrappedUIContext{
 		Err:     p,
 		Subject: "error executing template",

--- a/internal/pkg/errors/template_errors.go
+++ b/internal/pkg/errors/template_errors.go
@@ -102,8 +102,8 @@ func (p *PackTemplateError) parseExecError(execErr template.ExecError) {
 	// after here we'll return this since it's "good enough"
 	p.Err = errors.New(p.Extra[len(p.Extra)-1])
 
-	// Maybe we can do better on the "variable.PackContextable" bit if it shows up
-	if strings.Contains(p.Err.Error(), "variable.PackContextable") {
+	// Maybe we can do better on the "parser.PackContextable" bit if it shows up
+	if strings.Contains(p.Err.Error(), "parser.PackContextable") {
 		p.fixupPackContextable()
 	}
 
@@ -185,14 +185,14 @@ func (p *PackTemplateError) enhanceNPE() {
 }
 
 func (p *PackTemplateError) fixupPackContextable() {
-	const typeConst = "variable.PackContextable"
+	const typeConst = "parser.PackContextable"
 	errStr := p.Err.Error()
 
-	// attempt to extract the "variable.PackContextable.blah" part.
+	// attempt to extract the "parser.PackContextable.blah" part.
 	varRefStr := ""
 
 	// Since there's no variable component to the regex, we can use MustCompile
-	pRE := regexp.MustCompile(`(?m)^.*(variable\.PackContextable\.[\w]+)(?:[[:space:]]|$)`)
+	pRE := regexp.MustCompile(`(?m)^.*(parser\.PackContextable\.[\w]+)(?:[[:space:]]|$)`)
 
 	// If there's a match, FindStringSubmatch will return 2 matches: one for the
 	// whole string and one for the capture group

--- a/internal/pkg/errors/template_errors.go
+++ b/internal/pkg/errors/template_errors.go
@@ -167,20 +167,20 @@ func (p *PackTemplateError) enhanceNPE() {
 			atPackName := parts[1]
 			rootPackName := p.tplctx.Name()
 
-			if atPackName == rootPackName {
+			if atPackName == rootPackName || atPackName == "my" {
 				atPackName = ""
 			}
 
 			p.Suggestions = []string{
+				// TODO: This error will need to be modified if parser-v1 becomes unsupported.
 				fmt.Sprintf(
-					"The legacy %q syntax should be updated to use `var %q .%s`.",
+					"The legacy %q syntax should be updated to use `var %q .%s`. You can run legacy packs unmodified by using the `--parser-v1` flag",
 					p.at,
 					parts[2],
 					atPackName,
 				),
 			}
 		}
-
 	}
 }
 

--- a/internal/pkg/errors/ui_context.go
+++ b/internal/pkg/errors/ui_context.go
@@ -16,8 +16,10 @@ var ErrNoTemplatesRendered = newError("no templates were rendered by the rendere
 // UI errors outputs. If a prefix is used more than once, it should have a
 // const created.
 const (
-	UIContextErrorDetail          = "Detail: "
-	UIContextErrorSuggestion      = "Suggestion: "
+	UIContextErrorDetail          = "Details: "
+	UIContextErrorSuggestion      = "Suggestions: "
+	UIContextErrorFilename        = "Filename: "
+	UIContextErrorPosition        = "Position: "
 	UIContextPrefixGitRegistryURL = "Git Registry URL: "
 	UIContextPrefixPackName       = "Pack Name: "
 	UIContextPrefixPackPath       = "Pack Path: "

--- a/internal/pkg/renderer/renderer.go
+++ b/internal/pkg/renderer/renderer.go
@@ -130,7 +130,7 @@ func (r *Renderer) Render(p *pack.Pack, variables *parser.ParsedVariables) (*Ren
 
 		dot := src.getDot()
 		if err := tpl.ExecuteTemplate(&buf, name, dot); err != nil {
-			return nil, fmt.Errorf("failed to render %s: %v", name, err)
+			return nil, fmt.Errorf("failed to render %s: %w", name, err)
 		}
 
 		// Even when using "missingkey=zero", missing values will be rendered

--- a/terminal/noninteractive.go
+++ b/terminal/noninteractive.go
@@ -237,7 +237,7 @@ func (ui *nonInteractiveUI) ErrorWithContext(err error, sub string, ctx ...strin
 			key, rest, found := strings.Cut(item, ": ")
 
 			if !found {
-				wrapped := wordwrap.WrapString(rest, 78)
+				wrapped := wordwrap.WrapString(key, 78)
 				lines := strings.Split(wrapped, "\n")
 				for _, l := range lines {
 					ui.Error("  " + l)


### PR DESCRIPTION
**Description**
Following the work in PR #462 , this PR consults the ErrorContext and if there are Details or Suggestions in it, extracts them to be shown immediately following the Error.

<img width="1110" alt="Screenshot 2023-10-27 at 2 55 19 PM" src="https://github.com/hashicorp/nomad-pack/assets/464492/880af20d-ca66-45ef-afc3-11f61dbebfe7">

<img width="1114" alt="Screenshot 2023-10-27 at 3 26 07 PM" src="https://github.com/hashicorp/nomad-pack/assets/464492/24701739-24b0-4a69-9899-9a821ed33578">


**Reminders**

- [ ] Add `CHANGELOG.md` entry
