### PR TITLE
Add Nomad Variables support with automatic creation and deletion(Issue #409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 * cli: Add registry now honors default main/master branch [[GH-843](https://github.com/hashicorp/nomad-pack/pull/843)]
 * variable: Variables declaration now supports validation stanza [[GH-841](https://github.com/hashicorp/nomad-pack/pull/841)]
+* variable: Add support for `nomad_variable` blocks with automatic lifecycle management during pack deployment and destruction [[GH-409](https://github.com/hashicorp/nomad-pack/pull/853)]
 
 ## 0.4.2 (March 16, 2026)
 

--- a/docs/writing-packs.md
+++ b/docs/writing-packs.md
@@ -132,6 +132,27 @@ nomad_variable "app_config" {
   }
 }
 
+##### Important: Variable Creation Timing
+
+**Note:** Nomad Variables are created AFTER the job is deployed.
+
+This means:
+- First: Your job starts running
+- Second: Variables are created
+- If variable creation fails: Your job is still running, but the command shows an error
+
+**Example:**
+```bash
+$ nomad-pack run my-app
+Job deployed
+Variable creation failed
+```
+In this case, my-app is running, but variables weren't created.
+
+**What to do if this happens:**
+1. Fix the problem in your variables.hcl
+2. Run `nomad-pack run my-app` again
+
 #### outputs.tpl
 
 The `outputs.tpl` is an optional file that defines an output to be printed when a pack is deployed.

--- a/docs/writing-packs.md
+++ b/docs/writing-packs.md
@@ -108,6 +108,30 @@ variable "resources" {
 }
 ```
 
+#### Nomad Variables
+
+In addition to pack variables, you can define Nomad Variables that will be automatically created in Nomad's native variable storage when you deploy your pack. These variables are useful for storing secrets, configuration, and other data that needs to be accessible to your Nomad jobs.
+
+Nomad Variables are defined using `nomad_variable` blocks in your `variables.hcl` file:
+
+```hcl
+nomad_variable "app_secrets" {
+  path      = "nomad/jobs/myapp/secrets"
+  namespace = "default"
+  items = {
+    db_password = "secret123"
+    api_key     = "key456"
+  }
+}
+
+nomad_variable "app_config" {
+  path = "nomad/jobs/myapp/config"
+  items = {
+    log_level    = "info"
+    feature_flag = "enabled"
+  }
+}
+
 #### outputs.tpl
 
 The `outputs.tpl` is an optional file that defines an output to be printed when a pack is deployed.

--- a/fixtures/v2/simple_raw_exec_v2/variables.hcl
+++ b/fixtures/v2/simple_raw_exec_v2/variables.hcl
@@ -42,3 +42,19 @@ variable "namespace" {
   description = "namespace to run the job in"
   default     = ""
 }
+nomad_variable "app_config" {
+  path = "nomad/jobs/simple_raw_exec/config"
+  items = {
+    database_url = "postgres://localhost:5432/mydb"
+    api_key = "secret-api-key-123"
+    environment = "production"
+  }
+}
+
+nomad_variable "secrets" {
+  path = "nomad/jobs/simple_raw_exec/secrets"
+  items = {
+    admin_password = "super-secret-password"
+    jwt_secret = "jwt-signing-key-xyz"
+  }
+}

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/nomad-pack/internal/pkg/variable/parser"
 	"github.com/hashicorp/nomad-pack/internal/runner"
 	"github.com/hashicorp/nomad-pack/internal/runner/job"
+	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
 	"github.com/hashicorp/nomad-pack/terminal"
 )
 
@@ -197,6 +198,121 @@ func renderPack(
 		return nil, errors.New("failed to render")
 	}
 	return r, nil
+}
+
+// createNomadVariables creates Nomad Variables defined in nomad_variable blocks
+func createNomadVariables(
+	parsedVars *parser.ParsedVariables,
+	client *api.Client,
+	ui terminal.UI,
+	errCtx *errors.UIErrorContext,
+) error {
+	nomadVars := parsedVars.GetNomadVars()
+	if len(nomadVars) == 0 {
+		return nil // No nomad variables to create
+	}
+
+	ui.Output("Creating Nomad Variables...")
+
+	for _, nvList := range nomadVars {
+		for _, nv := range nvList {
+			// Convert cty.Value items to map[string]string for Nomad API
+			items := make(map[string]string)
+			for key, val := range nv.Items {
+				// Convert cty.Value to Go interface
+				goVal, err := variables.ConvertCtyToInterface(val)
+				if err != nil {
+					return fmt.Errorf("failed to convert variable %s.%s: %w", nv.Name, key, err)
+				}
+				items[key] = fmt.Sprintf("%v", goVal)
+			}
+
+			// Create the Nomad Variable
+			variable := &api.Variable{
+				Path:      nv.Path,
+				Namespace: nv.Namespace,
+				Items:     items,
+			}
+
+			// Set default namespace if not specified
+			if variable.Namespace == "" {
+				variable.Namespace = "default"
+			}
+
+			ui.Output(fmt.Sprintf("  Creating variable at path: %s (namespace: %s)",
+				nv.Path, variable.Namespace))
+
+			// Check if variable already exists and warn user
+			existing, _, err := client.Variables().Read(nv.Path, &api.QueryOptions{
+				Namespace: variable.Namespace,
+			})
+			if err == nil && existing != nil {
+				ui.Warning(fmt.Sprintf("  ⚠ Variable at path %s already exists and will be updated", nv.Path))
+			}
+
+			// Create or update the variable
+			_, _, err = client.Variables().Create(variable, nil)
+			if err != nil {
+				// If variable exists, try to update it
+				if strings.Contains(err.Error(), "already exists") {
+					_, _, err = client.Variables().Update(variable, nil)
+					if err != nil {
+						return fmt.Errorf("failed to update variable at path %s: %w", nv.Path, err)
+					}
+					ui.Output(fmt.Sprintf("  ✓ Updated variable: %s", nv.Name))
+				} else {
+					return fmt.Errorf("failed to create variable at path %s: %w", nv.Path, err)
+				}
+			} else {
+				ui.Output(fmt.Sprintf("  ✓ Created variable: %s", nv.Name))
+			}
+		}
+	}
+
+	ui.Success("Nomad Variables created successfully")
+	return nil
+}
+
+// deleteNomadVariables deletes Nomad Variables defined in nomad_variable blocks
+func deleteNomadVariables(
+	parsedVars *parser.ParsedVariables,
+	client *api.Client,
+	ui terminal.UI,
+	errCtx *errors.UIErrorContext,
+) error {
+	nomadVars := parsedVars.GetNomadVars()
+	if len(nomadVars) == 0 {
+		return nil // no nomad variables to delete
+	}
+
+	ui.Output("Deleting Nomad Variables...")
+
+	for _, variables := range nomadVars {
+		for _, nv := range variables {
+			namespace := nv.Namespace
+			if namespace == "" {
+				namespace = "default"
+			}
+
+			ui.Output(fmt.Sprintf("Deleting variable at path: %s (namespace: %s)", nv.Path, namespace))
+
+			//delete the variable
+			_, err := client.Variables().Delete(nv.Path, &api.WriteOptions{Namespace: namespace})
+			if err != nil {
+				// if variable doesn't exist, its not an error
+				if strings.Contains(err.Error(), "not found") {
+					ui.Output(fmt.Sprintf("Variable not found (already deleted): %s", nv.Name))
+				} else {
+					return fmt.Errorf("failed to delete variable at path %s: %w", nv.Path, err)
+				}
+			} else {
+				ui.Output(fmt.Sprintf("Deleted variable: %s", nv.Name))
+			}
+		}
+	}
+
+	ui.Success("Nomad Variables deleted successfully")
+	return nil
 }
 
 // TODO: This needs to be on a domain specific pkg rather than a UI helpers file.

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -200,12 +201,19 @@ func renderPack(
 	return r, nil
 }
 
+// getNamespaceOrDefault returns the provided namespace or "default" if empty
+func getNamespaceOrDefault(ns string) string {
+	if ns == "" {
+		return "default"
+	}
+	return ns
+}
+
 // createNomadVariables creates Nomad Variables defined in nomad_variable blocks
 func createNomadVariables(
 	parsedVars *parser.ParsedVariables,
 	client *api.Client,
 	ui terminal.UI,
-	errCtx *errors.UIErrorContext,
 ) error {
 	nomadVars := parsedVars.GetNomadVars()
 	if len(nomadVars) == 0 {
@@ -224,7 +232,23 @@ func createNomadVariables(
 				if err != nil {
 					return fmt.Errorf("failed to convert variable %s.%s: %w", nv.Name, key, err)
 				}
-				items[key] = fmt.Sprintf("%v", goVal)
+
+				// serialize complex types as JSON, simple types as strings
+				var strVal string
+				switch v := goVal.(type) {
+				case string:
+					strVal = v
+				case int, int64, float64, bool:
+					strVal = fmt.Sprintf("%v", v)
+				default:
+					// for maps, slices and other complex types, use JSON
+					jsonBytes, err := json.Marshal(goVal)
+					if err != nil {
+						return fmt.Errorf("failed to serialize variable %s.%s as JSON: %w", nv.Name, key, err)
+					}
+					strVal = string(jsonBytes)
+				}
+				items[key] = strVal
 			}
 
 			// Create the Nomad Variable
@@ -235,25 +259,15 @@ func createNomadVariables(
 			}
 
 			// Set default namespace if not specified
-			if variable.Namespace == "" {
-				variable.Namespace = "default"
-			}
+			variable.Namespace = getNamespaceOrDefault(variable.Namespace)
 
 			ui.Output(fmt.Sprintf("  Creating variable at path: %s (namespace: %s)",
 				nv.Path, variable.Namespace))
 
-			// Check if variable already exists and warn user
-			existing, _, err := client.Variables().Read(nv.Path, &api.QueryOptions{
-				Namespace: variable.Namespace,
-			})
-			if err == nil && existing != nil {
-				ui.Warning(fmt.Sprintf("  ⚠ Variable at path %s already exists and will be updated", nv.Path))
-			}
-
-			// Create or update the variable
-			_, _, err = client.Variables().Create(variable, nil)
+			// Try to create the variable first
+			_, _, err := client.Variables().Create(variable, nil)
 			if err != nil {
-				// If variable exists, try to update it
+				// If variable exists, update it instead
 				if strings.Contains(err.Error(), "already exists") {
 					_, _, err = client.Variables().Update(variable, nil)
 					if err != nil {
@@ -268,7 +282,6 @@ func createNomadVariables(
 			}
 		}
 	}
-
 	ui.Success("Nomad Variables created successfully")
 	return nil
 }
@@ -278,7 +291,6 @@ func deleteNomadVariables(
 	parsedVars *parser.ParsedVariables,
 	client *api.Client,
 	ui terminal.UI,
-	errCtx *errors.UIErrorContext,
 ) error {
 	nomadVars := parsedVars.GetNomadVars()
 	if len(nomadVars) == 0 {
@@ -287,16 +299,13 @@ func deleteNomadVariables(
 
 	ui.Output("Deleting Nomad Variables...")
 
-	for _, variables := range nomadVars {
-		for _, nv := range variables {
-			namespace := nv.Namespace
-			if namespace == "" {
-				namespace = "default"
-			}
+	for _, varList := range nomadVars {
+		for _, nv := range varList {
+			namespace := getNamespaceOrDefault(nv.Namespace)
 
 			ui.Output(fmt.Sprintf("Deleting variable at path: %s (namespace: %s)", nv.Path, namespace))
 
-			//delete the variable
+			// delete the variable
 			_, err := client.Variables().Delete(nv.Path, &api.WriteOptions{Namespace: namespace})
 			if err != nil {
 				// if variable doesn't exist, its not an error

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -143,6 +143,14 @@ func (c *RunCommand) run() int {
 		return 1
 	}
 
+	// create nomad variables
+	if r.ParsedVariables() != nil {
+		if err := createNomadVariables(r.ParsedVariables(), client, c.ui, errorContext); err != nil {
+			c.ui.ErrorWithContext(err, "failed to create Nomad Variables", errorContext.GetAll()...)
+			return 1
+		}
+	}
+
 	// Monitor deployments unless detach flag is set
 	if !c.jobConfig.RunConfig.Detach {
 		evalIDs := runDeployer.EvalIDs()

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -145,7 +145,8 @@ func (c *RunCommand) run() int {
 
 	// create nomad variables
 	if r.ParsedVariables() != nil {
-		if err := createNomadVariables(r.ParsedVariables(), client, c.ui, errorContext); err != nil {
+		if err := createNomadVariables(r.ParsedVariables(), client, c.ui); err != nil {
+			c.ui.Warning("Job is running, but variable creation failed")
 			c.ui.ErrorWithContext(err, "failed to create Nomad Variables", errorContext.GetAll()...)
 			return 1
 		}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -188,7 +188,7 @@ func (c *StopCommand) Run(args []string) int {
 
 	// after all jobs are stopped, delete Nomad Variables if purging
 	if c.purge && r.ParsedVariables() != nil {
-		if err := deleteNomadVariables(r.ParsedVariables(), client, c.ui, errorContext); err != nil {
+		if err := deleteNomadVariables(r.ParsedVariables(), client, c.ui); err != nil {
 			c.ui.ErrorWithContext(err, "failed to delete Nomad Variables", errorContext.GetAll()...)
 			// don't return error - jobs are already stopped
 		}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -186,6 +186,14 @@ func (c *StopCommand) Run(args []string) int {
 		stoppedJobs = append(stoppedJobs, *job.Name)
 	}
 
+	// after all jobs are stopped, delete Nomad Variables if purging
+	if c.purge && r.ParsedVariables() != nil {
+		if err := deleteNomadVariables(r.ParsedVariables(), client, c.ui, errorContext); err != nil {
+			c.ui.ErrorWithContext(err, "failed to delete Nomad Variables", errorContext.GetAll()...)
+			// don't return error - jobs are already stopped
+		}
+	}
+
 	monitorExitCode := 0
 	// Monitor all evaluations in parallel unless --detach is specified
 	if !c.detach && len(evalIDs) > 0 {

--- a/internal/pkg/renderer/renderer.go
+++ b/internal/pkg/renderer/renderer.go
@@ -120,6 +120,7 @@ func (r *Renderer) Render(p *pack.Pack, variables *parser.ParsedVariables) (*Ren
 	rendered := &Rendered{
 		parentRenders:     make(map[string]string),
 		dependencyRenders: make(map[string]string),
+		parsedVariables:   variables,
 	}
 
 	for name, src := range filesToRender {
@@ -313,6 +314,7 @@ func prepareFilesV1(p *pack.Pack,
 type Rendered struct {
 	parentRenders     map[string]string
 	dependencyRenders map[string]string
+	parsedVariables   *parser.ParsedVariables
 }
 
 // ParentRenders returns a map of rendered templates belonging to the parent
@@ -331,3 +333,8 @@ func (r *Rendered) DependentRenders() map[string]string { return r.dependencyRen
 // LenDependentRenders returns the number of dependent rendered templates that
 // are stored.
 func (r *Rendered) LenDependentRenders() int { return len(r.dependencyRenders) }
+
+// ParsedVariables returns parsed variables used during rendering
+func (r *Rendered) ParsedVariables() *parser.ParsedVariables {
+	return r.parsedVariables
+}

--- a/internal/pkg/variable/decoder/decode.go
+++ b/internal/pkg/variable/decoder/decode.go
@@ -153,3 +153,93 @@ func shouldCompareDefaultType(varType, defaultType cty.Type) bool {
 	}
 	return false
 }
+
+// DecodeNomadVariableBlock parses a nomad_variable definition
+func DecodeNomadVariableBlock(block *hcl.Block) (*variables.NomadVariable, hcl.Diagnostics) {
+	if block == nil || block.Body == nil {
+		return nil, hcl.Diagnostics{}
+	}
+
+	content, diags := block.Body.Content(schema.NomadVariableBlockSchema)
+	if content == nil {
+		return nil, diags
+	}
+
+	if diags == nil {
+		diags = hcl.Diagnostics{}
+	}
+
+	nv := &variables.NomadVariable{
+		Name:  block.Labels[0],
+		Items: make(map[string]cty.Value),
+	}
+
+	// Parse "path" attribute (required)
+	if attr, exists := content.Attributes["path"]; exists {
+		val, pathDiags := attr.Expr.Value(nil)
+		diags = packdiags.SafeDiagnosticsExtend(diags, pathDiags)
+		if val.Type() == cty.String {
+			nv.Path = val.AsString()
+		} else {
+			diags = packdiags.SafeDiagnosticsAppend(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid type for path",
+				Detail:   fmt.Sprintf("The path attribute must be a string, got %s", val.Type().FriendlyName()),
+				Subject:  attr.Range.Ptr(),
+			})
+		}
+	} else {
+		diags = packdiags.SafeDiagnosticsAppend(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Missing required attribute",
+			Detail:   "The 'path' attribute is required for nomad_variable blocks",
+			Subject:  &block.DefRange,
+		})
+	}
+
+	// Parse "namespace" attribute (optional)
+	if attr, exists := content.Attributes["namespace"]; exists {
+		val, nsDiags := attr.Expr.Value(nil)
+		diags = packdiags.SafeDiagnosticsExtend(diags, nsDiags)
+		if val.Type() == cty.String {
+			nv.Namespace = val.AsString()
+		} else {
+			diags = packdiags.SafeDiagnosticsAppend(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid type for namespace",
+				Detail:   fmt.Sprintf("The namespace attribute must be a string, got %s", val.Type().FriendlyName()),
+				Subject:  attr.Range.Ptr(),
+			})
+		}
+	}
+
+	// Parse "items" attribute (required)
+	if attr, exists := content.Attributes["items"]; exists {
+		val, itemsDiags := attr.Expr.Value(nil)
+		diags = packdiags.SafeDiagnosticsExtend(diags, itemsDiags)
+
+		if val.Type().IsObjectType() || val.Type().IsMapType() {
+			nv.Items = val.AsValueMap()
+		} else {
+			diags = packdiags.SafeDiagnosticsAppend(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid type for items",
+				Detail:   fmt.Sprintf("The items attribute must be an object or map, got %s", val.Type().FriendlyName()),
+				Subject:  attr.Range.Ptr(),
+			})
+		}
+	} else {
+		diags = packdiags.SafeDiagnosticsAppend(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Missing required attribute",
+			Detail:   "The 'items' attribute is required for nomad_variable blocks",
+			Subject:  &block.DefRange,
+		})
+	}
+
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return nv, diags
+}

--- a/internal/pkg/variable/decoder/decode_test.go
+++ b/internal/pkg/variable/decoder/decode_test.go
@@ -643,6 +643,140 @@ variable "optional_list" {
 	}
 }
 
+func TestDecoder_DecodeNomadVariableBlock(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name        string
+		input       *hcl.Block
+		expectOut   *variables.NomadVariable
+		expectDiags hcl.Diagnostics
+		shouldErr   bool
+	}{
+		{
+			name:        "passes/on nil block",
+			input:       &hcl.Block{},
+			expectOut:   nil,
+			expectDiags: hcl.Diagnostics{},
+		},
+		{
+			name:  "passes/on valid block with all attributes",
+			input: testGetNomadVariableHCLBlock(t, testLoadPackFile(t, []byte(goodCompleteNomadVariableHCL))),
+			expectOut: &variables.NomadVariable{
+				Name:      "test",
+				Path:      "nomad/jobs/test",
+				Namespace: "default",
+				Items: map[string]cty.Value{
+					"key1": cty.StringVal("value1"),
+					"key2": cty.StringVal("value2"),
+				},
+			},
+			expectDiags: hcl.Diagnostics{},
+		},
+		{
+			name:  "passes/on valid block without optional namespace",
+			input: testGetNomadVariableHCLBlock(t, testLoadPackFile(t, []byte(goodMinimalNomadVariableHCL))),
+			expectOut: &variables.NomadVariable{
+				Name:      "test",
+				Path:      "nomad/jobs/test",
+				Namespace: "",
+				Items: map[string]cty.Value{
+					"key1": cty.StringVal("value1"),
+				},
+			},
+			expectDiags: hcl.Diagnostics{},
+		},
+		{
+			name:      "fails/on missing required path attribute",
+			input:     testGetNomadVariableHCLBlock(t, testLoadPackFile(t, []byte(badNomadVariableMissingPath))),
+			expectOut: nil,
+			expectDiags: hcl.Diagnostics{&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Missing required attribute",
+				Detail:   "The attribute \"path\" is required, but no definition was found.",
+			}},
+			shouldErr: true,
+		},
+		{
+			name:      "fails/on missing required items attribute",
+			input:     testGetNomadVariableHCLBlock(t, testLoadPackFile(t, []byte(badNomadVariableMissingItems))),
+			expectOut: nil,
+			expectDiags: hcl.Diagnostics{&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Missing required attribute",
+				Detail:   "The attribute \"items\" is required, but no definition was found.",
+			}},
+			shouldErr: true,
+		},
+		{
+			name:  "passes/on empty items map",
+			input: testGetNomadVariableHCLBlock(t, testLoadPackFile(t, []byte(goodNomadVariableEmptyItems))),
+			expectOut: &variables.NomadVariable{
+				Name:      "test",
+				Path:      "nomad/jobs/test",
+				Namespace: "",
+				Items:     nil,
+			},
+			expectDiags: hcl.Diagnostics{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ci.Parallel(t)
+			out, diags := DecodeNomadVariableBlock(tc.input)
+
+			if tc.shouldErr {
+				must.True(t, diags.HasErrors())
+				must.Nil(t, out)
+			} else {
+				must.Len(t, 0, diags, must.Sprint(diags.Error()))
+				must.Eq(t, tc.expectOut, out)
+			}
+		})
+	}
+
+}
+
+func testGetNomadVariableHCLBlock(t *testing.T, in hcl.Body) *hcl.Block {
+	t.Helper()
+	b, diags := in.Content(schema.VariableFileSchema)
+	must.Len(t, 0, diags, must.Sprint(diags.Error()))
+	must.True(t, len(b.Blocks) >= 1)
+	return b.Blocks[0]
+}
+
+const goodCompleteNomadVariableHCL = `nomad_variable "test" {
+	path = "nomad/jobs/test"
+	namespace = "default"
+	items = {
+		key1 = "value1"
+		key2 = "value2"
+	}
+}`
+
+const goodMinimalNomadVariableHCL = `nomad_variable "test" {
+	path = "nomad/jobs/test"
+	items = {
+		key1 = "value1"
+	}
+}`
+
+const goodNomadVariableEmptyItems = `nomad_variable "test" {
+	path = "nomad/jobs/test"
+	items = {}
+}`
+
+const badNomadVariableMissingPath = `nomad_variable "test" {
+	items = {
+		key1 = "value1"
+	}
+}`
+
+const badNomadVariableMissingItems = `nomad_variable "test" {
+	path = "nomad/jobs/test"
+}`
+
 const goodMinimalVariableHCL = `variable "good" {}`
 
 const goodCompleteVariableHCL = `variable "example" {

--- a/internal/pkg/variable/parser/parsed_variables.go
+++ b/internal/pkg/variable/parser/parsed_variables.go
@@ -19,10 +19,11 @@ import (
 // ParsedVariables wraps the parsed variables returned by parser.Parse and
 // provides functionality to access them.
 type ParsedVariables struct {
-	v1Vars   map[string]map[string]*variables.Variable
-	v2Vars   map[pack.ID]map[variables.ID]*variables.Variable
-	Metadata *pack.Metadata
-	version  *config.ParserVersion
+	v1Vars    map[string]map[string]*variables.Variable
+	v2Vars    map[pack.ID]map[variables.ID]*variables.Variable
+	nomadVars map[pack.ID][]*variables.NomadVariable
+	Metadata  *pack.Metadata
+	version   *config.ParserVersion
 }
 
 func (pv *ParsedVariables) IsV2() bool {
@@ -72,6 +73,11 @@ func (pv *ParsedVariables) GetVars() map[pack.ID]map[variables.ID]*variables.Var
 		return asV2Vars(pv.v1Vars)
 	}
 	return pv.v2Vars
+}
+
+// GetNomadVars returns parsed nomad_variable blocks
+func (pv *ParsedVariables) GetNomadVars() map[pack.ID][]*variables.NomadVariable {
+	return pv.nomadVars
 }
 
 // asV2Vars traverses the v1-style and converts it into an equivalent single

--- a/internal/pkg/variable/parser/parser_v2.go
+++ b/internal/pkg/variable/parser/parser_v2.go
@@ -34,6 +34,8 @@ type ParserV2 struct {
 	// the second is by the variable name.
 	rootVars map[pack.ID]map[variables.ID]*variables.Variable
 
+	nomadVars map[pack.ID][]*variables.NomadVariable // stores parsed nomad_variable blocks
+
 	// envOverrideVars, fileOverrideVars, cliOverrideVars are the override
 	// variables. The maps are keyed by the pack name they are associated to.
 	envOverrideVars  variables.PackIDKeyedVarMap
@@ -67,6 +69,7 @@ func NewParserV2(cfg *config.ParserConfig) (*ParserV2, error) {
 		},
 		cfg:              cfg,
 		rootVars:         make(map[pack.ID]map[variables.ID]*variables.Variable),
+		nomadVars:        make(map[pack.ID][]*variables.NomadVariable),
 		envOverrideVars:  make(variables.PackIDKeyedVarMap),
 		fileOverrideVars: make(variables.PackIDKeyedVarMap),
 		flagOverrideVars: make(variables.PackIDKeyedVarMap),
@@ -134,6 +137,7 @@ func (p *ParserV2) Parse() (*ParsedVariables, hcl.Diagnostics) {
 
 	out := new(ParsedVariables)
 	out.LoadV2Result(p.rootVars)
+	out.nomadVars = p.nomadVars
 
 	return out, diags
 }
@@ -212,42 +216,60 @@ func (p *ParserV2) loadPackFile(file *pack.File) (hcl.Body, hcl.Diagnostics) {
 }
 
 func (p *ParserV2) parseRootFiles() hcl.Diagnostics {
-
 	var diags hcl.Diagnostics
 
 	// Iterate all our root variable files.
 	for name, file := range p.cfg.RootVariableFiles {
-
 		hclBody, loadDiags := p.loadPackFile(file)
 		diags = packdiags.SafeDiagnosticsExtend(diags, loadDiags)
 
+		// Parse BOTH variable and nomad_variable blocks in one call
 		content, contentDiags := hclBody.Content(schema.VariableFileSchema)
 		diags = packdiags.SafeDiagnosticsExtend(diags, contentDiags)
 
-		rootVars, parseDiags := p.parseRootBodyContent(content)
+		// Separate the blocks by type
+		var variableBlocks []*hcl.Block
+		var nomadVariableBlocks []*hcl.Block
+
+		for _, block := range content.Blocks {
+			switch block.Type {
+			case "variable":
+				_, diags := p.parseVariableBlocks([]*hcl.Block{block})
+				if diags.HasErrors() {
+					return diags
+				}
+			case "nomad_variable":
+				_, diags := p.parseNomadVariableBlocks([]*hcl.Block{block})
+				if diags.HasErrors() {
+					return diags
+				}
+			}
+		}
+
+		// Parse regular variable blocks
+		rootVars, parseDiags := p.parseVariableBlocks(variableBlocks)
 		diags = packdiags.SafeDiagnosticsExtend(diags, parseDiags)
 
-		// If we don't have any errors processing the file, and its content,
-		// add an entry.
+		// Parse nomad_variable blocks
+		nomadVars, nomadParseDiags := p.parseNomadVariableBlocks(nomadVariableBlocks)
+		diags = packdiags.SafeDiagnosticsExtend(diags, nomadParseDiags)
+
+		// If we don't have any errors processing the file, add entries
 		if !diags.HasErrors() {
 			p.rootVars[name] = rootVars
+			p.nomadVars[name] = nomadVars
 		}
 	}
 
 	return diags
 }
 
-// parseRootBodyContent process the body of a root variables file, parsing
-// each variable block found.
-func (p *ParserV2) parseRootBodyContent(body *hcl.BodyContent) (map[variables.ID]*variables.Variable, hcl.Diagnostics) {
-
+// parseVariableBlocks processes variable blocks
+func (p *ParserV2) parseVariableBlocks(blocks []*hcl.Block) (map[variables.ID]*variables.Variable, hcl.Diagnostics) {
 	packRootVars := map[variables.ID]*variables.Variable{}
-
 	var diags hcl.Diagnostics
 
-	// Due to the parsing that uses variableFileSchema, it is safe to assume
-	// every block has a type "variable".
-	for _, block := range body.Blocks {
+	for _, block := range blocks {
 		cfg, cfgDiags := decoder.DecodeVariableBlock(block)
 		diags = packdiags.SafeDiagnosticsExtend(diags, cfgDiags)
 		if cfg != nil {
@@ -255,6 +277,21 @@ func (p *ParserV2) parseRootBodyContent(body *hcl.BodyContent) (map[variables.ID
 		}
 	}
 	return packRootVars, diags
+}
+
+// parseNomadVariableBlocks processes nomad_variable blocks
+func (p *ParserV2) parseNomadVariableBlocks(blocks []*hcl.Block) ([]*variables.NomadVariable, hcl.Diagnostics) {
+	var nomadVars []*variables.NomadVariable
+	var diags hcl.Diagnostics
+
+	for _, block := range blocks {
+		nv, nvDiags := decoder.DecodeNomadVariableBlock(block)
+		diags = packdiags.SafeDiagnosticsExtend(diags, nvDiags)
+		if nv != nil {
+			nomadVars = append(nomadVars, nv)
+		}
+	}
+	return nomadVars, diags
 }
 
 func (p *ParserV2) parseEnvVariable(name string, rawVal string) hcl.Diagnostics {

--- a/internal/pkg/variable/parser/parser_v2.go
+++ b/internal/pkg/variable/parser/parser_v2.go
@@ -234,15 +234,9 @@ func (p *ParserV2) parseRootFiles() hcl.Diagnostics {
 		for _, block := range content.Blocks {
 			switch block.Type {
 			case "variable":
-				_, diags := p.parseVariableBlocks([]*hcl.Block{block})
-				if diags.HasErrors() {
-					return diags
-				}
+				variableBlocks = append(variableBlocks, block)
 			case "nomad_variable":
-				_, diags := p.parseNomadVariableBlocks([]*hcl.Block{block})
-				if diags.HasErrors() {
-					return diags
-				}
+				nomadVariableBlocks = append(nomadVariableBlocks, block)
 			}
 		}
 

--- a/internal/pkg/variable/parser/parser_v2_test.go
+++ b/internal/pkg/variable/parser/parser_v2_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/nomad-pack/internal/pkg/variable/parser/config"
 	"github.com/hashicorp/nomad-pack/sdk/pack"
 	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
+	"github.com/hashicorp/nomad/ci"
 	"github.com/shoenig/test/must"
 	"github.com/spf13/afero"
 	"github.com/zclconf/go-cty/cty"
@@ -488,4 +489,46 @@ func NewStringVariableV2(key, value, kind string) *variables.Variable {
 		Value:     cty.StringVal(value),
 		DeclRange: hcl.Range{Filename: fmt.Sprintf("<value for var %s from %s>", key, kind)},
 	}
+}
+
+func TestParsedVariables_GetNomadVars(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("returns empty map when no nomad variables", func(t *testing.T) {
+		pv := &ParsedVariables{
+			nomadVars: make(map[pack.ID][]*variables.NomadVariable),
+		}
+		nvs := pv.GetNomadVars()
+		must.NotNil(t, nvs)
+		must.MapEmpty(t, nvs)
+	})
+
+	t.Run("returns nil when nomadVars is nil", func(t *testing.T) {
+		pv := &ParsedVariables{
+			nomadVars: nil,
+		}
+		nvs := pv.GetNomadVars()
+		must.Nil(t, nvs)
+	})
+
+	t.Run("returns nomad variables map", func(t *testing.T) {
+		nv1 := &variables.NomadVariable{
+			Name: "test1",
+			Path: "nomad/jobs/test1",
+		}
+		nv2 := &variables.NomadVariable{
+			Name: "test2",
+			Path: "nomad/jobs/test2",
+		}
+		pv := &ParsedVariables{
+			nomadVars: map[pack.ID][]*variables.NomadVariable{
+				"example": {nv1, nv2},
+			},
+		}
+		nvs := pv.GetNomadVars()
+		must.Eq(t, 1, len(nvs))
+		must.Eq(t, 2, len(nvs["example"]))
+		must.Eq(t, "test1", nvs["example"][0].Name)
+		must.Eq(t, "test2", nvs["example"][1].Name)
+	})
 }

--- a/internal/pkg/variable/schema/schema.go
+++ b/internal/pkg/variable/schema/schema.go
@@ -23,6 +23,10 @@ var VariableFileSchema = &hcl.BodySchema{
 			Type:       "variable",
 			LabelNames: []string{"name"},
 		},
+		{
+			Type:       "nomad_variable",
+			LabelNames: []string{"name"},
+		},
 	},
 }
 
@@ -45,5 +49,14 @@ var ValidationBlockSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{Name: ValidationAttributeCondition, Required: true},
 		{Name: ValidationAttributeErrorMessage, Required: true},
+	},
+}
+
+// NomadVariableBlockSchema defines attributes inside a nomad_variable block
+var NomadVariableBlockSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{Name: "path"},
+		{Name: "namespace"},
+		{Name: "items"},
 	},
 }

--- a/internal/pkg/variable/schema/schema_test.go
+++ b/internal/pkg/variable/schema/schema_test.go
@@ -1,0 +1,101 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
+)
+
+func TestNomadVariableBlockSchema(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("has required path attribute", func(t *testing.T) {
+		schema := NomadVariableBlockSchema
+		must.NotNil(t, schema)
+		must.NotNil(t, schema.Attributes)
+
+		// Find path attribute in slice
+		var pathAttr *hcl.AttributeSchema
+		for i := range schema.Attributes {
+			if schema.Attributes[i].Name == "path" {
+				pathAttr = &schema.Attributes[i]
+				break
+			}
+		}
+		must.NotNil(t, pathAttr)
+		must.Eq(t, "path", pathAttr.Name)
+	})
+
+	t.Run("has optional namespace attribute", func(t *testing.T) {
+		schema := NomadVariableBlockSchema
+
+		// Find namespace attribute in slice
+		var namespaceAttr *hcl.AttributeSchema
+		for i := range schema.Attributes {
+			if schema.Attributes[i].Name == "namespace" {
+				namespaceAttr = &schema.Attributes[i]
+				break
+			}
+		}
+		must.NotNil(t, namespaceAttr)
+		must.Eq(t, "namespace", namespaceAttr.Name)
+	})
+
+	t.Run("has required items attribute", func(t *testing.T) {
+		schema := NomadVariableBlockSchema
+
+		// Find items attribute in slice
+		var itemsAttr *hcl.AttributeSchema
+		for i := range schema.Attributes {
+			if schema.Attributes[i].Name == "items" {
+				itemsAttr = &schema.Attributes[i]
+				break
+			}
+		}
+		must.NotNil(t, itemsAttr)
+		must.Eq(t, "items", itemsAttr.Name)
+	})
+}
+
+func TestVariableFileSchema(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("recognizes nomad_variable blocks", func(t *testing.T) {
+		schema := VariableFileSchema
+		must.NotNil(t, schema)
+		must.NotNil(t, schema.Blocks)
+
+		// Find nomad_variable block
+		var nvBlock *hcl.BlockHeaderSchema
+		for i := range schema.Blocks {
+			if schema.Blocks[i].Type == "nomad_variable" {
+				nvBlock = &schema.Blocks[i]
+				break
+			}
+		}
+		must.NotNil(t, nvBlock)
+		must.Eq(t, "nomad_variable", nvBlock.Type)
+		must.SliceContains(t, nvBlock.LabelNames, "name")
+	})
+
+	t.Run("still recognizes variable blocks", func(t *testing.T) {
+		schema := VariableFileSchema
+
+		// Find variable block
+		var varBlock *hcl.BlockHeaderSchema
+		for i := range schema.Blocks {
+			if schema.Blocks[i].Type == "variable" {
+				varBlock = &schema.Blocks[i]
+				break
+			}
+		}
+		must.NotNil(t, varBlock)
+		must.Eq(t, "variable", varBlock.Type)
+		must.SliceContains(t, varBlock.LabelNames, "name")
+	})
+}

--- a/sdk/pack/variables/nomad_variables.go
+++ b/sdk/pack/variables/nomad_variables.go
@@ -1,0 +1,25 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package variables
+
+import (
+	"github.com/zclconf/go-cty/cty"
+)
+
+// NomadVariable represents a Nomad Variable
+// that should be created during pack deployment
+type NomadVariable struct {
+
+	// Name is the label from the nomad_variable block
+	Name string
+
+	// Path is where to store variable in Nomad
+	Path string
+
+	// Namespace is the Nomad namespace
+	Namespace string
+
+	// Items are key-value pairs to store
+	Items map[string]cty.Value
+}

--- a/sdk/pack/variables/nomad_variables_test.go
+++ b/sdk/pack/variables/nomad_variables_test.go
@@ -1,0 +1,59 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package variables
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestNomadVariable(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("creates nomad variable with all fields", func(t *testing.T) {
+		items := map[string]cty.Value{
+			"key1": cty.StringVal("value1"),
+			"key2": cty.StringVal("value2"),
+		}
+
+		nv := &NomadVariable{
+			Name:      "test",
+			Path:      "nomad/jobs/test",
+			Namespace: "default",
+			Items:     items,
+		}
+
+		must.Eq(t, "test", nv.Name)
+		must.Eq(t, "nomad/jobs/test", nv.Path)
+		must.Eq(t, "default", nv.Namespace)
+		must.Eq(t, 2, len(nv.Items))
+	})
+
+	t.Run("creates nomad variable without namespace", func(t *testing.T) {
+		items := map[string]cty.Value{
+			"key1": cty.StringVal("value1"),
+		}
+
+		nv := &NomadVariable{
+			Name:  "test",
+			Path:  "nomad/jobs/test",
+			Items: items,
+		}
+
+		must.Eq(t, "", nv.Namespace)
+	})
+
+	t.Run("creates nomad variable with empty items", func(t *testing.T) {
+		nv := &NomadVariable{
+			Name:  "test",
+			Path:  "nomad/jobs/test",
+			Items: make(map[string]cty.Value),
+		}
+
+		must.Eq(t, 0, len(nv.Items))
+	})
+}


### PR DESCRIPTION
**Description**

Implements Issue #409 - Adds support for Nomad Variables in nomad-pack, allowing packs to define persistent encrypted key-value pairs that are automatically created during pack deployment and deleted during pack destruction.

# Changes

Added nomad_variable block support in pack variables.hcl files
Automatic variable creation during nomad-pack run
Automatic variable deletion during nomad-pack stop
Full HCL parsing and validation for nomad_variable blocks

# Demonstration

Let us take an example file as variables.hcl

nomad_variable "app_config" {
  path = "nomad/jobs/myapp/config"
  namespace = "default"
  items = {
    database_url = "postgres://localhost:5432/mydb"
    api_key = "secret-key-123"
  }
}

nomad_variable "app_secrets" {
  path = "nomad/jobs/myapp/secrets"
  items = {
    admin_password = "super-secret"
  }
}

Then, 
1) Deploy Pack - Variables Created Automatically

<img width="851" height="328" alt="image" src="https://github.com/user-attachments/assets/b64ed45a-ff38-43d2-b2bc-6902c013844b" />

2) Verifying variables exist

<img width="540" height="105" alt="image" src="https://github.com/user-attachments/assets/ff05664f-8d45-4a1f-975c-f39e9442f61e" />

3) View Variable Contents

<img width="802" height="296" alt="image" src="https://github.com/user-attachments/assets/0367c05c-b0de-4a6b-b646-23a30c88a66c" />

4) Variables Deleted on Pack Stop

<img width="689" height="408" alt="image" src="https://github.com/user-attachments/assets/53507890-f702-4750-9b1d-27f199b55023" />

Here, Automatic deletion via nomad-pack stop can work for registry packs but has path resolution issues with local packs 

**Reminders**

- [x] Add `CHANGELOG.md` entry


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

