### PR TITLE
fix: make plan --deploy-override skip conflict validation

### DIFF
--- a/internal/runner/job/conflict.go
+++ b/internal/runner/job/conflict.go
@@ -80,11 +80,11 @@ func (r *Runner) hasDeployOverride() bool {
 	if r.cfg == nil {
 		return false
 	}
-	if r.cfg.RunConfig != nil {
-		return r.cfg.RunConfig.DeployOverride
-	}
-	if r.cfg.PlanConfig != nil {
-		return r.cfg.PlanConfig.DeployOverride
+	runOverride := r.cfg.RunConfig != nil && r.cfg.RunConfig.DeployOverride
+	planOverride := r.cfg.PlanConfig != nil && r.cfg.PlanConfig.DeployOverride
+
+	if runOverride || planOverride {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
## Summary
- fix `hasDeployOverride()` so it checks both `RunConfig` and `PlanConfig`
- restore expected behavior for `plan --deploy-override`

## Test plan
- [x] go test ./internal/runner/job
- [x] go test ./internal/cli -run TestCLI_RunReconcileIgnoresOtherDeployments -count=1

Fixes #845