### PR TITLE
build: remove 32-bit builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         goos: ["linux"]
-        goarch: ["arm", "arm64", "amd64"]
+        goarch: ["arm64", "amd64"]
       fail-fast: true
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -184,7 +184,7 @@ jobs:
     strategy:
       matrix:
         goos: ["freebsd", "windows"]
-        goarch: ["amd64", "arm", "arm64"]
+        goarch: ["amd64", "arm64"]
         exclude:
           - goos: "windows"
             goarch: "arm"
@@ -221,7 +221,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        arch: ["arm", "arm64", "amd64"]
+        arch: ["arm64", "amd64"]
       fail-fast: true
     env:
       version: ${{ needs.get-product-version.outputs.product-version }}


### PR DESCRIPTION
We no longer intend to release 32-bit builds for any platform for Nomad ecosystem projects.

Ref: https://github.com/hashicorp/nomad/pull/23189
Ref: https://github.com/hashicorp/nomad-enterprise/issues/1053