### PR TITLE
ci: Update makefile golangci-lint to v2 to align with GHA CI.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -65,7 +65,7 @@ tools: lint-deps test-deps  # Install all tools
 .PHONY: lint-deps
 lint-deps: ## Install linter dependencies
 	@echo "==> Updating linter dependencies..."
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.0
 	go install github.com/hashicorp/hcl/v2/cmd/hclfmt@d0c4fa8b0bbc2e4eeccd1ed2a32c2089ed8c5cf1
 
 .PHONY: test-deps

--- a/go.mod
+++ b/go.mod
@@ -237,7 +237,7 @@ require (
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/hpcloud/tail v1.0.1-0.20170814160653-37f427138745 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
-	github.com/ishidawataru/sctp v0.0.0-20250303034628-ecf9ed6df987 // indirect
+	github.com/ishidawataru/sctp v0.0.0-20250829011129-4b890084db30 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1331,8 +1331,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/ishidawataru/sctp v0.0.0-20250303034628-ecf9ed6df987 h1:pf7+hef676aOjZ9XcvEw5qhdTPPaFVfavOQS+IntVOY=
-github.com/ishidawataru/sctp v0.0.0-20250303034628-ecf9ed6df987/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
+github.com/ishidawataru/sctp v0.0.0-20250829011129-4b890084db30 h1:SF8DGX8bGAXMAvxtJvFFy2KIAPwxIEDP3XpzZVhz0i4=
+github.com/ishidawataru/sctp v0.0.0-20250829011129-4b890084db30/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.3.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=


### PR DESCRIPTION
closes #759 
related https://github.com/hashicorp/nomad-pack/pull/660

The linked PR update golangci-lint to v2 but did not alter the makefile dependency to match. This change makes that change and updates a dependency which I found was needed locally. Without the dependency change I found lint would fail with the following error:
```console
internal/cli/testhelper/testhelper.go:14:2: could not import github.com/hashicorp/nomad/command/agent (/Users/jrasell/go/pkg/mod/github.com/hashicorp/nomad@v1.10.5/command/agent/agent.go:24:2: could not import github.com/hashicorp/nomad/client (/Users/jrasell/go/pkg/mod/github.com/hashicorp/nomad@v1.10.5/client/client.go:25:2: could not import github.com/hashicorp/nomad/client/allocrunner (/Users/jrasell/go/pkg/mod/github.com/hashicorp/nomad@v1.10.5/client/allocrunner/alloc_runner.go:17:2: could not import github.com/hashicorp/nomad/client/allocrunner/hookstats (/Users/jrasell/go/pkg/mod/github.com/hashicorp/nomad@v1.10.5/client/allocrunner/hookstats/hookstats.go:10:2: could not import github.com/hashicorp/nomad/client/allocrunner/interfaces (/Users/jrasell/go/pkg/mod/github.com/hashicorp/nomad@v1.10.5/client/allocrunner/interfaces/runner.go:12:2: could not import github.com/hashicorp/nomad/client/pluginmanager/drivermanager (/Users/jrasell/go/pkg/mod/github.com/hashicorp/nomad@v1.10.5/client/pluginmanager/drivermanager/testing.go:15:2: could not import github.com/hashicorp/nomad/helper/pluginutils/catalog (/Users/jrasell/go/pkg/mod/github.com/hashicorp/nomad@v1.10.5/helper/pluginutils/catalog/register.go:7:2: could not import github.com/hashicorp/nomad/drivers/docker (/Users/jrasell/go/pkg/mod/github.com/hashicorp/nomad@v1.10.5/drivers/docker/driver.go:44:2: could not import github.com/hashicorp/nomad/drivers/shared/resolvconf (/Users/jrasell/go/pkg/mod/github.com/hashicorp/nomad@v1.10.5/drivers/shared/resolvconf/mount.go:12:2: could not import github.com/docker/docker/libnetwork/types (/Users/jrasell/go/pkg/mod/github.com/docker/docker@v28.4.0+incompatible/libnetwork/types/types.go:12:2: could not import github.com/ishidawataru/sctp (-: # github.com/ishidawataru/sctp
../../../go/pkg/mod/github.com/ishidawataru/sctp@v0.0.0-20250303034628-ecf9ed6df987/sctp.go:734:67: too many arguments in call to listenSCTPExtConfig
	have (string, *SCTPAddr, InitMsg, func(network string, address string, c syscall.RawConn) error, NotificationHandler)
	want (string, *SCTPAddr, InitMsg, func(network string, address string, c syscall.RawConn) error)
../../../go/pkg/mod/github.com/ishidawataru/sctp@v0.0.0-20250303034628-ecf9ed6df987/sctp.go:738:72: too many arguments in call to dialSCTPExtConfig
	have (string, *SCTPAddr, *SCTPAddr, InitMsg, func(network string, address string, c syscall.RawConn) error, NotificationHandler)
	want (string, *SCTPAddr, *SCTPAddr, InitMsg, func(network string, address string, c syscall.RawConn) error)))))))))))) (typecheck)
	"github.com/hashicorp/nomad/command/agent"
```  