### PR TITLE
Fix #827: Panic when calling status command with namespace wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ IMPROVEMENTS:
 
 
 BUG FIXES:
-* cli: Fix panic when calling status command with namespace wildcard by adding namespace parameter to QueryOptions [[GH-827](https://github.com/hashicorp/nomad-pack/pull/854)]
+* cli: Fix panic when calling status command with namespace wildcard [[GH-827](https://github.com/hashicorp/nomad-pack/pull/854)]
 
 
 ## 0.4.2 (March 16, 2026)

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -360,7 +360,7 @@ func getDeployedPacks(c *api.Client) (map[string]map[string]struct{}, error) {
 			Namespace: jobStub.Namespace,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("error retrieving job %s: %s", jobStub.ID, err)
+			return nil, fmt.Errorf("error retrieving job %s: %w", jobStub.ID, err)
 		}
 
 		if nomadJob.Meta != nil {


### PR DESCRIPTION
**Description**

## Problem
The `nomad-pack status --namespace='*'` command panics with a nil pointer dereference when attempting to retrieve job information across multiple namespaces.

## Root Cause
When listing jobs across all namespaces using the wildcard `'*'`, the `List()` call returns jobs from all namespaces. However, the subsequent `Info()` call in `getDeployedPacks()` didn't specify which namespace to search in via `QueryOptions`. This caused the API to search only in the default namespace, failing to find jobs from other namespaces and returning `nil`, which led to a nil pointer dereference when accessing `nomadJob.ID` in the error message.

## Solution
Added `Namespace: jobStub.Namespace` to the `QueryOptions` parameter in the `Info()` call of `internal/cli/helpers.go`. This ensures the API searches in the correct namespace for each job.

## Changes
- Modified `internal/cli/helpers.go` line 359
- Added namespace parameter to QueryOptions in `getDeployedPacks()` function

## Testing Steps 

Start Nomad development agent and then deployed a test pack for verification with the help of this command

./bin/nomad-pack run ./fixtures/v2/simple_raw_exec_v2

# Functional testing results:

<img width="715" height="293" alt="image" src="https://github.com/user-attachments/assets/64ecc874-b540-454c-a508-d17765d7b350" />

All commands execute successfully
Pack information displays correctly
No nil pointer dereference error
Wildcard namespace functionality restored

**Reminders**

- [x] Add `CHANGELOG.md` entry


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

