### PR TITLE
[build] Fix `team` in ci.hcl

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -4,7 +4,7 @@
 schema = "1"
 
 project "nomad-pack" {
-  team = "nomad-pack"
+  team = "nomad"
 
   slack {
     notification_channel = "C03B5EWFW01"


### PR DESCRIPTION
**Description**
While updating the ci.hcl file, I caught the `team` field in my search and replace. This changes it back to Nomad.

