### PR TITLE
Replace path separators to slash on windows for local packs

### DIFF
--- a/internal/pkg/cache/pack.go
+++ b/internal/pkg/cache/pack.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/hashicorp/nomad-pack/sdk/pack"
 )
@@ -46,7 +48,11 @@ func (cfg *PackConfig) Init() {
 func (cfg *PackConfig) initFromDirectory(packPath string) {
 	// Keep the original user argument so that we can explain how to manage in output
 	cfg.SourcePath = cfg.Name
-	cfg.Path = packPath
+	if runtime.GOOS == "windows" {
+		cfg.Path = strings.Replace(packPath, "\\", "/", -1)
+	} else {
+		cfg.Path = packPath
+	}
 	cfg.Name = path.Base(cfg.Path)
 	cfg.Registry = DevRegistryName
 	cfg.Ref = DevRef


### PR DESCRIPTION
**Description**
Replace path separators to slash on windows for local packs. It is for fixing issue [577](https://github.com/hashicorp/nomad-pack/issues/577),

**Reminders**

- [ ] Add `CHANGELOG.md` entry
