### PR TITLE
allow slash in nomad-pack ref

### DIFF
--- a/internal/pkg/caching/add.go
+++ b/internal/pkg/caching/add.go
@@ -130,7 +130,7 @@ func (c *Cache) addFromURI(opts *AddOpts) (cachedRegistry *Registry, err error) 
 
 	// Store a metadata JSON file for the cached registry
 	b, _ := json.MarshalIndent(cachedRegistry, "", "  ")
-	metaPath := filepath.Join(c.cfg.Path, opts.RegistryName, opts.Ref, "/metadata.json")
+	metaPath := filepath.Join(c.cfg.Path, opts.RegistryName, EscapeRef(opts.Ref), "metadata.json")
 	if err = os.WriteFile(metaPath, b, 0644); err != nil {
 		logger.ErrorWithContext(err, "error processing metadata file for the registry", c.ErrorContext.GetAll()...)
 		return
@@ -339,14 +339,15 @@ func (opts *AddOpts) RegistryPath() string {
 
 // PackPath fulfills the cacheOperationProvider interface for AddOpts
 func (opts *AddOpts) PackPath() string {
-	return path.Join(opts.cachePath, opts.RegistryName, opts.Ref, opts.PackDir())
+	return path.Join(opts.cachePath, opts.RegistryName, EscapeRef(opts.Ref), opts.PackDir())
 }
 
 // PackDir fulfills the cacheOperationProvider interface for AddOpts
 func (opts *AddOpts) PackDir() string {
 	escaped := EscapePackName(opts.PackName)
 	if opts.Ref != "" {
-		return AppendRef(escaped, opts.Ref)
+		// Escape the ref so that slashes don't create unexpected sub-directories.
+		return AppendRef(escaped, EscapeRef(opts.Ref))
 	}
 	return escaped
 }

--- a/internal/pkg/caching/cache.go
+++ b/internal/pkg/caching/cache.go
@@ -180,7 +180,9 @@ func (c *Cache) Load() (err error) {
 		}
 		for _, registryRef := range registryRefs {
 			opts.RegistryName = registryEntry.Name()
-			opts.Ref = registryRef.Name()
+			// Unescape the directory name to recover the original ref that may
+			// contain slashes (e.g. "pack-name/v1.0.0" stored as "pack-name!_v1.0.0").
+			opts.Ref = UnescapeRef(registryRef.Name())
 
 			// Load the registry from the path
 			var registry *Registry
@@ -212,6 +214,20 @@ func AppendRef(name, ref string) string {
 		return name
 	}
 	return fmt.Sprintf("%s@%s", name, ref)
+}
+
+// EscapeRef makes a git ref safe for use as a filesystem path component by
+// replacing forward slashes with the escape sequence "!_". Slashes in refs (e.g.
+// namespaced tags like "pack-name/v1.0.0") would otherwise be interpreted as
+// directory separators by path.Join and friends.
+func EscapeRef(ref string) string {
+	return strings.ReplaceAll(ref, "/", "!_")
+}
+
+// UnescapeRef reverses the escaping applied by EscapeRef, converting "!_"
+// back to "/".
+func UnescapeRef(escaped string) string {
+	return strings.ReplaceAll(escaped, "!_", "/")
 }
 
 // EscapePackName escapes a pack name for safe use as a filesystem path
@@ -271,7 +287,8 @@ func refFromPackEntry(packEntry os.DirEntry) (ref string) {
 
 	segments := strings.Split(packEntry.Name(), "@")
 	if len(segments) == 2 {
-		ref = segments[1]
+		// Unescape the ref component: slashes in git refs are stored as "!_".
+		ref = UnescapeRef(segments[1])
 	}
 
 	return

--- a/internal/pkg/caching/cache_test.go
+++ b/internal/pkg/caching/cache_test.go
@@ -857,3 +857,101 @@ func TestPackDirEscaping(t *testing.T) {
 	must.Eq(t, lower.PackDir(), (&DeleteOpts{PackName: "donutdns", Ref: "latest"}).PackDir())
 	must.Eq(t, upper.PackDir(), (&DeleteOpts{PackName: "donutDNS", Ref: "latest"}).PackDir())
 }
+
+// TestEscapeRef verifies that EscapeRef replaces forward slashes so that
+// git refs such as "pack-name/v1.0.0" are safe to use as filesystem path
+// components.
+func TestEscapeRef(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		// Plain ref – unchanged.
+		{"latest", "latest"},
+		// SHA – unchanged.
+		{"abc123", "abc123"},
+		// Namespaced tag with single slash.
+		{"pack-name/v1.0.0", "pack-name!_v1.0.0"},
+		// Multiple slashes.
+		{"foo/bar/v2.3.4", "foo!_bar!_v2.3.4"},
+		// Empty string.
+		{"", ""},
+	}
+	for _, testCase := range cases {
+		tc := testCase
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			must.Eq(t, tc.expected, EscapeRef(tc.input))
+		})
+	}
+}
+
+// TestUnescapeRef verifies that UnescapeRef is the inverse of EscapeRef.
+func TestUnescapeRef(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"latest", "latest"},
+		{"abc123", "abc123"},
+		{"pack-name!_v1.0.0", "pack-name/v1.0.0"},
+		{"foo!_bar!_v2.3.4", "foo/bar/v2.3.4"},
+		{"", ""},
+	}
+	for _, testCase := range cases {
+		tc := testCase
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			must.Eq(t, tc.expected, UnescapeRef(tc.input))
+		})
+	}
+}
+
+// TestEscapeRefRoundTrip verifies EscapeRef / UnescapeRef are inverses.
+func TestEscapeRefRoundTrip(t *testing.T) {
+	t.Parallel()
+	refs := []string{
+		"latest",
+		"abc123def456",
+		"pack-name/v1.0.0",
+		"ns/sub/v0.1.2",
+		"",
+	}
+	for _, r := range refs {
+		ref := r
+		t.Run(ref, func(t *testing.T) {
+			t.Parallel()
+			must.Eq(t, ref, UnescapeRef(EscapeRef(ref)))
+		})
+	}
+}
+
+// TestPackDirSlashRef verifies that a ref containing a forward slash (e.g. a
+// namespaced git tag) produces a single flat directory component rather than
+// creating unexpected sub-directories.
+func TestPackDirSlashRef(t *testing.T) {
+	t.Parallel()
+	slashRef := "pack-name/v1.0.0"
+	escaped := "pack-name!_v1.0.0"
+
+	addOpts := &AddOpts{PackName: "simple_raw_exec", Ref: slashRef}
+	must.Eq(t, "simple_raw_exec@"+escaped, addOpts.PackDir(),
+		must.Sprint("AddOpts.PackDir must escape slashes in ref"))
+
+	getOpts := &GetOpts{PackName: "simple_raw_exec", Ref: slashRef}
+	must.Eq(t, "simple_raw_exec@"+escaped, getOpts.PackDir(),
+		must.Sprint("GetOpts.PackDir must escape slashes in ref"))
+
+	delOpts := &DeleteOpts{PackName: "simple_raw_exec", Ref: slashRef}
+	must.Eq(t, "simple_raw_exec@"+escaped, delOpts.PackDir(),
+		must.Sprint("DeleteOpts.PackDir must escape slashes in ref"))
+
+	// RegistryPath must not split the ref into sub-directories.
+	cacheRoot := "/tmp/cache"
+	getOpts2 := &GetOpts{cachePath: cacheRoot, RegistryName: "my-registry", Ref: slashRef}
+	expectedPath := cacheRoot + "/my-registry/" + escaped
+	must.Eq(t, expectedPath, getOpts2.RegistryPath(),
+		must.Sprint("GetOpts.RegistryPath must not create sub-directory for slash in ref"))
+}

