### PR TITLE
test: drop testify for shoenig/test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,10 +37,9 @@ require (
 	github.com/olekukonko/tablewriter v1.0.9
 	github.com/posener/complete v1.2.3
 	github.com/ryanuber/columnize v2.1.2+incompatible
-	github.com/shoenig/test v1.12.1
+	github.com/shoenig/test v1.12.2
 	github.com/spf13/afero v1.14.0
 	github.com/spf13/pflag v1.0.10
-	github.com/stretchr/testify v1.10.0
 	github.com/zclconf/go-cty v1.17.0
 	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6
 	golang.org/x/term v0.34.0
@@ -313,6 +312,7 @@ require (
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	github.com/tencentcloud/tencentcloud-sdk-go v3.0.233+incompatible // indirect
 	github.com/tj/go-spin v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1636,8 +1636,8 @@ github.com/shoenig/go-landlock v1.2.2 h1:cIEdRXuHkzapHJGMBM+GpWdDlZU5MSJWaxxCri7
 github.com/shoenig/go-landlock v1.2.2/go.mod h1:MLSBZBAUvZh/4flRg+LysngJvz/0OdtpWTEAWuJViSY=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
-github.com/shoenig/test v1.12.1 h1:mLHfnMv7gmhhP44WrvT+nKSxKkPDiNkIuHGdIGI9RLU=
-github.com/shoenig/test v1.12.1/go.mod h1:UxJ6u/x2v/TNs/LoLxBNJRV9DiwBBKYxXSyczsBHFoI=
+github.com/shoenig/test v1.12.2 h1:ZVT8NeIUwGWpZcKaepPmFMoNQ3sVpxvqUh/MAqwFiJI=
+github.com/shoenig/test v1.12.2/go.mod h1:UxJ6u/x2v/TNs/LoLxBNJRV9DiwBBKYxXSyczsBHFoI=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/internal/pkg/errors/packdiags/packdiags_test.go
+++ b/internal/pkg/errors/packdiags/packdiags_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/shoenig/test/must"
-	"github.com/stretchr/testify/require"
 )
 
 var testRange = hcl.Range{
@@ -94,40 +93,40 @@ func TestPackDiag_SafeDiagnosticsAppend(t *testing.T) {
 	var diag *hcl.Diagnostic
 
 	// HasErrors on hcl.Diagnostics is not nil-safe
-	require.Panicsf(t, func() {
+	must.Panic(t, func() {
 		d1 := diags.Append(diag)
 		d1.HasErrors()
-	}, "should have panicked")
+	}, must.Sprint("should have panicked"))
 
 	// Using SafeDiagnosticsAppend should prevent the panic
-	require.NotPanicsf(t, func() {
+	must.NotPanic(t, func() {
 		d2 := SafeDiagnosticsAppend(diags, diag)
 		d2.HasErrors()
-	}, "should not have panicked")
+	}, must.Sprint("should not have panicked"))
 
 	// Verify that the original case still panics
-	require.Panicsf(t, func() {
+	must.Panic(t, func() {
 		d1 := diags.Append(diag)
 		d1.HasErrors()
-	}, "should have panicked")
+	}, must.Sprint("should have panicked"))
 }
 
 func TestPackDiag_SafeDiagnosticsExtend(t *testing.T) {
 	var diag *hcl.Diagnostic
 	diags := hcl.Diagnostics{}
 	diags2 := hcl.Diagnostics{diag}
-	require.Panicsf(t, func() {
+	must.Panic(t, func() {
 		d := diags.Extend(diags2)
 		d.HasErrors()
-	}, "should have panicked")
+	}, must.Sprint("should have panicked"))
 
-	require.NotPanicsf(t, func() {
+	must.NotPanic(t, func() {
 		d := SafeDiagnosticsExtend(diags, diags2)
 		d.HasErrors()
-	}, "should not have panicked")
+	}, must.Sprint("should not have panicked"))
 
-	require.Panicsf(t, func() {
+	must.Panic(t, func() {
 		d := diags.Extend(diags2)
 		d.HasErrors()
-	}, "should have still panicked")
+	}, must.Sprint("should have still panicked"))
 }


### PR DESCRIPTION
https://github.com/shoenig/test/pull/179 adds `must.Panic` and `must.NotPanic` and ~must (heh) be merged and released before we should move forward with this.~ has been released in `v1.12.2`.

Closes #727