### PR TITLE
fix: Output template rendering fails with --parser-v1 flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 * cli: Fix panic when calling status command with namespace wildcard [[GH-827](https://github.com/hashicorp/nomad-pack/pull/854)]
+* renderer: Fixed output template rendering to respect --parser-v1 flag [[GH-875](https://github.com/hashicorp/nomad-pack/pull/875)]
 
 ## 0.4.2 (March 16, 2026)
 

--- a/internal/pkg/renderer/renderer.go
+++ b/internal/pkg/renderer/renderer.go
@@ -189,9 +189,28 @@ func (r *Renderer) RenderOutput() (string, error) {
 		return "", err
 	}
 
-	ptc, _ := r.pv.ToPackTemplateContext(r.pack)
+	// Choose the appropriate template context based on parser version
+	// V1 parser uses flat map structure(e.g., .packname.variable)
+	// V2 parser uses nested structure with pack metadata (e.g., .my.variable)
+	var templateData interface{}
+	var diags hcl.Diagnostics
+
+	if r.pv.IsV1() {
+		// Use V1 conversion for --parser-v1 flag
+		templateData, diags = r.pv.ConvertVariablesToMapInterface()
+	} else {
+		// Use V2 conversion for default parser (current behavior)
+		templateData, diags = r.pv.ToPackTemplateContext(r.pack)
+	}
+
+	// Check for conversion errors
+	if diags.HasErrors() {
+		return "", fmt.Errorf("failed to create template context: %v", diags)
+	}
+
+	// Execute the template with the correct context
 	var buf strings.Builder
-	if err := r.tpl.ExecuteTemplate(&buf, r.pack.OutputTemplateFile.Name, ptc); err != nil {
+	if err := r.tpl.ExecuteTemplate(&buf, r.pack.OutputTemplateFile.Name, templateData); err != nil {
 		return "", fmt.Errorf("failed to render %s: %w", r.pack.OutputTemplateFile.Name, err)
 	}
 

--- a/internal/pkg/renderer/renderer_output_test.go
+++ b/internal/pkg/renderer/renderer_output_test.go
@@ -1,0 +1,202 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package renderer
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/hashicorp/nomad-pack/internal/pkg/variable/parser"
+	"github.com/hashicorp/nomad-pack/sdk/pack"
+	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// TestRenderOutput_V1Parser_Success tests that output template rendering
+// works correctly with V1 parser. This is the fix for issue #525.
+func TestRenderOutput_V1Parser_Success(t *testing.T) {
+	// Create a pack with output template using V1 syntax
+	p := &pack.Pack{
+		Metadata: &pack.Metadata{
+			Pack: &pack.MetadataPack{
+				Name: "testpack",
+			},
+			App: &pack.MetadataApp{},
+		},
+		OutputTemplateFile: &pack.File{
+			Name:    "outputs.tpl",
+			Content: []byte("Job: {{ .testpack.job_name }}"),
+		},
+	}
+
+	// Create V1 parsed variables
+	pv := &parser.ParsedVariables{}
+	v1Vars := map[string]map[string]*variables.Variable{
+		"testpack": {
+			"job_name": {
+				Name:  "job_name",
+				Value: cty.StringVal("my-job"),
+			},
+		},
+	}
+	err := pv.LoadV1Result(v1Vars)
+	require.NoError(t, err)
+
+	// Create renderer with proper template setup
+	r := &Renderer{
+		pack: p,
+		pv:   pv,
+	}
+
+	// Initialize template with funcMap
+	r.tpl = template.New("test").Funcs(funcMap(r))
+
+	// Render output - should work with V1 parser
+	output, err := r.RenderOutput()
+	require.NoError(t, err)
+	require.Equal(t, "Job: my-job", output)
+}
+
+// TestRenderOutput_V2Parser_Success tests that output template rendering
+// continues to work with V2 parser (no regression).
+func TestRenderOutput_V2Parser_Success(t *testing.T) {
+	// Create a pack with simple output template (no variables)
+	p := &pack.Pack{
+		Metadata: &pack.Metadata{
+			Pack: &pack.MetadataPack{
+				Name: "testpack",
+			},
+			App: &pack.MetadataApp{},
+		},
+		OutputTemplateFile: &pack.File{
+			Name:    "outputs.tpl",
+			Content: []byte("Deployment successful!"),
+		},
+		Path: "/test/path",
+	}
+
+	// Create V2 parsed variables (empty is fine)
+	pv := &parser.ParsedVariables{}
+	v2Vars := map[pack.ID]map[variables.ID]*variables.Variable{}
+	err := pv.LoadV2Result(v2Vars)
+	require.NoError(t, err)
+
+	// Create renderer
+	r := &Renderer{
+		pack: p,
+		pv:   pv,
+	}
+	r.tpl = template.New("test").Funcs(funcMap(r))
+
+	// Render output - should work without error
+	output, err := r.RenderOutput()
+	require.NoError(t, err)
+	require.Equal(t, "Deployment successful!", output)
+}
+
+// TestRenderOutput_NoOutputTemplate tests that when pack has no output
+// template, RenderOutput returns empty string without error.
+func TestRenderOutput_NoOutputTemplate(t *testing.T) {
+	// Create a pack without output template
+	p := &pack.Pack{
+		Metadata: &pack.Metadata{
+			Pack: &pack.MetadataPack{
+				Name: "testpack",
+			},
+			App: &pack.MetadataApp{},
+		},
+		OutputTemplateFile: nil, // No output template
+	}
+
+	// Create V2 parsed variables
+	pv := &parser.ParsedVariables{}
+	v2Vars := map[pack.ID]map[variables.ID]*variables.Variable{}
+	err := pv.LoadV2Result(v2Vars)
+	require.NoError(t, err)
+
+	// Create renderer
+	r := &Renderer{
+		pack: p,
+		pv:   pv,
+		tpl:  template.New("test"),
+	}
+
+	// Render output - should return empty string
+	output, err := r.RenderOutput()
+	require.NoError(t, err)
+	require.Equal(t, "", output)
+}
+
+// TestRenderOutput_EmptyOutputTemplate tests that empty output template
+// returns empty string without error.
+func TestRenderOutput_EmptyOutputTemplate(t *testing.T) {
+	// Create a pack with empty output template
+	p := &pack.Pack{
+		Metadata: &pack.Metadata{
+			Pack: &pack.MetadataPack{
+				Name: "testpack",
+			},
+			App: &pack.MetadataApp{},
+		},
+		OutputTemplateFile: &pack.File{
+			Name:    "outputs.tpl",
+			Content: []byte(""), // Empty content
+		},
+	}
+
+	// Create V2 parsed variables
+	pv := &parser.ParsedVariables{}
+	v2Vars := map[pack.ID]map[variables.ID]*variables.Variable{}
+	err := pv.LoadV2Result(v2Vars)
+	require.NoError(t, err)
+
+	// Create renderer
+	r := &Renderer{
+		pack: p,
+		pv:   pv,
+	}
+	r.tpl = template.New("test").Funcs(funcMap(r))
+
+	// Render output - should return empty string
+	output, err := r.RenderOutput()
+	require.NoError(t, err)
+	require.Equal(t, "", output)
+}
+
+// TestRenderOutput_InvalidTemplateSyntax tests that malformed template
+// syntax returns an error.
+func TestRenderOutput_InvalidTemplateSyntax(t *testing.T) {
+	// Create a pack with invalid template syntax
+	p := &pack.Pack{
+		Metadata: &pack.Metadata{
+			Pack: &pack.MetadataPack{
+				Name: "testpack",
+			},
+			App: &pack.MetadataApp{},
+		},
+		OutputTemplateFile: &pack.File{
+			Name:    "outputs.tpl",
+			Content: []byte("{{ .my.job_name "), // Missing closing braces
+		},
+	}
+
+	// Create V2 parsed variables
+	pv := &parser.ParsedVariables{}
+	v2Vars := map[pack.ID]map[variables.ID]*variables.Variable{}
+	err := pv.LoadV2Result(v2Vars)
+	require.NoError(t, err)
+
+	// Create renderer
+	r := &Renderer{
+		pack: p,
+		pv:   pv,
+	}
+	r.tpl = template.New("test").Funcs(funcMap(r))
+
+	// Render output - should return error
+	output, err := r.RenderOutput()
+	require.Error(t, err)
+	require.Equal(t, "", output)
+}

--- a/internal/pkg/renderer/renderer_output_test.go
+++ b/internal/pkg/renderer/renderer_output_test.go
@@ -10,54 +10,9 @@ import (
 	"github.com/hashicorp/nomad-pack/internal/pkg/variable/parser"
 	"github.com/hashicorp/nomad-pack/sdk/pack"
 	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test/must"
 	"github.com/zclconf/go-cty/cty"
 )
-
-// TestRenderOutput_V1Parser_Success tests that output template rendering
-// works correctly with V1 parser. This is the fix for issue #525.
-func TestRenderOutput_V1Parser_Success(t *testing.T) {
-	// Create a pack with output template using V1 syntax
-	p := &pack.Pack{
-		Metadata: &pack.Metadata{
-			Pack: &pack.MetadataPack{
-				Name: "testpack",
-			},
-			App: &pack.MetadataApp{},
-		},
-		OutputTemplateFile: &pack.File{
-			Name:    "outputs.tpl",
-			Content: []byte("Job: {{ .testpack.job_name }}"),
-		},
-	}
-
-	// Create V1 parsed variables
-	pv := &parser.ParsedVariables{}
-	v1Vars := map[string]map[string]*variables.Variable{
-		"testpack": {
-			"job_name": {
-				Name:  "job_name",
-				Value: cty.StringVal("my-job"),
-			},
-		},
-	}
-	err := pv.LoadV1Result(v1Vars)
-	require.NoError(t, err)
-
-	// Create renderer with proper template setup
-	r := &Renderer{
-		pack: p,
-		pv:   pv,
-	}
-
-	// Initialize template with funcMap
-	r.tpl = template.New("test").Funcs(funcMap(r))
-
-	// Render output - should work with V1 parser
-	output, err := r.RenderOutput()
-	require.NoError(t, err)
-	require.Equal(t, "Job: my-job", output)
-}
 
 // TestRenderOutput_V2Parser_Success tests that output template rendering
 // continues to work with V2 parser (no regression).
@@ -81,19 +36,19 @@ func TestRenderOutput_V2Parser_Success(t *testing.T) {
 	pv := &parser.ParsedVariables{}
 	v2Vars := map[pack.ID]map[variables.ID]*variables.Variable{}
 	err := pv.LoadV2Result(v2Vars)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	// Create renderer
 	r := &Renderer{
 		pack: p,
 		pv:   pv,
 	}
-	r.tpl = template.New("test").Funcs(funcMap(r))
+	r.tpl = template.New("test").Delims("[[", "]]").Funcs(funcMap(r))
 
-	// Render output - should work without error
+	// Render output
 	output, err := r.RenderOutput()
-	require.NoError(t, err)
-	require.Equal(t, "Deployment successful!", output)
+	must.NoError(t, err)
+	must.Eq(t, "Deployment successful!", output)
 }
 
 // TestRenderOutput_NoOutputTemplate tests that when pack has no output
@@ -114,7 +69,7 @@ func TestRenderOutput_NoOutputTemplate(t *testing.T) {
 	pv := &parser.ParsedVariables{}
 	v2Vars := map[pack.ID]map[variables.ID]*variables.Variable{}
 	err := pv.LoadV2Result(v2Vars)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	// Create renderer
 	r := &Renderer{
@@ -125,8 +80,8 @@ func TestRenderOutput_NoOutputTemplate(t *testing.T) {
 
 	// Render output - should return empty string
 	output, err := r.RenderOutput()
-	require.NoError(t, err)
-	require.Equal(t, "", output)
+	must.NoError(t, err)
+	must.Eq(t, "", output)
 }
 
 // TestRenderOutput_EmptyOutputTemplate tests that empty output template
@@ -150,19 +105,19 @@ func TestRenderOutput_EmptyOutputTemplate(t *testing.T) {
 	pv := &parser.ParsedVariables{}
 	v2Vars := map[pack.ID]map[variables.ID]*variables.Variable{}
 	err := pv.LoadV2Result(v2Vars)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	// Create renderer
 	r := &Renderer{
 		pack: p,
 		pv:   pv,
 	}
-	r.tpl = template.New("test").Funcs(funcMap(r))
+	r.tpl = template.New("test").Delims("[[", "]]").Funcs(funcMap(r))
 
 	// Render output - should return empty string
 	output, err := r.RenderOutput()
-	require.NoError(t, err)
-	require.Equal(t, "", output)
+	must.NoError(t, err)
+	must.Eq(t, "", output)
 }
 
 // TestRenderOutput_InvalidTemplateSyntax tests that malformed template
@@ -178,7 +133,7 @@ func TestRenderOutput_InvalidTemplateSyntax(t *testing.T) {
 		},
 		OutputTemplateFile: &pack.File{
 			Name:    "outputs.tpl",
-			Content: []byte("{{ .my.job_name "), // Missing closing braces
+			Content: []byte("[[ .my.job_name "), // Missing closing braces
 		},
 	}
 
@@ -186,17 +141,105 @@ func TestRenderOutput_InvalidTemplateSyntax(t *testing.T) {
 	pv := &parser.ParsedVariables{}
 	v2Vars := map[pack.ID]map[variables.ID]*variables.Variable{}
 	err := pv.LoadV2Result(v2Vars)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	// Create renderer
 	r := &Renderer{
 		pack: p,
 		pv:   pv,
 	}
-	r.tpl = template.New("test").Funcs(funcMap(r))
+	r.tpl = template.New("test").Delims("[[", "]]").Funcs(funcMap(r))
 
 	// Render output - should return error
 	output, err := r.RenderOutput()
-	require.Error(t, err)
-	require.Equal(t, "", output)
+	must.Error(t, err)
+	must.Eq(t, "", output)
+}
+
+// TestRenderOutput_V1Parser_Success tests that output template rendering
+// works correctly with V1 parser.
+func TestRenderOutput_V1Parser_Success(t *testing.T) {
+	// Create a pack with output template using V1 syntax
+	p := &pack.Pack{
+		Metadata: &pack.Metadata{
+			Pack: &pack.MetadataPack{
+				Name: "simple_raw_exec",
+			},
+			App: &pack.MetadataApp{},
+		},
+		OutputTemplateFile: &pack.File{
+			Name:    "outputs.tpl",
+			Content: []byte("Deployed: [[ .simple_raw_exec.job_name ]]"),
+		},
+	}
+
+	// Create V1 parsed variables
+	pv := &parser.ParsedVariables{}
+	v1Vars := map[string]map[string]*variables.Variable{
+		"simple_raw_exec": {
+			"job_name": {
+				Name:  "job_name",
+				Value: cty.StringVal("my-test-job"),
+			},
+		},
+	}
+	err := pv.LoadV1Result(v1Vars)
+	must.NoError(t, err)
+
+	// Create renderer
+	r := &Renderer{
+		pack: p,
+		pv:   pv,
+	}
+	r.tpl = template.New("test").Delims("[[", "]]").Funcs(funcMap(r))
+
+	// Before fix: This would panic with "nil pointer evaluating parser.PackContextable.job_name"
+	// After fix: Should render successfully
+	output, err := r.RenderOutput()
+	must.NoError(t, err)
+	must.Eq(t, "Deployed: my-test-job", output)
+}
+
+// TestRenderOutput_V1Parser_UndefinedVariable tests that referencing a
+// non-existent variable in V1 parser renders as "<no value>" gracefully.
+func TestRenderOutput_V1Parser_UndefinedVariable(t *testing.T) {
+	// Create a pack with template referencing a variable that doesn't exist
+	p := &pack.Pack{
+		Metadata: &pack.Metadata{
+			Pack: &pack.MetadataPack{
+				Name: "testpack",
+			},
+			App: &pack.MetadataApp{},
+		},
+		OutputTemplateFile: &pack.File{
+			Name:    "outputs.tpl",
+			Content: []byte("Job: [[ .testpack.missing_var ]]"),
+		},
+	}
+
+	// Create V1 parsed variables - but without the referenced variable
+	pv := &parser.ParsedVariables{}
+	v1Vars := map[string]map[string]*variables.Variable{
+		"testpack": {
+			"job_name": {
+				Name:  "job_name",
+				Value: cty.StringVal("my-job"),
+			},
+			// Note: missing_var is NOT defined
+		},
+	}
+	err := pv.LoadV1Result(v1Vars)
+	must.NoError(t, err)
+
+	// Create renderer
+	r := &Renderer{
+		pack: p,
+		pv:   pv,
+	}
+	r.tpl = template.New("test").Delims("[[", "]]").Funcs(funcMap(r))
+
+	// Render output
+	output, err := r.RenderOutput()
+	must.NoError(t, err)
+	must.Eq(t, "Job: <no value>", output)
 }

--- a/internal/pkg/renderer/renderer_output_test.go
+++ b/internal/pkg/renderer/renderer_output_test.go
@@ -5,7 +5,6 @@ package renderer
 
 import (
 	"testing"
-	"text/template"
 
 	"github.com/hashicorp/nomad-pack/internal/pkg/variable/parser"
 	"github.com/hashicorp/nomad-pack/sdk/pack"
@@ -14,16 +13,166 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// TestRenderOutput_V2Parser_Success tests that output template rendering
-// continues to work with V2 parser (no regression).
-func TestRenderOutput_V2Parser_Success(t *testing.T) {
-	// Create a pack with simple output template (no variables)
+// TestRenderOutput_V1Parser_Success is the primary regression test.
+// Without the fix, this test fails with "nil pointer evaluating parser.PackContextable.job_name"
+// because RenderOutput() uses V2 context even when --parser-v1 flag is set.
+func TestRenderOutput_V1Parser_Success(t *testing.T) {
 	p := &pack.Pack{
 		Metadata: &pack.Metadata{
-			Pack: &pack.MetadataPack{
-				Name: "testpack",
+			Pack: &pack.MetadataPack{Name: "simple_raw_exec"},
+			App:  &pack.MetadataApp{},
+		},
+		TemplateFiles: []*pack.File{
+			{
+				Name:    "simple_raw_exec/templates/job.nomad.tpl",
+				Content: []byte(`job "[[ .my.job_name ]]" { type = "batch" }`),
 			},
-			App: &pack.MetadataApp{},
+		},
+		OutputTemplateFile: &pack.File{
+			Name:    "outputs.tpl",
+			Content: []byte("[[ .simple_raw_exec.job_name ]] deployed."),
+		},
+	}
+
+	pv := &parser.ParsedVariables{}
+	err := pv.LoadV1Result(map[string]map[string]*variables.Variable{
+		"simple_raw_exec": {
+			"job_name": {Name: "job_name", Value: cty.StringVal("my-job")},
+		},
+	})
+	must.NoError(t, err)
+
+	r := &Renderer{}
+	_, err = r.Render(p, pv)
+	must.NoError(t, err)
+
+	output, err := r.RenderOutput()
+	must.NoError(t, err)
+	must.Eq(t, "my-job deployed.", output)
+}
+
+func TestRenderOutput_V1Parser_WithVariable(t *testing.T) {
+	p := &pack.Pack{
+		Metadata: &pack.Metadata{
+			Pack: &pack.MetadataPack{Name: "testpack"},
+			App:  &pack.MetadataApp{},
+		},
+		TemplateFiles: []*pack.File{
+			{
+				Name:    "testpack/templates/job.nomad.tpl",
+				Content: []byte(`job "[[ .my.job_name ]]" { type = "batch" }`),
+			},
+		},
+		OutputTemplateFile: &pack.File{
+			Name:    "outputs.tpl",
+			Content: []byte("Job [[ .testpack.job_name ]] is ready."),
+		},
+	}
+
+	pv := &parser.ParsedVariables{}
+	err := pv.LoadV1Result(map[string]map[string]*variables.Variable{
+		"testpack": {
+			"job_name": {Name: "job_name", Value: cty.StringVal("test-job")},
+		},
+	})
+	must.NoError(t, err)
+
+	r := &Renderer{}
+	_, err = r.Render(p, pv)
+	must.NoError(t, err)
+
+	output, err := r.RenderOutput()
+	must.NoError(t, err)
+	must.Eq(t, "Job test-job is ready.", output)
+}
+
+func TestRenderOutput_V1Parser_MultipleVariables(t *testing.T) {
+	p := &pack.Pack{
+		Metadata: &pack.Metadata{
+			Pack: &pack.MetadataPack{Name: "mypack"},
+			App:  &pack.MetadataApp{},
+		},
+		TemplateFiles: []*pack.File{
+			{
+				Name:    "mypack/templates/job.nomad.tpl",
+				Content: []byte(`job "[[ .my.job_name ]]" { type = "batch" }`),
+			},
+		},
+		OutputTemplateFile: &pack.File{
+			Name:    "outputs.tpl",
+			Content: []byte("Deployed [[ .mypack.job_name ]] to [[ .mypack.region ]]."),
+		},
+	}
+
+	pv := &parser.ParsedVariables{}
+	err := pv.LoadV1Result(map[string]map[string]*variables.Variable{
+		"mypack": {
+			"job_name": {Name: "job_name", Value: cty.StringVal("my-app")},
+			"region":   {Name: "region", Value: cty.StringVal("us-east-1")},
+		},
+	})
+	must.NoError(t, err)
+
+	r := &Renderer{}
+	_, err = r.Render(p, pv)
+	must.NoError(t, err)
+
+	output, err := r.RenderOutput()
+	must.NoError(t, err)
+	must.Eq(t, "Deployed my-app to us-east-1.", output)
+}
+
+func TestRenderOutput_V1Parser_ComplexTemplate(t *testing.T) {
+	p := &pack.Pack{
+		Metadata: &pack.Metadata{
+			Pack: &pack.MetadataPack{Name: "webapp"},
+			App:  &pack.MetadataApp{},
+		},
+		TemplateFiles: []*pack.File{
+			{
+				Name:    "webapp/templates/job.nomad.tpl",
+				Content: []byte(`job "[[ .my.job_name ]]" { type = "service" }`),
+			},
+		},
+		OutputTemplateFile: &pack.File{
+			Name: "outputs.tpl",
+			Content: []byte(`Deployment Summary:
+- Job: [[ .webapp.job_name ]]
+- Count: [[ .webapp.count ]]
+- Status: Ready`),
+		},
+	}
+
+	pv := &parser.ParsedVariables{}
+	err := pv.LoadV1Result(map[string]map[string]*variables.Variable{
+		"webapp": {
+			"job_name": {Name: "job_name", Value: cty.StringVal("web-server")},
+			"count":    {Name: "count", Value: cty.NumberIntVal(3)},
+		},
+	})
+	must.NoError(t, err)
+
+	r := &Renderer{}
+	_, err = r.Render(p, pv)
+	must.NoError(t, err)
+
+	output, err := r.RenderOutput()
+	must.NoError(t, err)
+	must.StrContains(t, output, "web-server")
+	must.StrContains(t, output, "3")
+}
+
+func TestRenderOutput_V2Parser_Success(t *testing.T) {
+	p := &pack.Pack{
+		Metadata: &pack.Metadata{
+			Pack: &pack.MetadataPack{Name: "testpack"},
+			App:  &pack.MetadataApp{},
+		},
+		TemplateFiles: []*pack.File{
+			{
+				Name:    "testpack/templates/job.nomad.tpl",
+				Content: []byte(`job "test-job" { type = "batch" }`),
+			},
 		},
 		OutputTemplateFile: &pack.File{
 			Name:    "outputs.tpl",
@@ -32,214 +181,48 @@ func TestRenderOutput_V2Parser_Success(t *testing.T) {
 		Path: "/test/path",
 	}
 
-	// Create V2 parsed variables (empty is fine)
 	pv := &parser.ParsedVariables{}
 	v2Vars := map[pack.ID]map[variables.ID]*variables.Variable{}
 	err := pv.LoadV2Result(v2Vars)
 	must.NoError(t, err)
 
-	// Create renderer
-	r := &Renderer{
-		pack: p,
-		pv:   pv,
-	}
-	r.tpl = template.New("test").Delims("[[", "]]").Funcs(funcMap(r))
+	r := &Renderer{}
+	_, err = r.Render(p, pv)
+	must.NoError(t, err)
 
-	// Render output
 	output, err := r.RenderOutput()
 	must.NoError(t, err)
 	must.Eq(t, "Deployment successful!", output)
 }
 
-// TestRenderOutput_NoOutputTemplate tests that when pack has no output
-// template, RenderOutput returns empty string without error.
-func TestRenderOutput_NoOutputTemplate(t *testing.T) {
-	// Create a pack without output template
+func TestRenderOutput_V2Parser_InvalidTemplateSyntax(t *testing.T) {
 	p := &pack.Pack{
 		Metadata: &pack.Metadata{
-			Pack: &pack.MetadataPack{
-				Name: "testpack",
-			},
-			App: &pack.MetadataApp{},
+			Pack: &pack.MetadataPack{Name: "testpack"},
+			App:  &pack.MetadataApp{},
 		},
-		OutputTemplateFile: nil, // No output template
-	}
-
-	// Create V2 parsed variables
-	pv := &parser.ParsedVariables{}
-	v2Vars := map[pack.ID]map[variables.ID]*variables.Variable{}
-	err := pv.LoadV2Result(v2Vars)
-	must.NoError(t, err)
-
-	// Create renderer
-	r := &Renderer{
-		pack: p,
-		pv:   pv,
-		tpl:  template.New("test"),
-	}
-
-	// Render output - should return empty string
-	output, err := r.RenderOutput()
-	must.NoError(t, err)
-	must.Eq(t, "", output)
-}
-
-// TestRenderOutput_EmptyOutputTemplate tests that empty output template
-// returns empty string without error.
-func TestRenderOutput_EmptyOutputTemplate(t *testing.T) {
-	// Create a pack with empty output template
-	p := &pack.Pack{
-		Metadata: &pack.Metadata{
-			Pack: &pack.MetadataPack{
-				Name: "testpack",
+		TemplateFiles: []*pack.File{
+			{
+				Name:    "testpack/templates/job.nomad.tpl",
+				Content: []byte(`job "test" { type = "batch" }`),
 			},
-			App: &pack.MetadataApp{},
 		},
 		OutputTemplateFile: &pack.File{
 			Name:    "outputs.tpl",
-			Content: []byte(""), // Empty content
+			Content: []byte("[[ .my.job_name "),
 		},
 	}
 
-	// Create V2 parsed variables
 	pv := &parser.ParsedVariables{}
 	v2Vars := map[pack.ID]map[variables.ID]*variables.Variable{}
 	err := pv.LoadV2Result(v2Vars)
 	must.NoError(t, err)
 
-	// Create renderer
-	r := &Renderer{
-		pack: p,
-		pv:   pv,
-	}
-	r.tpl = template.New("test").Delims("[[", "]]").Funcs(funcMap(r))
-
-	// Render output - should return empty string
-	output, err := r.RenderOutput()
-	must.NoError(t, err)
-	must.Eq(t, "", output)
-}
-
-// TestRenderOutput_InvalidTemplateSyntax tests that malformed template
-// syntax returns an error.
-func TestRenderOutput_InvalidTemplateSyntax(t *testing.T) {
-	// Create a pack with invalid template syntax
-	p := &pack.Pack{
-		Metadata: &pack.Metadata{
-			Pack: &pack.MetadataPack{
-				Name: "testpack",
-			},
-			App: &pack.MetadataApp{},
-		},
-		OutputTemplateFile: &pack.File{
-			Name:    "outputs.tpl",
-			Content: []byte("[[ .my.job_name "), // Missing closing braces
-		},
-	}
-
-	// Create V2 parsed variables
-	pv := &parser.ParsedVariables{}
-	v2Vars := map[pack.ID]map[variables.ID]*variables.Variable{}
-	err := pv.LoadV2Result(v2Vars)
+	r := &Renderer{}
+	_, err = r.Render(p, pv)
 	must.NoError(t, err)
 
-	// Create renderer
-	r := &Renderer{
-		pack: p,
-		pv:   pv,
-	}
-	r.tpl = template.New("test").Delims("[[", "]]").Funcs(funcMap(r))
-
-	// Render output - should return error
 	output, err := r.RenderOutput()
 	must.Error(t, err)
 	must.Eq(t, "", output)
-}
-
-// TestRenderOutput_V1Parser_Success tests that output template rendering
-// works correctly with V1 parser.
-func TestRenderOutput_V1Parser_Success(t *testing.T) {
-	// Create a pack with output template using V1 syntax
-	p := &pack.Pack{
-		Metadata: &pack.Metadata{
-			Pack: &pack.MetadataPack{
-				Name: "simple_raw_exec",
-			},
-			App: &pack.MetadataApp{},
-		},
-		OutputTemplateFile: &pack.File{
-			Name:    "outputs.tpl",
-			Content: []byte("Deployed: [[ .simple_raw_exec.job_name ]]"),
-		},
-	}
-
-	// Create V1 parsed variables
-	pv := &parser.ParsedVariables{}
-	v1Vars := map[string]map[string]*variables.Variable{
-		"simple_raw_exec": {
-			"job_name": {
-				Name:  "job_name",
-				Value: cty.StringVal("my-test-job"),
-			},
-		},
-	}
-	err := pv.LoadV1Result(v1Vars)
-	must.NoError(t, err)
-
-	// Create renderer
-	r := &Renderer{
-		pack: p,
-		pv:   pv,
-	}
-	r.tpl = template.New("test").Delims("[[", "]]").Funcs(funcMap(r))
-
-	// Before fix: This would panic with "nil pointer evaluating parser.PackContextable.job_name"
-	// After fix: Should render successfully
-	output, err := r.RenderOutput()
-	must.NoError(t, err)
-	must.Eq(t, "Deployed: my-test-job", output)
-}
-
-// TestRenderOutput_V1Parser_UndefinedVariable tests that referencing a
-// non-existent variable in V1 parser renders as "<no value>" gracefully.
-func TestRenderOutput_V1Parser_UndefinedVariable(t *testing.T) {
-	// Create a pack with template referencing a variable that doesn't exist
-	p := &pack.Pack{
-		Metadata: &pack.Metadata{
-			Pack: &pack.MetadataPack{
-				Name: "testpack",
-			},
-			App: &pack.MetadataApp{},
-		},
-		OutputTemplateFile: &pack.File{
-			Name:    "outputs.tpl",
-			Content: []byte("Job: [[ .testpack.missing_var ]]"),
-		},
-	}
-
-	// Create V1 parsed variables - but without the referenced variable
-	pv := &parser.ParsedVariables{}
-	v1Vars := map[string]map[string]*variables.Variable{
-		"testpack": {
-			"job_name": {
-				Name:  "job_name",
-				Value: cty.StringVal("my-job"),
-			},
-			// Note: missing_var is NOT defined
-		},
-	}
-	err := pv.LoadV1Result(v1Vars)
-	must.NoError(t, err)
-
-	// Create renderer
-	r := &Renderer{
-		pack: p,
-		pv:   pv,
-	}
-	r.tpl = template.New("test").Delims("[[", "]]").Funcs(funcMap(r))
-
-	// Render output
-	output, err := r.RenderOutput()
-	must.NoError(t, err)
-	must.Eq(t, "Job: <no value>", output)
 }


### PR DESCRIPTION
**Description**
Fixes #525

## Problem
Output template rendering fails when using --parser-v1 flag with error: "nil pointer evaluating parser.PackContextable.job_name"

<img width="2416" height="1120" alt="image" src="https://github.com/user-attachments/assets/18fdc6d4-32e6-4637-9ed4-6c3420ac9076" />

## Solution
Added parser version check to use correct template context:

V1 parser: ConvertVariablesToMapInterface()
V2 parser: ToPackTemplateContext()

## Changes
Modified: internal/pkg/renderer/renderer.go (added version check)
Added: internal/pkg/renderer/renderer_output_test.go (5 tests)

## Testing
### Template Rendering with V1 Parser
<img width="912" height="310" alt="image" src="https://github.com/user-attachments/assets/04afc023-5d48-4017-8012-b9a5c543f608" />

### Job Deployment success
<img width="969" height="124" alt="image" src="https://github.com/user-attachments/assets/1feeadc6-680f-4b64-8f97-ba8868e1762f" />

<img width="1077" height="108" alt="image" src="https://github.com/user-attachments/assets/ea7b00b3-51a2-46e2-8175-778ee77f7260" />

**Reminders**

- [x] Add `CHANGELOG.md` entry


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

