### PR TITLE
[cli] Relax regex used for nil pointer enhancements

### DIFF
--- a/internal/pkg/errors/template_errors.go
+++ b/internal/pkg/errors/template_errors.go
@@ -220,11 +220,7 @@ func (p *PackTemplateError) fixupPackContextable() {
 		return
 	}
 
-	atRE, err := regexp.Compile(`^.*"` + p.Filename + `" at <(.+)>$`)
-	if err != nil {
-		// there's a janky filename that's breaking the regex.
-		return
-	}
+	atRE := regexp.MustCompile(`^executing .* at <(.+)>$`)
 
 	for _, e := range p.Extra {
 		// if it matches, there should be 2 items in the matches slice

--- a/internal/pkg/renderer/renderer.go
+++ b/internal/pkg/renderer/renderer.go
@@ -185,7 +185,7 @@ func (r *Renderer) RenderOutput() (string, error) {
 	ptc, _ := r.pv.ToPackTemplateContext(r.pack)
 	var buf strings.Builder
 	if err := r.tpl.ExecuteTemplate(&buf, r.pack.OutputTemplateFile.Name, ptc); err != nil {
-		return "", fmt.Errorf("failed to render %s: %v", r.pack.OutputTemplateFile.Name, err)
+		return "", fmt.Errorf("failed to render %s: %w", r.pack.OutputTemplateFile.Name, err)
 	}
 
 	return buf.String(), nil


### PR DESCRIPTION
**Description**
When parsing a template execution error, the regex that extracted the location was too restrictive causing the decorated errors in any _-named helper template to not be rendered properly.