### PR TITLE
Inject metadata into HCL templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 * build: Update Go version to 1.24.6 [[GH-719](https://github.com/hashicorp/nomad-pack/pull/719)]
 * build: Update go-getter version to 1.7.9 [[GH-719](https://github.com/hashicorp/nomad-pack/pull/719)] to resolve CVE-2025-8959. Nomad Client Agents with Landlock support are not impacted by this vulnerability.
+* pack: Inject pack metadata into HCL jobspec when running the job [[GH-737](https://github.com/hashicorp/nomad-pack/pull/737)]
 
 ## 0.4.0 (July 9, 2025)
 

--- a/internal/runner/job/job.go
+++ b/internal/runner/job/job.go
@@ -80,10 +80,6 @@ func (r *Runner) CanonicalizeTemplates() []*errors.WrappedUIContext {
 		}
 	}
 
-	for _, jobSpec := range r.parsedTemplates {
-		r.setJobMeta(jobSpec.Job())
-	}
-
 	return nil
 }
 

--- a/internal/runner/job/job.go
+++ b/internal/runner/job/job.go
@@ -174,7 +174,9 @@ func (r *Runner) SetRunnerConfig(cfg *runner.Config) { r.runnerCfg = cfg }
 // SetTemplates satisfies the SetTemplates function of the runner.Runner
 // interface.
 func (r *Runner) SetTemplates(templates map[string]string) {
-	r.rawTemplates = templates
+	for n, tpl := range templates {
+		r.rawTemplates[n] = r.setHCLMeta(tpl)
+	}
 }
 
 // determines next launch time and outputs to terminal

--- a/internal/runner/job/metadata.go
+++ b/internal/runner/job/metadata.go
@@ -3,7 +3,15 @@
 
 package job
 
-import "github.com/hashicorp/nomad/api"
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/jobspec2/hclutil"
+	"github.com/zclconf/go-cty/cty"
+)
 
 const (
 	PackPathKey           = "pack.path"
@@ -33,4 +41,103 @@ func (r *Runner) setJobMeta(job *api.Job) {
 
 	// Replace the job metadata with our modified ref.
 	job.Meta = jobMeta
+}
+
+// setHCLMeta sets the nomad-pack metadata in the HCL job definition, merging
+// the values with any existing meta block or attribute. If the parsing fails,
+// or the HCL is invalid, the original job is returned unmodified so that the
+// errors can be caught later during job parsing.
+func (r *Runner) setHCLMeta(job string) string {
+	file, diags := hclsyntax.ParseConfig([]byte(job), "", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return job
+	}
+	content, diags := file.Body.Content(&hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{
+			{Type: "job", LabelNames: []string{""}},
+		},
+	})
+	if diags.HasErrors() {
+		return job
+	}
+
+	result := map[string]cty.Value{}
+	deleteBlock := false
+	for _, b := range content.Blocks {
+		cont, _, diags := b.Body.PartialContent(&hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{Name: "meta", Required: false},
+			},
+			Blocks: []hcl.BlockHeaderSchema{
+				{Type: "meta"},
+			},
+		})
+		if diags.HasErrors() {
+			return job
+		}
+
+		if len(cont.Blocks) == 0 && len(cont.Attributes) == 0 {
+			continue
+		}
+
+		// If an meta attribute is defined, we will merge the values with the
+		// nomad-pack ones.  If a meta block exists but no attribute, we need to
+		// extract the value from the block for merging.  If both are defined by
+		// the user, the attribute takes precedence and the block is ignored.
+		// This is invalid HCL and will be caught during the job parsing, but
+		// prevents deletion of user defined values.
+		if len(cont.Attributes) == 0 && len(cont.Blocks) > 0 {
+			deleteBlock = true
+
+			b := hclutil.BlocksAsAttrs(b.Body)
+			attrs, diags := b.JustAttributes()
+			if diags.HasErrors() {
+				return job
+			}
+			r := []map[string]cty.Value{}
+			diag := gohcl.DecodeExpression(attrs["meta"].Expr, nil, &r)
+			if diag.HasErrors() {
+				return job
+			}
+			result = r[0]
+		} else {
+			metaExpr := cont.Attributes["meta"].Expr
+			diag := gohcl.DecodeExpression(metaExpr, nil, &result)
+			if diag.HasErrors() {
+				return job
+			}
+		}
+	}
+
+	wFile, _ := hclwrite.ParseConfig([]byte(job), "", hcl.Pos{Line: 1, Column: 1})
+	rootBody := wFile.Body()
+
+	var jobBlock *hclwrite.Block
+	for _, b := range rootBody.Blocks() {
+		if b.Type() == "job" {
+			jobBlock = b
+			break
+		}
+	}
+
+	if jobBlock == nil {
+		return job
+	}
+	jobBody := jobBlock.Body()
+
+	result[PackPathKey] = cty.StringVal(r.runnerCfg.PathPath)
+	result[PackNameKey] = cty.StringVal(r.runnerCfg.PackName)
+	result[PackRegistryKey] = cty.StringVal(r.runnerCfg.RegistryName)
+	result[PackDeploymentNameKey] = cty.StringVal(r.runnerCfg.DeploymentName)
+	result[PackJobKey] = cty.StringVal(jobBlock.Labels()[0])
+	result[PackRefKey] = cty.StringVal(r.runnerCfg.PackRef)
+
+	jobBody.SetAttributeValue("meta", cty.ObjectVal(result))
+
+	// If we extracted the meta data from a block, delete it so we don't return invalid HCL
+	if deleteBlock {
+		jobBody.RemoveBlock(jobBody.FirstMatchingBlock("meta", nil))
+	}
+
+	return string(wFile.Bytes())
 }

--- a/internal/runner/job/metadata.go
+++ b/internal/runner/job/metadata.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/jobspec2/hclutil"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -21,27 +20,6 @@ const (
 	PackJobKey            = "pack.job"
 	PackRefKey            = "pack.version"
 )
