### PR TITLE
handle packs of mixed casing

### DIFF
--- a/internal/pkg/caching/add.go
+++ b/internal/pkg/caching/add.go
@@ -344,10 +344,11 @@ func (opts *AddOpts) PackPath() string {
 
 // PackDir fulfills the cacheOperationProvider interface for AddOpts
 func (opts *AddOpts) PackDir() string {
+	escaped := EscapePackName(opts.PackName)
 	if opts.Ref != "" {
-		return AppendRef(opts.PackName, opts.Ref)
+		return AppendRef(escaped, opts.Ref)
 	}
-	return opts.PackName
+	return escaped
 }
 
 // AtRef fulfills the cacheOperationProvider interface for AddOpts

--- a/internal/pkg/caching/cache.go
+++ b/internal/pkg/caching/cache.go
@@ -214,6 +214,57 @@ func AppendRef(name, ref string) string {
 	return fmt.Sprintf("%s@%s", name, ref)
 }
 
+// EscapePackName escapes a pack name for safe use as a filesystem path
+// component. Each uppercase letter is replaced by an exclamation mark followed
+// by the lowercase equivalent, mirroring the Go module cache convention.
+// This ensures producing distinct directory names even on case-insensitive
+// filesystems
+//
+// Examples:
+//
+//	"donutdns"  -> "donutdns"    (no uppercase, unchanged)
+//	"donutDNS"  -> "donut!d!n!s"
+//	"MyPack"    -> "!my!pack"
+func EscapePackName(name string) string {
+	var buf strings.Builder
+	for _, r := range name {
+		if r >= 'A' && r <= 'Z' {
+			buf.WriteByte('!')
+			buf.WriteRune(r - 'A' + 'a')
+		} else {
+			buf.WriteRune(r)
+		}
+	}
+
+	return buf.String()
+}
+
+// UnescapePackName reverses the escaping applied by EscapePackName. It returns
+// an error when the escaped string is malformed (e.g. a trailing '!' or an
+// '!' followed by a non-lowercase-ASCII letter).
+func UnescapePackName(escaped string) (string, error) {
+	var buf strings.Builder
+
+	runes := []rune(escaped)
+	for i := 0; i < len(runes); i++ {
+		if runes[i] == '!' {
+			if i+1 >= len(runes) {
+				return "", fmt.Errorf("invalid escaped pack name %q: trailing '!'", escaped)
+			}
+			r := runes[i+1]
+			if r < 'a' || r > 'z' {
+				return "", fmt.Errorf("invalid escaped pack name %q: '!' followed by non-lowercase-ASCII %q", escaped, r)
+			}
+			buf.WriteRune(r - 'a' + 'A')
+			i++
+		} else {
+			buf.WriteRune(runes[i])
+		}
+	}
+
+	return buf.String(), nil
+}
+
 // This is a utility method to parse the ref from the pack entry
 func refFromPackEntry(packEntry os.DirEntry) (ref string) {
 	ref = "unknown"
@@ -224,6 +275,25 @@ func refFromPackEntry(packEntry os.DirEntry) (ref string) {
 	}
 
 	return
+}
+
+// nameFromPackEntry extracts and unescapes the pack name from a directory entry.
+// Directory entry names follow the format `<escaped-pack-name>@<ref>`.
+// The returned name is the canonical (unescaped) pack name suitable for display.
+func nameFromPackEntry(packEntry os.DirEntry) string {
+	name := packEntry.Name()
+	// Strip the @ref suffix when present.
+	if idx := strings.LastIndex(name, "@"); idx != -1 {
+		name = name[:idx]
+	}
+
+	unescaped, err := UnescapePackName(name)
+	if err != nil {
+		// Fall back to the escaped form rather than surfacing a parse error.
+		return name
+	}
+
+	return unescaped
 }
 
 // getGitHeadRef is a helper method that takes a directory which is a git

--- a/internal/pkg/caching/cache_test.go
+++ b/internal/pkg/caching/cache_test.go
@@ -754,3 +754,106 @@ func hasFile(name string) func(d fs.DirEntry) bool {
 		return d.Type().IsRegular() && d.Name() == name
 	}
 }
