### PR TITLE
runner: fix panic in deploy override check

### DIFF
--- a/internal/runner/job/conflict.go
+++ b/internal/runner/job/conflict.go
@@ -36,8 +36,7 @@ func (r *Runner) CheckForConflicts(errCtx *errors.UIErrorContext) []*errors.Wrap
 // supplied job is found. If the job is found, we confirm if it belongs to this
 // Nomad Pack deployment. In the event it doesn't this will result in an error.
 func (r *Runner) checkForConflict(jobName string) error {
-	deploy_override := r.cfg.RunConfig.DeployOverride || r.cfg.PlanConfig.DeployOverride
-	if deploy_override {
+	if r.hasDeployOverride() {
 		return nil
 	}
 
@@ -75,6 +74,19 @@ func (r *Runner) checkForConflict(jobName string) error {
 	}
 
 	return nil
+}
+
+func (r *Runner) hasDeployOverride() bool {
+	if r.cfg == nil {
+		return false
+	}
+	if r.cfg.RunConfig != nil {
+		return r.cfg.RunConfig.DeployOverride
+	}
+	if r.cfg.PlanConfig != nil {
+		return r.cfg.PlanConfig.DeployOverride
+	}
+	return false
 }
 
 type ErrExistsNonPack struct {


### PR DESCRIPTION
In #757 we added an `-override-deploy` flag, but the check for this flag has a panicking bug because the plan config is nil when the run config is non-nil and vice-versa.

Ref: https://github.com/hashicorp/nomad-pack/pull/757


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

