### PR TITLE
Update help text for `registry list`

### DIFF
--- a/internal/cli/registry_list.go
+++ b/internal/cli/registry_list.go
@@ -85,12 +85,12 @@ func (c *RegistryListCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *RegistryListCommand) Synopsis() string {
-	return "List registries and packs available in the local environment."
+	return "List registries configured in the local environment."
 }
 
 func (c *RegistryListCommand) Help() string {
 	c.Example = `
-	# List all available registries and their packs
+	# List all configured registries
 	nomad-pack registry list
 	`
 	return formatHelp(`


### PR DESCRIPTION
**Description**

Since the `pack list` command can list all packs loaded for all regestries or a specific one, we removed pack output from
the `registry list` command.  This PR updates the help text for the `registry list` command.

**Reminders**

- [ ] ~Add `CHANGELOG.md` entry~