-
-// add metadata to the job for in cluster querying and management
-func (r *Runner) setJobMeta(job *api.Job) {
-	jobMeta := make(map[string]string)
-
-	// If current job meta isn't nil, use that instead
-	if job.Meta != nil {
-		jobMeta = job.Meta
-	}
-
-	// Add the Nomad Pack custom metadata.
-	jobMeta[PackPathKey] = r.runnerCfg.PathPath
-	jobMeta[PackNameKey] = r.runnerCfg.PackName
-	jobMeta[PackRegistryKey] = r.runnerCfg.RegistryName
-	jobMeta[PackDeploymentNameKey] = r.runnerCfg.DeploymentName
-	jobMeta[PackJobKey] = *job.Name
-	jobMeta[PackRefKey] = r.runnerCfg.PackRef
-
-	// Replace the job metadata with our modified ref.
-	job.Meta = jobMeta
-}
 
 // setHCLMeta sets the nomad-pack metadata in the HCL job definition, merging
 // the values with any existing meta block or attribute. If the parsing fails,

--- a/internal/runner/job/metadata_test.go
+++ b/internal/runner/job/metadata_test.go
@@ -6,55 +6,10 @@ package job
 import (
 	"testing"
 
-	"github.com/hashicorp/nomad/api"
 	"github.com/shoenig/test/must"
 
-	"github.com/hashicorp/nomad-pack/internal/pkg/helper/pointer"
 	"github.com/hashicorp/nomad-pack/internal/runner"
 )
