### PR TITLE
[ui] Fix Non-interactive UI debug output

### DIFF
--- a/terminal/noninteractive.go
+++ b/terminal/noninteractive.go
@@ -49,7 +49,7 @@ func (ui *nonInteractiveUI) Output(msg string, raw ...any) {
 
 	switch style {
 	case DebugStyle:
-		msg = colorDebug.Sprintf("debug: %s\n" + msg)
+		msg = colorDebug.Sprintf("debug: %s\n", msg)
 	case HeaderStyle:
 		msg = "\n» " + msg
 	case ErrorStyle, ErrorBoldStyle:
@@ -63,9 +63,9 @@ func (ui *nonInteractiveUI) Output(msg string, raw ...any) {
 
 		return
 	case WarningStyle, WarningBoldStyle:
-		msg = colorWarning.Sprintf("warning: %s\n" + msg)
+		msg = colorWarning.Sprintf("warning: %s\n", msg)
 	case TraceStyle:
-		msg = colorTrace.Sprintf("trace: %s\n" + msg)
+		msg = colorTrace.Sprintf("trace: %s\n", msg)
 	case SuccessStyle, SuccessBoldStyle:
 
 	case InfoStyle:


### PR DESCRIPTION
The previous implementation used simple string concatenation. When updating for colorized output, the parameters were not properly converted to printf-style format strings and args.
