### PR TITLE
Required variables: error on unset variables that have no default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## UNRELEASED
 
+BREAKING CHANGES:
+* variables: Pack variables without `default` values now cause an error when not provided,
+  unless the `--allow-unset-vars` flag or `NOMAD_PACK_ALLOW_UNSET_VARS` env var are set.
+  [[GH-697](https://github.com/hashicorp/nomad-pack/pull/697)
+
 ## 0.3.0 (April 15, 2025)
 
 BREAKING CHANGES:

--- a/fixtures/v1/test_registry/packs/my_alias_test/deps/child2/variables.hcl
+++ b/fixtures/v1/test_registry/packs/my_alias_test/deps/child2/variables.hcl
@@ -9,6 +9,7 @@ variable "job_name" {
 
 variable "complex" {
   description = "complex object for rendering"
+  default     = {}
   type = object({
     name    = string
     address = string

--- a/fixtures/v2/test_registry/packs/my_alias_test/deps/child2/variables.hcl
+++ b/fixtures/v2/test_registry/packs/my_alias_test/deps/child2/variables.hcl
@@ -9,6 +9,7 @@ variable "job_name" {
 
 variable "complex" {
   description = "complex object for rendering"
+  default     = {}
   type = object({
     name    = string
     address = string

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -63,6 +63,10 @@ type baseCommand struct {
 	// to variables defined in the pack should be ignored or produce an error
 	ignoreMissingVars bool
 
+	// allowUnsetVars suppresses errors from variables with nil values,
+	// i.e. those that are not set and have no default
+	allowUnsetVars bool
+
 	// autoApproved is true when the user supplies the --auto-approve or -y flag
 	autoApproved bool
 
@@ -242,6 +246,13 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 				Completion: complete.PredictOr(complete.PredictFiles("*.var"), complete.PredictFiles("*.hcl")),
 			},
 			Shorthand: "f",
+		})
+
+		f.BoolVar(&flag.BoolVar{
+			Name:    "allow-unset-vars",
+			Target:  &c.allowUnsetVars,
+			Default: false,
+			Usage:   `Suppress errors from unset variables without default values.`,
 		})
 
 		f.BoolVar(&flag.BoolVar{

--- a/internal/cli/generate_varfile.go
+++ b/internal/cli/generate_varfile.go
@@ -137,6 +137,11 @@ func (c *generateVarFileCommand) Run(args []string) int {
 		return 1
 	}
 
+	// we need to always allow unset vars here, else we'll get an error
+	// from required variables (those without defaults, which are "unset"
+	// until something sets them, like the var file we're trying to create!)
+	c.baseCommand.allowUnsetVars = true
+
 	packManager := generatePackManager(c.baseCommand, nil, c.packConfig)
 	renderOutput, err := renderVariableOverrideFile(packManager, c.ui, errorContext)
 	if err != nil {

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -43,6 +43,7 @@ func generatePackManager(c *baseCommand, client *api.Client, packCfg *cache.Pack
 		VariableFiles:   c.varFiles,
 		VariableCLIArgs: c.vars,
 		VariableEnvVars: c.envVars,
+		AllowUnsetVars:  c.allowUnsetVars,
 		UseParserV1:     c.useParserV1,
 	}
 	return manager.NewPackManager(&cfg, client)

--- a/internal/pkg/manager/manager.go
+++ b/internal/pkg/manager/manager.go
@@ -94,7 +94,7 @@ func (pm *PackManager) ProcessVariableFiles() (*parser.ParsedVariables, []*error
 		return nil, errors.HCLDiagsToWrappedUIContext(diags)
 	}
 
-	// Ensure required variables are set.
+	// Ensure required variables are set, unless --allow-unset-vars
 	if !pm.cfg.AllowUnsetVars {
 		for _, vars := range parsedVars.GetVars() {
 			for _, v := range vars {

--- a/internal/pkg/variable/decoder/decode.go
+++ b/internal/pkg/variable/decoder/decode.go
@@ -88,14 +88,6 @@ func DecodeVariableBlock(block *hcl.Block) (*variables.Variable, hcl.Diagnostics
 		v.Value = val
 	}
 
-	// A variable may be explicitly required. If it is, and is not set,
-	// it should produce an error.
-	if attr, exists := content.Attributes[schema.VaraibleAttributeRequired]; exists {
-		val, valDiags := attr.Expr.Value(nil)
-		diags = packdiags.SafeDiagnosticsExtend(diags, valDiags)
-		v.Required = val.True()
-	}
-
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/internal/pkg/variable/decoder/decode.go
+++ b/internal/pkg/variable/decoder/decode.go
@@ -88,6 +88,14 @@ func DecodeVariableBlock(block *hcl.Block) (*variables.Variable, hcl.Diagnostics
 		v.Value = val
 	}
 
+	// A variable may be explicitly required. If it is, and is not set,
+	// it should produce an error.
+	if attr, exists := content.Attributes[schema.VaraibleAttributeRequired]; exists {
+		val, valDiags := attr.Expr.Value(nil)
+		diags = packdiags.SafeDiagnosticsExtend(diags, valDiags)
+		v.Required = val.True()
+	}
+
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/internal/pkg/variable/schema/schema.go
+++ b/internal/pkg/variable/schema/schema.go
@@ -9,6 +9,7 @@ const (
 	VariableAttributeType        = "type"
 	VariableAttributeDefault     = "default"
 	VariableAttributeDescription = "description"
+	VaraibleAttributeRequired    = "required"
 )
 
 // VariableFileSchema defines the hcl.BlockHeaderSchema for each root variable
@@ -29,5 +30,6 @@ var VariableBlockSchema = &hcl.BodySchema{
 		{Name: VariableAttributeDescription},
 		{Name: VariableAttributeDefault},
 		{Name: VariableAttributeType},
+		{Name: VaraibleAttributeRequired},
 	},
 }

--- a/internal/pkg/variable/schema/schema.go
+++ b/internal/pkg/variable/schema/schema.go
@@ -9,7 +9,6 @@ const (
 	VariableAttributeType        = "type"
 	VariableAttributeDefault     = "default"
 	VariableAttributeDescription = "description"
-	VaraibleAttributeRequired    = "required"
 )
 
 // VariableFileSchema defines the hcl.BlockHeaderSchema for each root variable
@@ -30,6 +29,5 @@ var VariableBlockSchema = &hcl.BodySchema{
 		{Name: VariableAttributeDescription},
 		{Name: VariableAttributeDefault},
 		{Name: VariableAttributeType},
-		{Name: VaraibleAttributeRequired},
 	},
 }

--- a/sdk/pack/variables/variables.go
+++ b/sdk/pack/variables/variables.go
@@ -101,12 +101,9 @@ func (v *Variable) AsOverrideString(pID pack.ID) string {
 
 	if v.hasDefault {
 		out.WriteString(fmt.Sprintf("#   default: %s\n", printDefault(v.Default)))
-	}
-
-	if v.Value.Equals(v.Default).True() {
 		out.WriteString(fmt.Sprintf("#\n# %s=%s\n\n", rvn, printDefault(v.Default)))
 	} else {
-		out.WriteString(fmt.Sprintf("#\n%s=%s\n\n", rvn, printDefault(v.Value)))
+		out.WriteString(fmt.Sprintf("#\n# %s=«required»\n\n", rvn))
 	}
 
 	out.WriteString("\n")

--- a/sdk/pack/variables/variables.go
+++ b/sdk/pack/variables/variables.go
@@ -50,6 +50,8 @@ type Variable struct {
 	// value into a Go type value.
 	Value cty.Value
 
+	Required bool
+
 	// DeclRange is the position marker of the variable within the file it was
 	// read from. This is used for diagnostics.
 	DeclRange hcl.Range

--- a/sdk/pack/variables/variables.go
+++ b/sdk/pack/variables/variables.go
@@ -50,8 +50,6 @@ type Variable struct {
 	// value into a Go type value.
 	Value cty.Value
 
-	Required bool
-
 	// DeclRange is the position marker of the variable within the file it was
 	// read from. This is used for diagnostics.
 	DeclRange hcl.Range


### PR DESCRIPTION
**Description**

With Nomad jobs, a `variable` without a `default` will produce an error during `nomad job run` if the variable is not set.

This PR aligns `nomad-pack` commands (render, plan, run) with that convention, removing the need for checking this in template logic.

<details><summary>Example results</summary>

Given this `variables.hcl`:

```hcl
variable "foo" {
  description = "i really need a foo"
  type        = string
}
variable "bar" {
  description = "i can use a bar"
  default     = "salad"
}
variable "bazzes" {
  description = "one or more baz"
  type        = list(string)
}
variable "good_luck" {
  default = {}
  type = object({
    some : number
  })
}
variable "who_knows" {}
```

```shell
$ nomad-pack info ./test/var-default
...
Pack "var-default" Variables:
        - "foo" (string: required) - i really need a foo
        - "bazzes" (list of string: required) - one or more baz
        - "who_knows" (unknown: required) -
        - "bar" (string: optional) - i can use a bar
        - "good_luck" (object: optional) 
```

The same errors from `render` below also happen for `plan` and `run`.

I could not find an easy way to make these errors less verbose, but I could hunt for it some more if desired.

```
$ nomad-pack render ./test/var-default
! Failed To Process Pack

    Error:   missing required variable: "who_knows"
    Context:
        - Registry Name: <<local folder>>
        - Pack Name: var-default
        - Pack Ref: <<none>>
        - Pack Path: /home/dbennett/code/hashicorp/nomad-pack/test/var-default

! Failed To Process Pack

    Error:   missing required variable: "foo" (i really need a foo)
    Context:
        - Registry Name: <<local folder>>
        - Pack Name: var-default
        - Pack Ref: <<none>>
        - Pack Path: /home/dbennett/code/hashicorp/nomad-pack/test/var-default

! Failed To Process Pack

    Error:   missing required variable: "bazzes" (one or more baz)
    Context:
        - Registry Name: <<local folder>>
        - Pack Name: var-default
        - Pack Ref: <<none>>
        - Pack Path: /home/dbennett/code/hashicorp/nomad-pack/test/var-default
```

```shell
$ nomad-pack generate var-file ./test/var-default
# variable "bar"
#   description: i can use a bar
#   default: "salad"
#
# bar="salad"


# variable "bazzes"
#   description: one or more baz
#   type: list(string)
#
# bazzes=«required»


# variable "foo"
#   description: i really need a foo
#   type: string
#
# foo=«required»


# variable "good_luck"
#   type: object({some = number})
#   default: {}
#
# good_luck={}


# variable "who_knows"
#
# who_knows=«required»



```

</details>

Since this is a breaking change, a CLI caller can fall back to the old logic with the new `--allow-unset-vars` flag or the `NOMAD_PACK_ALLOW_UNSET_VARS` environment variable.

Closes #695


**Reminders**

- [x] Add `CHANGELOG.md` entry
