### PR TITLE
Update README.md links to install sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Nomad Pack is used to:
 
 ## Installation
 
-To simplify the getting started experience, you can download a [precompiled binary][hashicorp_releases]
+To simplify the getting started experience, you can download a [precompiled binary][https://releases.hashicorp.com/nomad-pack/]
 and run it on your machine locally. After downloading Nomad Pack, unzip the package. Make sure that
 the nomad binary is available on your PATH. You can inspect the locations available on your path by
 running this command:
@@ -23,7 +23,7 @@ $ echo $PATH
 The output is a list of locations separated by colons. You can make Nomad Pack available by moving
 the binary to one of the listed locations, or by adding Nomad Pack's location to your PATH.
 
-Nomad Pack is also available as a [Docker image][docker_hub]. With Docker installed on your local
+Nomad Pack is also available as a [Docker image][https://hub.docker.com/r/hashicorp/nomad-pack/tags]. With Docker installed on your local
 machine, you can pull the latest image by running the following command:
 ```
 $ docker pull hashicorp/nomad-pack:0.0.1-techpreview1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Nomad Pack is used to:
 
 ## Installation
 
-To simplify the getting started experience, you can download a [precompiled binary][https://releases.hashicorp.com/nomad-pack/]
+To simplify the getting started experience, you can download a [precompiled binary](https://releases.hashicorp.com/nomad-pack/)
 and run it on your machine locally. After downloading Nomad Pack, unzip the package. Make sure that
 the nomad binary is available on your PATH. You can inspect the locations available on your path by
 running this command:
@@ -23,7 +23,7 @@ $ echo $PATH
 The output is a list of locations separated by colons. You can make Nomad Pack available by moving
 the binary to one of the listed locations, or by adding Nomad Pack's location to your PATH.
 
-Nomad Pack is also available as a [Docker image][https://hub.docker.com/r/hashicorp/nomad-pack/tags]. With Docker installed on your local
+Nomad Pack is also available as a [Docker image](https://hub.docker.com/r/hashicorp/nomad-pack/tags). With Docker installed on your local
 machine, you can pull the latest image by running the following command:
 ```
 $ docker pull hashicorp/nomad-pack:0.0.1-techpreview1
@@ -160,7 +160,3 @@ Pull Requests and feedback on both repositories are welcome!
 
 - [Introduction to Nomad Pack](https://learn.hashicorp.com/tutorials/nomad/nomad-pack-intro)
 - [Writing Custom Packs](https://learn.hashicorp.com/tutorials/nomad/nomad-pack-writing-packs)
-
-
-[hashicorp_releases]: (https://releases.hashicorp.com/nomad-pack/)
-[docker_hub]: (https://hub.docker.com/r/hashicorp/nomad-pack)


### PR DESCRIPTION
Fix links to Hashicorp Releases/DockerHub pages for nomad-pack

**Description**
Links were busted; now they're not.

**Reminders**

- [ ] Add `CHANGELOG.md` entry
