### PR TITLE
[Issue #473] Add Vault KV variable source

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -24,14 +24,15 @@ jobs:
           go install gotest.tools/gotestsum@latest
           make test-certs
 
-      # install nomad and consul. consul is required by the Consul KV variable
-      # source integration tests; the tests fail hard if consul is not on $PATH.
-      - name: Install Nomad and Consul
+      # install nomad, consul, and vault. consul is required by the Consul KV
+      # variable source integration tests and vault by the Vault KV variable
+      # source integration tests; the tests fail hard if they are not on $PATH.
+      - name: Install Nomad, Consul, and Vault
         run : |
           sudo apt -y install wget gpg coreutils
           wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt update && sudo apt -y install nomad consul
+          sudo apt update && sudo apt -y install nomad consul vault
 
       # Run tests with nice formatting. Save the original log in /tmp/gotest.log
       - name: Run tests

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.23.0
 	github.com/hashicorp/nomad v1.11.3
 	github.com/hashicorp/nomad/api v0.0.0-20260304165455-489f8b9d1054
+	github.com/hashicorp/vault/api v1.22.0
 	github.com/kr/text v0.2.0
 	github.com/lab47/vterm v0.0.0-20211107042118-80c3d2849f9c
 	github.com/mattn/go-isatty v0.0.22
@@ -241,7 +242,6 @@ require (
 	github.com/hashicorp/raft-autopilot v0.3.0 // indirect
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1 // indirect
 	github.com/hashicorp/serf v0.10.2 // indirect
-	github.com/hashicorp/vault/api v1.22.0 // indirect
 	github.com/hashicorp/vault/api/auth/kubernetes v0.10.0 // indirect
 	github.com/hashicorp/vic v1.5.1-0.20241121050025-d1d58fa204f5 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -282,17 +282,22 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 				Target:  &c.varSources,
 				Default: make([]string, 0),
 				Usage: `Specifies an external variable source as a URL, and may be
-						given more than once to read from several sources. Consul KV
-						is the only source currently supported, using the form
+						given more than once to read from several sources. Two source
+						types are supported. Consul KV uses the form
 						consul://<host>:<port>/<path>; for example,
-						consul://localhost:8500/nomad-pack. The host is optional: omit
-						it (consul:///<path>) to use the standard Consul environment
-						configuration, such as CONSUL_HTTP_ADDR and CONSUL_HTTP_TOKEN.
-						Each variable is read from <path>/<variable-name>, so include
-						any per-pack grouping in the path yourself. Variable sources
-						are applied in order of precedence, highest first: --var, then
-						--var-source, then --var-file, then environment variables. A
-						higher-precedence source overrides any lower one.`,
+						consul://localhost:8500/nomad-pack. Vault KV v2 uses the form
+						vault://<host>:<port>/<mount>/<path>; for example,
+						vault://localhost:8200/secret/nomad-pack. The host is
+						optional: omit it (consul:///<path> or vault:///<mount>/<path>)
+						to use the standard Consul or Vault environment configuration,
+						such as CONSUL_HTTP_ADDR and CONSUL_HTTP_TOKEN, or VAULT_ADDR
+						and VAULT_TOKEN. For Consul each variable is read from
+						<path>/<variable-name>; for Vault each variable is a field of
+						the secret at <mount>/<path>. Include any per-pack grouping in
+						the path yourself. Variable sources are applied in order of
+						precedence, highest first: --var, then --var-source, then
+						--var-file, then environment variables. A higher-precedence
+						source overrides any lower one.`,
 			})
 		}
 

--- a/internal/cli/varsource_config.go
+++ b/internal/cli/varsource_config.go
@@ -17,8 +17,10 @@ import (
 // variable parser.
 //
 // Supported URL formats:
-//   - consul:///path              (uses the Consul environment address)
-//   - consul://host:port/path     (uses the specified Consul address)
+//   - consul:///path                  (uses the Consul environment address)
+//   - consul://host:port/path         (uses the specified Consul address)
+//   - vault:///mount/path             (uses the Vault environment address)
+//   - vault://host:port/mount/path    (uses the specified Vault address)
 func parseVarSourceConfigs(urls []string) ([]source.SourceConfig, error) {
 	if len(urls) == 0 {
 		return nil, nil
@@ -50,8 +52,10 @@ func parseVarSourceConfig(urlStr string) (source.SourceConfig, error) {
 	switch u.Scheme {
 	case "consul":
 		return parseConsulSourceConfig(host, path)
+	case "vault":
+		return parseVaultSourceConfig(host, path)
 	default:
-		return nil, fmt.Errorf("unsupported scheme %q (supported: consul)", u.Scheme)
+		return nil, fmt.Errorf("unsupported scheme %q (supported: consul, vault)", u.Scheme)
 	}
 }
 
@@ -72,5 +76,28 @@ func parseConsulSourceConfig(host, path string) (source.SourceConfig, error) {
 		Priority: source.PriorityConsul,
 		Address:  host,
 		Path:     path,
+	}, nil
+}
+
+// parseVaultSourceConfig builds a Vault KV v2 source config from the host and
+// path of a vault:// URL. The first path segment is the KV v2 mount point and
+// the remainder is the secret path; all variables for the pack are stored as
+// fields of the single secret at <mount>/<path>. A non-empty host overrides the
+// Vault environment address; the rest of the Vault configuration, including the
+// token, comes from the standard Vault environment configuration (VAULT_ADDR,
+// VAULT_TOKEN, and so on) when the source is built.
+//   - vault:///secret/path/to/vars        -> host="",               mount="secret", path="path/to/vars"
+//   - vault://localhost:8200/secret/path  -> host="localhost:8200", mount="secret", path="path"
+func parseVaultSourceConfig(host, path string) (source.SourceConfig, error) {
+	mount, secretPath, ok := strings.Cut(path, "/")
+	if !ok || mount == "" || secretPath == "" {
+		return nil, fmt.Errorf("vault URL must include a mount and path (e.g., vault:///secret/nomad-pack)")
+	}
+
+	return source.VaultSourceConfig{
+		Priority: source.PriorityVault,
+		Address:  host,
+		Mount:    mount,
+		Path:     secretPath,
 	}, nil
 }

--- a/internal/pkg/variable/source/config.go
+++ b/internal/pkg/variable/source/config.go
@@ -4,7 +4,10 @@
 package source
 
 import (
+	"strings"
+
 	"github.com/hashicorp/consul/api"
+	vaultapi "github.com/hashicorp/vault/api"
 )
 
 // SourceConfig is a parsed, lazily-evaluated configuration for a variable
@@ -47,4 +50,38 @@ func (c ConsulSourceConfig) Build() (VariableSource, error) {
 	}
 
 	return NewConsulSource(c.Priority, apiCfg, c.Path)
+}
+
+// VaultSourceConfig holds the parsed configuration for a Vault KV v2 variable
+// source.
+type VaultSourceConfig struct {
+	// Priority is the precedence level applied to the built source.
+	Priority int
+
+	// Address is the Vault HTTP address. When empty, the address from the
+	// standard Vault environment configuration is used.
+	Address string
+
+	// Mount is the KV v2 engine mount point under which the secret lives.
+	Mount string
+
+	// Path is the secret path within the mount. All variables for the pack are
+	// stored as fields of the single secret at <Mount>/<Path>.
+	Path string
+}
+
+// Build implements SourceConfig by constructing a VaultSource.
+func (v VaultSourceConfig) Build() (VariableSource, error) {
+	apiCfg := vaultapi.DefaultConfig()
+	if v.Address != "" {
+		// Vault's API address must be a full URL (unlike Consul's host:port),
+		// so default to https when the URL omits a scheme.
+		addr := v.Address
+		if !strings.Contains(addr, "://") {
+			addr = "https://" + addr
+		}
+		apiCfg.Address = addr
+	}
+
+	return NewVaultSource(v.Priority, apiCfg, v.Mount, v.Path)
 }

--- a/internal/pkg/variable/source/vault_source.go
+++ b/internal/pkg/variable/source/vault_source.go
@@ -1,0 +1,152 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad-pack/sdk/pack"
+	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+// VaultSource fetches variables from a Vault KV v2 secret. All variables for a
+// pack are stored as fields of a single secret at <mount>/<path>. Callers
+// include any per-pack namespacing in the path themselves
+// (for example, mount="secret", path="myapp/config").
+type VaultSource struct {
+	name     string
+	priority int
+	client   *vaultapi.Client
+	mount    string // KV v2 mount point, e.g. "secret"
+	path     string // secret path within the mount, e.g. "myapp/config"
+}
+
+// NewVaultSource creates a new Vault KV v2 variable source.
+// config can be nil to use the default Vault configuration
+// (reads VAULT_ADDR and VAULT_TOKEN from the environment).
+// mount is the KV v2 engine mount point; path is the secret path within it.
+func NewVaultSource(priority int, config *vaultapi.Config, mount, path string) (*VaultSource, error) {
+	mount = strings.Trim(mount, "/")
+	if mount == "" {
+		return nil, fmt.Errorf("vault source requires a non-empty mount point")
+	}
+
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return nil, fmt.Errorf("vault source requires a non-empty secret path")
+	}
+
+	if config == nil {
+		config = vaultapi.DefaultConfig()
+	}
+
+	client, err := vaultapi.NewClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Vault client: %w", err)
+	}
+
+	name := fmt.Sprintf("vault(%s/%s/%s)", config.Address, mount, path)
+
+	return &VaultSource{
+		name:     name,
+		priority: priority,
+		client:   client,
+		mount:    mount,
+		path:     path,
+	}, nil
+}
+
+// Name returns the unique identifier for this source.
+func (v *VaultSource) Name() string {
+	return v.name
+}
+
+// Priority returns the precedence level (higher = higher priority).
+func (v *VaultSource) Priority() int {
+	return v.priority
+}
+
+// Fetch reads the Vault KV v2 secret at <mount>/<path> and returns variables
+// whose names appear in schema. Values are decoded using the schema type —
+// string fields are returned as-is; all other types are JSON-decoded.
+//
+// Each field of the secret maps to one pack variable. Fields not present in
+// the schema are silently skipped. An empty value for a non-string variable
+// is an error; empty strings are valid for string variables.
+//
+// Returns nil (not an error) when the secret does not exist at the given path
+func (v *VaultSource) Fetch(ctx context.Context, _ pack.ID, schema map[variables.ID]*variables.Variable) ([]*variables.Variable, error) {
+	secret, err := v.client.KVv2(v.mount).Get(ctx, v.path)
+	if err != nil {
+		if errors.Is(err, vaultapi.ErrSecretNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read Vault secret at %s/%s: %w", v.mount, v.path, err)
+	}
+
+	// A deleted secret has nil Data.
+	if secret.Data == nil {
+		return nil, nil
+	}
+
+	vars := make([]*variables.Variable, 0, len(secret.Data))
+	for rawKey, rawVal := range secret.Data {
+		schemaVar, inSchema := schema[variables.ID(rawKey)]
+		if !inSchema {
+			continue
+		}
+
+		// Vault KV stores all values as strings.
+		str, ok := rawVal.(string)
+		if !ok {
+			return nil, fmt.Errorf("vault value for %s is not a string (got %T)", rawKey, rawVal)
+		}
+
+		// A non-string variable has no meaningful empty form (there is no "empty"
+		// number or bool), so an empty value almost always means the Vault field
+		// was misconfigured. Empty values for string variables are valid and kept as "".
+		if str == "" && schemaVar.Type != cty.String {
+			return nil, fmt.Errorf("empty Vault value for %s: a %s value is required", rawKey, schemaVar.Type.FriendlyName())
+		}
+
+		expectedType := schemaVar.ConstraintType
+		if expectedType == cty.NilType {
+			expectedType = schemaVar.Type
+		}
+
+		value, err := v.convertValue([]byte(str), expectedType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert value for %s: %w", rawKey, err)
+		}
+
+		vars = append(vars, &variables.Variable{
+			Name:  variables.ID(rawKey),
+			Value: value,
+			Type:  value.Type(),
+		})
+	}
+
+	return vars, nil
+}
+
+// convertValue converts a raw Vault string value into a cty.Value of the
+// expected type using the same schema-aware rule as ConsulSource.
+func (v *VaultSource) convertValue(data []byte, expectedType cty.Type) (cty.Value, error) {
+	if expectedType == cty.String {
+		return cty.StringVal(string(data)), nil
+	}
+
+	val, err := ctyjson.Unmarshal(data, expectedType)
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("decoding Vault value as %s: %w", expectedType.FriendlyName(), err)
+	}
+
+	return val, nil
+}

--- a/internal/pkg/variable/source/vault_source.go
+++ b/internal/pkg/variable/source/vault_source.go
@@ -82,6 +82,7 @@ func (v *VaultSource) Priority() int {
 // is an error; empty strings are valid for string variables.
 //
 // Returns nil (not an error) when the secret does not exist at the given path
+// or when the latest version has been deleted.
 func (v *VaultSource) Fetch(ctx context.Context, _ pack.ID, schema map[variables.ID]*variables.Variable) ([]*variables.Variable, error) {
 	secret, err := v.client.KVv2(v.mount).Get(ctx, v.path)
 	if err != nil {
@@ -106,16 +107,16 @@ func (v *VaultSource) Fetch(ctx context.Context, _ pack.ID, schema map[variables
 		// Vault KV stores all values as strings.
 		str, ok := rawVal.(string)
 		if !ok {
-			return nil, fmt.Errorf("vault value for %s is not a string (got %T)", rawKey, rawVal)
+			return nil, fmt.Errorf("field %s is not a string (got %T)", rawKey, rawVal)
 		}
 
-		// A non-string variable has no meaningful empty form (there is no "empty"
-		// number or bool), so an empty value almost always means the Vault field
-		// was misconfigured. Empty values for string variables are valid and kept as "".
+		// Empty values for string variables are valid and kept as "".
 		if str == "" && schemaVar.Type != cty.String {
 			return nil, fmt.Errorf("empty Vault value for %s: a %s value is required", rawKey, schemaVar.Type.FriendlyName())
 		}
 
+		// Convert using the variable's constraint type. ConstraintType preserves
+		// optional() attributes.
 		expectedType := schemaVar.ConstraintType
 		if expectedType == cty.NilType {
 			expectedType = schemaVar.Type
@@ -137,12 +138,13 @@ func (v *VaultSource) Fetch(ctx context.Context, _ pack.ID, schema map[variables
 }
 
 // convertValue converts a raw Vault string value into a cty.Value of the
-// expected type using the same schema-aware rule as ConsulSource.
+// expected type.
 func (v *VaultSource) convertValue(data []byte, expectedType cty.Type) (cty.Value, error) {
 	if expectedType == cty.String {
 		return cty.StringVal(string(data)), nil
 	}
 
+	// For every other type, let cty decode the JSON directly into the expected type.
 	val, err := ctyjson.Unmarshal(data, expectedType)
 	if err != nil {
 		return cty.NilVal, fmt.Errorf("decoding Vault value as %s: %w", expectedType.FriendlyName(), err)

--- a/internal/pkg/variable/source/vault_source_integration_test.go
+++ b/internal/pkg/variable/source/vault_source_integration_test.go
@@ -1,0 +1,270 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad-pack/sdk/pack"
+	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
+	"github.com/hashicorp/nomad/ci"
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/shoenig/test/must"
+	"github.com/zclconf/go-cty/cty"
+)
+
+const devRootToken = "root"
+
+func startTestVault(t *testing.T) string {
+	t.Helper()
+
+	port := ci.PortAllocator.One()
+	listen := fmt.Sprintf("127.0.0.1:%d", port)
+	addr := "http://" + listen
+
+	cmd := exec.Command("vault", "server", "-dev",
+		"-dev-root-token-id="+devRootToken,
+		"-dev-listen-address="+listen,
+	)
+	if !testing.Verbose() {
+		cmd.Stdout = io.Discard
+		cmd.Stderr = io.Discard
+	}
+	must.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	waitForVault(t, addr)
+	return addr
+}
+
+func waitForVault(t *testing.T, addr string) {
+	t.Helper()
+
+	cfg := vaultapi.DefaultConfig()
+	cfg.Address = addr
+	client, err := vaultapi.NewClient(cfg)
+	must.NoError(t, err)
+
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		health, err := client.Sys().Health()
+		if err == nil && health.Initialized && !health.Sealed {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatal("vault dev server did not become ready within 20s")
+}
+
+func newVaultClient(t *testing.T, addr string) *vaultapi.Client {
+	t.Helper()
+	cfg := vaultapi.DefaultConfig()
+	cfg.Address = addr
+	client, err := vaultapi.NewClient(cfg)
+	must.NoError(t, err)
+	client.SetToken(devRootToken)
+	return client
+}
+
+func writeSecret(t *testing.T, client *vaultapi.Client, path string, data map[string]any) {
+	t.Helper()
+	_, err := client.KVv2("secret").Put(t.Context(), path, data)
+	must.NoError(t, err)
+}
+
+func newVaultSourceForServer(t *testing.T, addr, mount, path string) *VaultSource {
+	t.Helper()
+	cfg := vaultapi.DefaultConfig()
+	cfg.Address = addr
+	src, err := NewVaultSource(PriorityVault, cfg, mount, path)
+	must.NoError(t, err)
+	src.client.SetToken(devRootToken)
+	return src
+}
+
+func vaultVarsByName(vars []*variables.Variable) map[string]*variables.Variable {
+	out := make(map[string]*variables.Variable, len(vars))
+	for _, v := range vars {
+		out[string(v.Name)] = v
+	}
+	return out
+}
+
+func TestVaultSource_Fetch(t *testing.T) {
+	ci.Parallel(t)
+
+	addr := startTestVault(t)
+	client := newVaultClient(t, addr)
+
+	packID := pack.ID("webapp")
+	schema := map[variables.ID]*variables.Variable{
+		"replicas": {Name: "replicas", Type: cty.Number},
+		"region":   {Name: "region", Type: cty.String},
+		"name":     {Name: "name", Type: cty.String},
+	}
+
+	t.Run("fetches typed variables from secret", func(t *testing.T) {
+		writeSecret(t, client, "deploy/webapp", map[string]any{
+			"replicas": "3",
+			"region":   "us-west-2",
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "deploy/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 2, vars)
+
+		got := vaultVarsByName(vars)
+		replicas, _ := got["replicas"].Value.AsBigFloat().Int64()
+		must.Eq(t, int64(3), replicas)
+		must.Eq(t, "us-west-2", got["region"].Value.AsString())
+	})
+
+	t.Run("fields not in pack schema are ignored", func(t *testing.T) {
+		writeSecret(t, client, "staging/webapp", map[string]any{
+			"region":      "us-east-1",
+			"not_in_pack": "ignored",
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "staging/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "region", string(vars[0].Name))
+	})
+
+	t.Run("empty value for non-string variable is an error", func(t *testing.T) {
+		writeSecret(t, client, "prod/webapp", map[string]any{
+			"replicas": "",
+			"region":   "us-west-1",
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "prod/webapp")
+		_, err := src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "empty Vault value")
+	})
+
+	t.Run("object with optional field missing is valid", func(t *testing.T) {
+		objSchema := map[variables.ID]*variables.Variable{
+			"svc": {
+				Name: "svc",
+				Type: cty.Object(map[string]cty.Type{
+					"name": cty.String,
+					"port": cty.Number,
+				}),
+				ConstraintType: cty.ObjectWithOptionalAttrs(
+					map[string]cty.Type{"name": cty.String, "port": cty.Number},
+					[]string{"port"},
+				),
+			},
+		}
+		writeSecret(t, client, "services/webapp", map[string]any{
+			"svc": `{"name":"api"}`,
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "services/webapp")
+		vars, err := src.Fetch(t.Context(), packID, objSchema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "api", vars[0].Value.GetAttr("name").AsString())
+		must.True(t, vars[0].Value.GetAttr("port").IsNull())
+	})
+
+	t.Run("bool variable is decoded from JSON", func(t *testing.T) {
+		boolSchema := map[variables.ID]*variables.Variable{
+			"enabled": {Name: "enabled", Type: cty.Bool},
+		}
+		writeSecret(t, client, "config/webapp", map[string]any{
+			"enabled": "true",
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "config/webapp")
+		vars, err := src.Fetch(t.Context(), packID, boolSchema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.True(t, vars[0].Value.True())
+	})
+
+	t.Run("malformed JSON for non-string variable is an error", func(t *testing.T) {
+		writeSecret(t, client, "broken/webapp", map[string]any{
+			"replicas": "not-a-number",
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "broken/webapp")
+		_, err := src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "decoding Vault value")
+	})
+
+	t.Run("empty string value is kept for string variable", func(t *testing.T) {
+		writeSecret(t, client, "defaults/webapp", map[string]any{
+			"name": "",
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "defaults/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "", vars[0].Value.AsString())
+	})
+
+	t.Run("secret not found returns empty result", func(t *testing.T) {
+		src := newVaultSourceForServer(t, addr, "secret", "empty/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 0, vars)
+	})
+
+	t.Run("non-string field value is an error", func(t *testing.T) {
+		// replicas is stored as a JSON number rather than a string.
+		writeSecret(t, client, "typed/webapp", map[string]any{
+			"replicas": 3,
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "typed/webapp")
+		_, err := src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "is not a string")
+	})
+
+	t.Run("deleted secret returns empty result", func(t *testing.T) {
+		writeSecret(t, client, "deleted/webapp", map[string]any{
+			"region": "us-west-2",
+		})
+		must.NoError(t, client.KVv2("secret").Delete(t.Context(), "deleted/webapp"))
+
+		src := newVaultSourceForServer(t, addr, "secret", "deleted/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 0, vars)
+	})
+
+	t.Run("vault unavailable returns read error", func(t *testing.T) {
+		cfg := vaultapi.DefaultConfig()
+		cfg.Address = fmt.Sprintf("http://127.0.0.1:%d", ci.PortAllocator.One())
+		src, err := NewVaultSource(PriorityVault, cfg, "secret", "any/path")
+		must.NoError(t, err)
+		src.client.SetToken(devRootToken)
+
+		_, err = src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "failed to read Vault secret")
+	})
+
+	t.Run("mount and path with surrounding slashes fetch correctly", func(t *testing.T) {
+		writeSecret(t, client, "norm/webapp", map[string]any{
+			"region": "ap-southeast-1",
+		})
+
+		src := newVaultSourceForServer(t, addr, "/secret/", "/norm/webapp/")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "ap-southeast-1", vaultVarsByName(vars)["region"].Value.AsString())
+	})
+}


### PR DESCRIPTION
**Description**

This PR implements Subtask 3 of Issue https://github.com/hashicorp/nomad-pack/issues/473 (External Variable Sources for
nomad-pack). It adds support for fetching pack variables from Vault KV

E2E Testing:

<img width="773" height="712" alt="image" src="https://github.com/user-attachments/assets/cece83f4-42bf-4ad4-ae7f-34015f2bd29f" />

<img width="917" height="962" alt="image" src="https://github.com/user-attachments/assets/752a501d-30eb-40f1-b0ed-8b2e299a3816" />

<img width="978" height="603" alt="image" src="https://github.com/user-attachments/assets/620beb50-3fcc-49f2-80ee-bc1b191fff8d" />


**Reminders**

- [ ] Add `CHANGELOG.md` entry


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