--- a/internal/pkg/caching/delete.go
+++ b/internal/pkg/caching/delete.go
@@ -129,14 +129,17 @@ func (opts *DeleteOpts) PackPath() (packPath string) {
 func (opts *DeleteOpts) PackDir() string {
 	escaped := EscapePackName(opts.PackName)
 	if opts.Ref != "" {
-		return AppendRef(escaped, opts.Ref)
+		// Escape the ref so that slashes don't create unexpected sub-directories.
+		return AppendRef(escaped, EscapeRef(opts.Ref))
 	}
 	return escaped
 }
 
-// AtRef fulfills the cacheOperationProvider interface for DeleteOpts
+// AtRef fulfills the cacheOperationProvider interface for DeleteOpts.
+// Returns the filesystem-safe (escaped) form of the ref so that callers
+// that use it in path.Join operations handle slashes in git refs correctly.
 func (opts *DeleteOpts) AtRef() string {
-	return opts.Ref
+	return EscapeRef(opts.Ref)
 }
 
 // ForPackName fulfills the cacheOperationProvider interface for DeleteOpts
@@ -154,7 +157,7 @@ func (opts *DeleteOpts) IsTarget(dirEntry os.DirEntry) bool {
 	// If no pack name is set, then check if this directory contains the
 	// @ref string. If so, it is a target.
 	if opts.PackName == "" {
-		return strings.Contains(dirEntry.Name(), AppendRef("", opts.Ref))
+		return strings.Contains(dirEntry.Name(), AppendRef("", EscapeRef(opts.Ref)))
 	}
 
 	return dirEntry.Name() == opts.PackDir()

--- a/internal/pkg/caching/get.go
+++ b/internal/pkg/caching/get.go
@@ -60,7 +60,7 @@ type GetOpts struct {
 
 // RegistryPath fulfills the cacheOperationProvider interface for GetOpts
 func (opts *GetOpts) RegistryPath() string {
-	return path.Join(opts.cachePath, opts.RegistryName, opts.Ref)
+	return path.Join(opts.cachePath, opts.RegistryName, EscapeRef(opts.Ref))
 }
 
 // PackPath fulfills the cacheOperationProvider interface for GetOpts
@@ -72,7 +72,8 @@ func (opts *GetOpts) PackPath() string {
 func (opts *GetOpts) PackDir() string {
 	escaped := EscapePackName(opts.PackName)
 	if opts.Ref != "" {
-		return AppendRef(escaped, opts.Ref)
+		// Escape the ref so that slashes don't create unexpected sub-directories.
+		return AppendRef(escaped, EscapeRef(opts.Ref))
 	}
 	return escaped
 }
@@ -96,7 +97,7 @@ func (opts *GetOpts) IsLatest() bool {
 func (opts *GetOpts) IsTarget(dirEntry os.DirEntry) bool {
 	// TODO: Test with file paths.
 	// If pack name is empty, everything at revision is a target.
-	if opts.PackName == "" && strings.Contains(dirEntry.Name(), opts.Ref) {
+	if opts.PackName == "" && strings.Contains(dirEntry.Name(), EscapeRef(opts.Ref)) {
 		return true
 	}
 

--- a/internal/pkg/caching/pack.go
+++ b/internal/pkg/caching/pack.go
@@ -64,9 +64,12 @@ func (cfg *PackConfig) initFromArgs() {
 	// Escape the pack name so the constructed path matches the directory name
 	// stored on disk. See EscapePackName for details.
 	escapedName := EscapePackName(cfg.Name)
-	cfg.Path = path.Join(DefaultCachePath(), cfg.Registry, cfg.Ref, escapedName)
+	// Escape the ref so that slashes in git refs (e.g. "pack-name/v1.0.0") are
+	// stored as a single path component rather than creating sub-directories.
+	escapedRef := EscapeRef(cfg.Ref)
+	cfg.Path = path.Join(DefaultCachePath(), cfg.Registry, escapedRef, escapedName)
 	if cfg.Ref != "" {
-		cfg.Path = AppendRef(cfg.Path, cfg.Ref)
+		cfg.Path = AppendRef(cfg.Path, escapedRef)
 	}
 }
 


### PR DESCRIPTION
**Description**
Git tags with forward slashes (e.g. pack-name/v1.0.0) were not supported as a --ref value when adding a registry. When path.Join or filepath.Join received a ref containing /, it interpreted it as a directory separator, creating a nested folder structure on disk:

This caused packs to be stored at an unexpected path, so subsequent commands (run, plan, status, registry list) could not locate them.

Fix:
Introduced **EscapeRef / UnescapeRef** functions in the caching package, following the same !- based escaping convention already used by EscapePackName / UnescapePackName. Forward slashes in refs are replaced with !_

[Jira Ticket](https://hashicorp.atlassian.net/browse/NMD-1180)

**Reminders**

- [x] Add `CHANGELOG.md` entry


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

