### PR TITLE
Detect os/arch more makily

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,8 +13,22 @@ GIT_COMMIT = $$(git rev-parse --short HEAD)
 GIT_DIRTY  = $$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 GO_LDFLAGS := "$(GO_LDFLAGS) -X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)"
 
-OS   = $(strip $(shell echo -n $${GOOS:-$$(uname | tr [[:upper:]] [[:lower:]])}))
-ARCH = $(strip $(shell echo -n $${GOARCH:-$$(A=$$(uname -m); if [ $$A = x86_64 ]; then A=amd64; elif [ $$A = aarch64 ]; then A=arm64; fi; echo $$A)}))
+ifdef GOOS
+	OS = $(GOOS)
+else
+	OS = $(shell uname | tr [[:upper:]] [[:lower:]])
+endif
+
+MACHINE = $(shell uname -m)
+ifdef GOARCH
+	ARCH = $(GOARCH)
+else ifeq ($(MACHINE),aarch64)
+	ARCH = arm64
+else ifeq ($(MACHINE),x86_64)
+	ARCH = amd64
+else
+	ARCH = $(MACHINE)
+endif
 
 PLATFORM ?= $(OS)/$(ARCH)
 DIST      = dist/$(PLATFORM)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ GIT_DIRTY  = $$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 GO_LDFLAGS := "$(GO_LDFLAGS) -X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)"
 
 OS   = $(strip $(shell echo -n $${GOOS:-$$(uname | tr [[:upper:]] [[:lower:]])}))
-ARCH = $(strip $(shell echo -n $${GOARCH:-$$(A=$$(uname -m); [ $$A = x86_64 ] && A=amd64 || [ $$A = aarch64 ] && A=arm64 ; echo $$A)}))
+ARCH = $(strip $(shell echo -n $${GOARCH:-$$(A=$$(uname -m); if [ $$A = x86_64 ]; then A=amd64; elif [ $$A = aarch64 ]; then A=arm64; fi; echo $$A)}))
 
 PLATFORM ?= $(OS)/$(ARCH)
 DIST      = dist/$(PLATFORM)


### PR DESCRIPTION
My `linux/amd64` was being erroneously detected as `linux/arm64`, due to some subshell `|| ... &&` confusion.

This makes it more makey, which both works and reads a little cleaner IMO.