-
-func TestDeployer_setJobMeta(t *testing.T) {
-	testCases := []struct {
-		inputRunner       *Runner
-		inputJob          *api.Job
-		expectedOutputJob *api.Job
-		name              string
-	}{
-		{
-			inputRunner: &Runner{
-				runnerCfg: &runner.Config{
-					PackName:       "foobar",
-					PathPath:       "/opt/src/foobar",
-					PackRef:        "123456",
-					DeploymentName: "foobar@123456",
-					RegistryName:   "default",
-				},
-			},
-			inputJob: &api.Job{
-				Name: pointer.Of("foobar"),
-			},
-			expectedOutputJob: &api.Job{
-				Name: pointer.Of("foobar"),
-				Meta: map[string]string{
-					PackPathKey:           "/opt/src/foobar",
-					PackNameKey:           "foobar",
-					PackRegistryKey:       "default",
-					PackDeploymentNameKey: "foobar@123456",
-					PackJobKey:            "foobar",
-					PackRefKey:            "123456",
-				},
-			},
-			name: "nil input meta",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tc.inputRunner.setJobMeta(tc.inputJob)
-			must.Eq(t, tc.expectedOutputJob, tc.inputJob)
-		})
-	}
-}
 
 func TestDeployer_setHCLMeta(t *testing.T) {
 	defaultConfig := &runner.Config{

--- a/internal/runner/job/metadata_test.go
+++ b/internal/runner/job/metadata_test.go
@@ -55,3 +55,164 @@ func TestDeployer_setJobMeta(t *testing.T) {
 		})
 	}
 }
