### PR TITLE
CI: run tests on PRs

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,5 +1,13 @@
 name: Go Tests
-on: [push]
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   test:
     name: Test
@@ -23,7 +31,7 @@ jobs:
           wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
           sudo apt update && sudo apt -y install nomad
-          
+
       # Run tests with nice formatting. Save the original log in /tmp/gotest.log
       - name: Run tests
         run: |


### PR DESCRIPTION
The test workflow doesn't run on PRs, which is what allowed bugs like the one described in #786 to slip through to main.

Ref: https://github.com/hashicorp/nomad-pack/pull/786



<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

