### PR TITLE
build: use a generic mac runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
       - get-go-version
       - get-product-version
       - generate-ldflags
-    runs-on: macos-11
+    runs-on: macos
     strategy:
       matrix:
         goos: ["darwin"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
       - get-go-version
       - get-product-version
       - generate-ldflags
-    runs-on: macos
+    runs-on: macos-latest
     strategy:
       matrix:
         goos: ["darwin"]


### PR DESCRIPTION
`macos-11` runner has been deprecated. Changing to generic `macos-latest` runner instead since we don't depend on any macos version specific tooling and just want darwin os. 