+
+// Tests for EscapePackName / UnescapePackName
+func TestEscapePackName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		// All lowercase – must be unchanged.
+		{"donutdns", "donutdns"},
+		// Uppercase letters must be escaped with '!' + lowercase.
+		{"donutDNS", "donut!d!n!s"},
+		{"MyPack", "!my!pack"},
+		// Mixed numbers/underscore – unchanged.
+		{"my_pack_1", "my_pack_1"},
+		// All uppercase.
+		{"ABC", "!a!b!c"},
+		// Empty string.
+		{"", ""},
+	}
+	for _, testCase := range cases {
+		tc := testCase
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			must.Eq(t, tc.expected, EscapePackName(tc.input))
+		})
+	}
+}
+
+func TestUnescapePackName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{"donutdns", "donutdns", false},
+		{"donut!d!n!s", "donutDNS", false},
+		{"!my!pack", "MyPack", false},
+		{"!a!b!c", "ABC", false},
+		{"my_pack_1", "my_pack_1", false},
+		{"", "", false},
+		// Error cases.
+		{"trailing!", "", true},
+		{"bad!1", "", true},
+		{"bad!Z", "", true},
+	}
+	for _, testCase := range cases {
+		tc := testCase
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			got, err := UnescapePackName(tc.input)
+			if tc.wantErr {
+				must.Error(t, err)
+				return
+			}
+			must.NoError(t, err)
+			must.Eq(t, tc.expected, got)
+		})
+	}
+}
+
+func TestEscapeUnescapeRoundTrip(t *testing.T) {
+	t.Parallel()
+	names := []string{
+		"donutdns",
+		"donutDNS",
+		"MyPack",
+		"ABC",
+		"simple_raw_exec",
+		"SimpleRawExec",
+		"",
+	}
+	for _, n := range names {
+		name := n
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, err := UnescapePackName(EscapePackName(name))
+			must.NoError(t, err)
+			must.Eq(t, name, got)
+		})
+	}
+}
+
+// TestPackDirEscaping ensures that two pack names differing only in casing
+// produce distinct directory names on disk.
+func TestPackDirEscaping(t *testing.T) {
+	t.Parallel()
+
+	lower := &AddOpts{PackName: "donutdns", Ref: "latest"}
+	upper := &AddOpts{PackName: "donutDNS", Ref: "latest"}
+
+	must.NotEq(t, lower.PackDir(), upper.PackDir(),
+		must.Sprint("PackDir must differ for names that differ only in casing"))
+	must.Eq(t, "donutdns@latest", lower.PackDir())
+	must.Eq(t, "donut!d!n!s@latest", upper.PackDir())
+
+	// GetOpts and DeleteOpts must produce the same escaped dirs.
+	must.Eq(t, lower.PackDir(), (&GetOpts{PackName: "donutdns", Ref: "latest"}).PackDir())
+	must.Eq(t, upper.PackDir(), (&GetOpts{PackName: "donutDNS", Ref: "latest"}).PackDir())
+	must.Eq(t, lower.PackDir(), (&DeleteOpts{PackName: "donutdns", Ref: "latest"}).PackDir())
+	must.Eq(t, upper.PackDir(), (&DeleteOpts{PackName: "donutDNS", Ref: "latest"}).PackDir())
+}

--- a/internal/pkg/caching/delete.go
+++ b/internal/pkg/caching/delete.go
@@ -127,10 +127,11 @@ func (opts *DeleteOpts) PackPath() (packPath string) {
 
 // PackDir fulfills the cacheOperationProvider interface for DeleteOpts
 func (opts *DeleteOpts) PackDir() string {
+	escaped := EscapePackName(opts.PackName)
 	if opts.Ref != "" {
-		return AppendRef(opts.PackName, opts.Ref)
+		return AppendRef(escaped, opts.Ref)
 	}
-	return opts.PackName
+	return escaped
 }
 
 // AtRef fulfills the cacheOperationProvider interface for DeleteOpts

--- a/internal/pkg/caching/get.go
+++ b/internal/pkg/caching/get.go
@@ -70,10 +70,11 @@ func (opts *GetOpts) PackPath() string {
 
 // PackDir fulfills the cacheOperationProvider interface for GetOpts
 func (opts *GetOpts) PackDir() string {
+	escaped := EscapePackName(opts.PackName)
 	if opts.Ref != "" {
-		return AppendRef(opts.PackName, opts.Ref)
+		return AppendRef(escaped, opts.Ref)
 	}
-	return opts.PackName
+	return escaped
 }
 
 // AtRevision fulfills the cacheOperationProvider interface for GetOpts

--- a/internal/pkg/caching/pack.go
+++ b/internal/pkg/caching/pack.go
@@ -61,7 +61,10 @@ func (cfg *PackConfig) initFromDirectory(packPath string) {
 // initFromArgs is a utility function to build a pack path for registry added
 // packs. Not for use with file system based packs.
 func (cfg *PackConfig) initFromArgs() {
-	cfg.Path = path.Join(DefaultCachePath(), cfg.Registry, cfg.Ref, cfg.Name)
+	// Escape the pack name so the constructed path matches the directory name
+	// stored on disk. See EscapePackName for details.
+	escapedName := EscapePackName(cfg.Name)
+	cfg.Path = path.Join(DefaultCachePath(), cfg.Registry, cfg.Ref, escapedName)
 	if cfg.Ref != "" {
 		cfg.Path = AppendRef(cfg.Path, cfg.Ref)
 	}

--- a/internal/pkg/caching/registry.go
+++ b/internal/pkg/caching/registry.go
@@ -88,8 +88,9 @@ func (r *Registry) get(opts *GetOpts, cache *Cache) error {
 			invalidOpts := &GetOpts{
 				cachePath:    opts.cachePath,
 				RegistryName: opts.RegistryName,
-				PackName:     packEntry.Name(),
-				Ref:          opts.Ref,
+				// Use the unescaped pack name for display purposes.
+				PackName: nameFromPackEntry(packEntry),
+				Ref:      opts.Ref,
 			}
 			cachedPack = invalidPackDefinition(invalidOpts)
 			// Append the pack to the registry's packs field.
@@ -110,8 +111,9 @@ func (r *Registry) get(opts *GetOpts, cache *Cache) error {
 			invalidOpts := &GetOpts{
 				cachePath:    opts.cachePath,
 				RegistryName: opts.RegistryName,
-				PackName:     packEntry.Name(),
-				Ref:          refFromPackEntry(packEntry),
+				// Use the unescaped pack name for display purposes.
+				PackName: nameFromPackEntry(packEntry),
+				Ref:      refFromPackEntry(packEntry),
 			}
 			cachedPack = invalidPackDefinition(invalidOpts)
 		} else {


### PR DESCRIPTION
**Description**
Fix
Adopted the same escaping convention used by the Go module cache: each uppercase letter X is replaced by !x before the directory name is written to disk donutDNS → donut!d!n!s. This guarantees distinct directory names on all filesystems regardless of case sensitivity.

The escaping is entirely internal. Users always provide and see the original pack name — the ! characters on disk are never exposed.

[JIRA Ticket](https://hashicorp.atlassian.net/browse/NMD-1192)

**Reminders**

- [x] Add `CHANGELOG.md` entry


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

