### PR TITLE
ci: declare permissions on go-tests and jira-sync

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -10,6 +10,12 @@ on:
 
 name: Jira Issue Sync
 
+# Jira mirror only reads issue/comment metadata; writes go to Jira via
+# JIRA_API_TOKEN.
+permissions:
+  issues: read
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` on the two CI workflows that hadn't declared scopes:

- `go-tests.yml` — `contents: read`. Runs gotestsum + the Nomad pack test suite.
- `jira-sync.yml` — `issues: read` + `contents: read`. The atlassian/gajira-* and tomhjp/gh-action-jira-* steps write to Jira via `JIRA_API_TOKEN`; the GitHub side only needs to read the issue event.

YAML validated locally.