+
+func TestDeployer_setHCLMeta(t *testing.T) {
+	defaultConfig := &runner.Config{
+		PackName:       "foobar",
+		PathPath:       "/opt/src/foobar",
+		PackRef:        "123456",
+		DeploymentName: "foobar@123456",
+		RegistryName:   "default",
+	}
+	testCases := []struct {
+		desc        string
+		inputRunner *Runner
+		inputJob    string
+		expectedJob string
+	}{
+		{
+			desc: "empty job returns empty job",
+			inputRunner: &Runner{
+				runnerCfg: defaultConfig,
+			},
+			inputJob:    "",
+			expectedJob: "",
+		},
+		{
+			desc: "job without meta defined gets meta attribute added",
+			inputRunner: &Runner{
+				runnerCfg: defaultConfig,
+			},
+			inputJob: "job \"basic\" {}",
+			expectedJob: `job "basic" { meta = {
+  "pack.deployment_name" = "foobar@123456"
+  "pack.job"             = "basic"
+  "pack.name"            = "foobar"
+  "pack.path"            = "/opt/src/foobar"
+  "pack.registry"        = "default"
+  "pack.version"         = "123456"
+  }
+}`,
+		},
+		{
+			desc: "existing meta attribute is merged with nomad-pack metadata",
+			inputRunner: &Runner{
+				runnerCfg: defaultConfig,
+			},
+			inputJob: "job \"foobar\" { meta = { \"other.stuff\" = \"foobar\" \n \"thing\" = \"baz\" } }",
+			expectedJob: `job "foobar" { meta = {
+  "other.stuff"          = "foobar"
+  "pack.deployment_name" = "foobar@123456"
+  "pack.job"             = "foobar"
+  "pack.name"            = "foobar"
+  "pack.path"            = "/opt/src/foobar"
+  "pack.registry"        = "default"
+  "pack.version"         = "123456"
+  thing                  = "baz"
+} }`,
+		},
+		{
+			desc: "existing meta block is merged with nomad-pack metadata",
+			inputRunner: &Runner{
+				runnerCfg: defaultConfig,
+			},
+			inputJob: "job \"foobar\" {\n meta {\n other = \"foobar\" \n thing = \"baz\" \n}\n }",
+			expectedJob: `job "foobar" {
+  meta = {
+    other                  = "foobar"
+    "pack.deployment_name" = "foobar@123456"
+    "pack.job"             = "foobar"
+    "pack.name"            = "foobar"
+    "pack.path"            = "/opt/src/foobar"
+    "pack.registry"        = "default"
+    "pack.version"         = "123456"
+    thing                  = "baz"
+  }
+}`,
+		},
+		{
+			desc: "nested meta block is untouched",
+			inputRunner: &Runner{
+				runnerCfg: defaultConfig,
+			},
+			inputJob: "job \"foobar\" {\n task \"server\" {\n meta {\n other = \"foobar\" \n thing = \"baz\" \n}\n }\n }",
+			expectedJob: `job "foobar" {
+  task "server" {
+    meta {
+      other = "foobar"
+      thing = "baz"
+    }
+  }
+  meta = {
+    "pack.deployment_name" = "foobar@123456"
+    "pack.job"             = "foobar"
+    "pack.name"            = "foobar"
+    "pack.path"            = "/opt/src/foobar"
+    "pack.registry"        = "default"
+    "pack.version"         = "123456"
+  }
+}`,
+		},
+		{
+			desc: "multiple meta blocks returns one merged meta attribute and one block ignored, as invalid HCL",
+			inputRunner: &Runner{
+				runnerCfg: defaultConfig,
+			},
+			inputJob: "job \"foobar\" {\n meta {\n other = \"foobar\" \n thing = \"baz\" \n}\n meta {\n other2 = \"foobar2\" \n thing2 = \"baz2\" \n}\n }",
+			expectedJob: `job "foobar" {
+  meta {
+    other2 = "foobar2"
+    thing2 = "baz2"
+  }
+  meta = {
+    other                  = "foobar"
+    "pack.deployment_name" = "foobar@123456"
+    "pack.job"             = "foobar"
+    "pack.name"            = "foobar"
+    "pack.path"            = "/opt/src/foobar"
+    "pack.registry"        = "default"
+    "pack.version"         = "123456"
+    thing                  = "baz"
+  }
+}`,
+		},
+		{
+			desc: "multiple meta attributes returns unchanged job, as invalid HCL",
+			inputRunner: &Runner{
+				runnerCfg: defaultConfig,
+			},
+			inputJob:    "job \"foobar\" {\n meta = {\n other = \"foobar\" \n thing = \"baz\" \n}\n meta = {\n other2 = \"foobar2\" \n thing2 = \"baz2\" \n}\n }",
+			expectedJob: "job \"foobar\" {\n meta = {\n other = \"foobar\" \n thing = \"baz\" \n}\n meta = {\n other2 = \"foobar2\" \n thing2 = \"baz2\" \n}\n }",
+		},
+		{
+			desc: "defined meta attribute & block returns merged meta attribute, and the block ignored, as invalid HCL",
+			inputRunner: &Runner{
+				runnerCfg: defaultConfig,
+			},
+			inputJob: "job \"foobar\" {\n meta {\n other = \"foobar\" \n thing = \"baz\" \n}\n meta = {\n \"other.2\" = \"foobar2\" \n \"thing.2\" = \"baz2\" \n}\n }",
+			expectedJob: `job "foobar" {
+  meta {
+    other = "foobar"
+    thing = "baz"
+  }
+  meta = {
+    "other.2"              = "foobar2"
+    "pack.deployment_name" = "foobar@123456"
+    "pack.job"             = "foobar"
+    "pack.name"            = "foobar"
+    "pack.path"            = "/opt/src/foobar"
+    "pack.registry"        = "default"
+    "pack.version"         = "123456"
+    "thing.2"              = "baz2"
+  }
+}`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := tc.inputRunner.setHCLMeta(tc.inputJob)
+			must.Eq(t, tc.expectedJob, result)
+		})
+	}
+
+}


### PR DESCRIPTION
**Description**
Currently, nomad-pack injects metadata about the pack into the json definition of the job and not the HCL. When a pack job is managed outside of nomad-pack, like in the UI, the job loses its reference to the pack and is unable to be managed with nomad-pack until the job is completely removed. 

This change takes the rendered HCL and injects the metadata into the job/meta block, instead of just the json. It will merge with the defined meta attribute or block if it exists. In the case that it cannot successfully parse the HCL, the original job will be returned. If the job is has multiple meta attributes/blocks defined, it will merge with one and return the other untouched. This is invalid, but will be caught in the next step of the process, which is parsing the templates in nomad. The approach is to inject these values with as little change to the underlying job as possible, and allow any existing invalid HCL to still be passed through and caught in nomad during the parsing step. 

**Reminders**

- [x] Add `CHANGELOG.md` entry


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

