### PR TITLE
[Issue #473] Add Nomad Variables variable source

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -24,8 +24,9 @@ jobs:
           go install gotest.tools/gotestsum@latest
           make test-certs
 
-      # install nomad, consul, and vault. consul is required by the Consul KV
-      # variable source integration tests and vault by the Vault KV variable
+      # install nomad, consul, and vault. nomad is required by the Nomad
+      # Variables variable source integration tests, consul by the Consul KV
+      # variable source integration tests, and vault by the Vault KV variable
       # source integration tests; the tests fail hard if they are not on $PATH.
       - name: Install Nomad, Consul, and Vault
         run : |

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -293,10 +293,12 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 						(consul:///<path>, vault:///<mount>/<path>, or nomad:///<path>)
 						to use the standard environment configuration for that tool,
 						such as CONSUL_HTTP_ADDR and CONSUL_HTTP_TOKEN, VAULT_ADDR and
-						VAULT_TOKEN, or NOMAD_ADDR and NOMAD_TOKEN. For Consul each
-						variable is read from <path>/<variable-name>; for Vault each
-						variable is a field of the secret at <mount>/<path>; for Nomad
-						each variable is an item of the Nomad Variable at <path>. Include
+						VAULT_TOKEN, or NOMAD_ADDR and NOMAD_TOKEN. NOMAD_ADDR may point
+						at a unix:// socket, so Pack can run as a Nomad job and read
+						variables over the task's API socket. For Consul each variable
+						is read from <path>/<variable-name>; for Vault each variable is
+						a field of the secret at <mount>/<path>; for Nomad each variable
+						is an item of the Nomad Variable at <path>. Include
 						any per-pack grouping in the path yourself. Variable sources are
 						applied in order of precedence, highest first: --var, then
 						--var-source, then --var-file, then environment variables. A

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -282,22 +282,25 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 				Target:  &c.varSources,
 				Default: make([]string, 0),
 				Usage: `Specifies an external variable source as a URL, and may be
-						given more than once to read from several sources. Two source
+						given more than once to read from several sources. Three source
 						types are supported. Consul KV uses the form
 						consul://<host>:<port>/<path>; for example,
 						consul://localhost:8500/nomad-pack. Vault KV v2 uses the form
 						vault://<host>:<port>/<mount>/<path>; for example,
-						vault://localhost:8200/secret/nomad-pack. The host is
-						optional: omit it (consul:///<path> or vault:///<mount>/<path>)
-						to use the standard Consul or Vault environment configuration,
-						such as CONSUL_HTTP_ADDR and CONSUL_HTTP_TOKEN, or VAULT_ADDR
-						and VAULT_TOKEN. For Consul each variable is read from
-						<path>/<variable-name>; for Vault each variable is a field of
-						the secret at <mount>/<path>. Include any per-pack grouping in
-						the path yourself. Variable sources are applied in order of
-						precedence, highest first: --var, then --var-source, then
-						--var-file, then environment variables. A higher-precedence
-						source overrides any lower one.`,
+						vault://localhost:8200/secret/nomad-pack. Nomad Variables use
+						the form nomad://<host>:<port>/<path>; for example,
+						nomad://localhost:4646/nomad-pack. The host is optional: omit it
+						(consul:///<path>, vault:///<mount>/<path>, or nomad:///<path>)
+						to use the standard environment configuration for that tool,
+						such as CONSUL_HTTP_ADDR and CONSUL_HTTP_TOKEN, VAULT_ADDR and
+						VAULT_TOKEN, or NOMAD_ADDR and NOMAD_TOKEN. For Consul each
+						variable is read from <path>/<variable-name>; for Vault each
+						variable is a field of the secret at <mount>/<path>; for Nomad
+						each variable is an item of the Nomad Variable at <path>. Include
+						any per-pack grouping in the path yourself. Variable sources are
+						applied in order of precedence, highest first: --var, then
+						--var-source, then --var-file, then environment variables. A
+						higher-precedence source overrides any lower one.`,
 			})
 		}
 

--- a/internal/cli/varsource_config.go
+++ b/internal/cli/varsource_config.go
@@ -21,6 +21,8 @@ import (
 //   - consul://host:port/path         (uses the specified Consul address)
 //   - vault:///mount/path             (uses the Vault environment address)
 //   - vault://host:port/mount/path    (uses the specified Vault address)
+//   - nomad:///path                   (uses the Nomad environment address)
+//   - nomad://host:port/path          (uses the specified Nomad address)
 func parseVarSourceConfigs(urls []string) ([]source.SourceConfig, error) {
 	if len(urls) == 0 {
 		return nil, nil
@@ -54,8 +56,10 @@ func parseVarSourceConfig(urlStr string) (source.SourceConfig, error) {
 		return parseConsulSourceConfig(host, path)
 	case "vault":
 		return parseVaultSourceConfig(host, path)
+	case "nomad":
+		return parseNomadSourceConfig(host, path)
 	default:
-		return nil, fmt.Errorf("unsupported scheme %q (supported: consul, vault)", u.Scheme)
+		return nil, fmt.Errorf("unsupported scheme %q (supported: consul, vault, nomad)", u.Scheme)
 	}
 }
 
@@ -99,5 +103,26 @@ func parseVaultSourceConfig(host, path string) (source.SourceConfig, error) {
 		Address:  host,
 		Mount:    mount,
 		Path:     secretPath,
+	}, nil
+}
+
+// parseNomadSourceConfig builds a Nomad Variables source config from the host
+// and path of a nomad:// URL. The path is the Nomad Variable path; all variables
+// for the pack are stored as items of the single Nomad Variable at <path>. A
+// non-empty host overrides the Nomad environment address; the rest of the Nomad
+// configuration, including the token and namespace, comes from the standard
+// Nomad environment configuration (NOMAD_ADDR, NOMAD_TOKEN, NOMAD_NAMESPACE, and
+// so on) when the source is built.
+//   - nomad:///path/to/vars        -> host="",               path="path/to/vars"
+//   - nomad://localhost:4646/path  -> host="localhost:4646", path="path"
+func parseNomadSourceConfig(host, path string) (source.SourceConfig, error) {
+	if path == "" {
+		return nil, fmt.Errorf("nomad URL must include a path (e.g., nomad:///nomad-pack)")
+	}
+
+	return source.NomadSourceConfig{
+		Priority: source.PriorityNomad,
+		Address:  host,
+		Path:     path,
 	}, nil
 }

--- a/internal/pkg/variable/source/config.go
+++ b/internal/pkg/variable/source/config.go
@@ -103,12 +103,21 @@ type NomadSourceConfig struct {
 }
 
 // Build implements SourceConfig by constructing a NomadSource.
+//
+// When no host is supplied (the nomad:///path form), the address and every
+// other client setting come entirely from the standard Nomad environment via
+// nomadapi.DefaultConfig() — NOMAD_ADDR, NOMAD_TOKEN, NOMAD_NAMESPACE, and so
+// on flow through unchanged. NOMAD_ADDR may point at a unix socket (unix://…),
+// so running Pack inside a Nomad task and aiming it at the task's API socket
+// needs no special handling here: the nomad/api client dials the socket
+// natively and the workload's token authenticates as usual.
 func (n NomadSourceConfig) Build() (VariableSource, error) {
 	apiCfg := nomadapi.DefaultConfig()
 	if n.Address != "" {
-		// Nomad's API address must be a full URL (unlike Consul's host:port), so
-		// default to http when the URL omits a scheme — matching Nomad's own
-		// default address (http://127.0.0.1:4646).
+		// A host taken from the URL is always a TCP host:port. Nomad's API
+		// address must be a full URL, so default to http when it omits a scheme —
+		// matching Nomad's own default address (http://127.0.0.1:4646). Use the
+		// nomad:///path form with NOMAD_ADDR for a unix socket or https.
 		addr := n.Address
 		if !strings.Contains(addr, "://") {
 			addr = "http://" + addr

--- a/internal/pkg/variable/source/config.go
+++ b/internal/pkg/variable/source/config.go
@@ -102,22 +102,16 @@ type NomadSourceConfig struct {
 	Path string
 }
 
-// Build implements SourceConfig by constructing a NomadSource.
-//
-// When no host is supplied (the nomad:///path form), the address and every
-// other client setting come entirely from the standard Nomad environment via
-// nomadapi.DefaultConfig() — NOMAD_ADDR, NOMAD_TOKEN, NOMAD_NAMESPACE, and so
-// on flow through unchanged. NOMAD_ADDR may point at a unix socket (unix://…),
-// so running Pack inside a Nomad task and aiming it at the task's API socket
-// needs no special handling here: the nomad/api client dials the socket
-// natively and the workload's token authenticates as usual.
+// Build implements SourceConfig by constructing a NomadSource. When no host is
+// supplied (the nomad:///path form), the address and the rest of the client
+// settings come from nomadapi.DefaultConfig(), so NOMAD_ADDR is honored as-is —
+// including a unix:// socket such as the Task API socket.
 func (n NomadSourceConfig) Build() (VariableSource, error) {
 	apiCfg := nomadapi.DefaultConfig()
 	if n.Address != "" {
 		// A host taken from the URL is always a TCP host:port. Nomad's API
 		// address must be a full URL, so default to http when it omits a scheme —
-		// matching Nomad's own default address (http://127.0.0.1:4646). Use the
-		// nomad:///path form with NOMAD_ADDR for a unix socket or https.
+		// matching Nomad's own default address (http://127.0.0.1:4646).
 		addr := n.Address
 		if !strings.Contains(addr, "://") {
 			addr = "http://" + addr

--- a/internal/pkg/variable/source/config.go
+++ b/internal/pkg/variable/source/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/consul/api"
+	nomadapi "github.com/hashicorp/nomad/api"
 	vaultapi "github.com/hashicorp/vault/api"
 )
 
@@ -84,4 +85,36 @@ func (v VaultSourceConfig) Build() (VariableSource, error) {
 	}
 
 	return NewVaultSource(v.Priority, apiCfg, v.Mount, v.Path)
+}
+
+// NomadSourceConfig holds the parsed configuration for a Nomad Variables
+// variable source.
+type NomadSourceConfig struct {
+	// Priority is the precedence level applied to the built source.
+	Priority int
+
+	// Address is the Nomad HTTP address. When empty, the address from the
+	// standard Nomad environment configuration is used.
+	Address string
+
+	// Path is the Nomad Variable path. All variables for the pack are stored as
+	// items of the single Nomad Variable at this path.
+	Path string
+}
+
+// Build implements SourceConfig by constructing a NomadSource.
+func (n NomadSourceConfig) Build() (VariableSource, error) {
+	apiCfg := nomadapi.DefaultConfig()
+	if n.Address != "" {
+		// Nomad's API address must be a full URL (unlike Consul's host:port), so
+		// default to http when the URL omits a scheme — matching Nomad's own
+		// default address (http://127.0.0.1:4646).
+		addr := n.Address
+		if !strings.Contains(addr, "://") {
+			addr = "http://" + addr
+		}
+		apiCfg.Address = addr
+	}
+
+	return NewNomadSource(n.Priority, apiCfg, n.Path)
 }

--- a/internal/pkg/variable/source/nomad_source.go
+++ b/internal/pkg/variable/source/nomad_source.go
@@ -1,0 +1,130 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+
+	"github.com/hashicorp/nomad-pack/sdk/pack"
+	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+// NomadSource fetches variables from a Nomad Variable. All variables for a pack
+// are stored as items of a single Nomad Variable at <path>.
+type NomadSource struct {
+	name     string
+	priority int
+	client   *api.Client
+	path     string // Nomad Variable path, e.g. "nomad-pack/myapp"
+}
+
+// NewNomadSource creates a new Nomad Variables source. config can be nil to use
+// the default Nomad configuration (reads NOMAD_ADDR, NOMAD_TOKEN, and
+// NOMAD_NAMESPACE from the environment). path is the Nomad Variable path whose
+// items become pack variables.
+func NewNomadSource(priority int, config *api.Config, path string) (*NomadSource, error) {
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return nil, fmt.Errorf("nomad source requires a non-empty variable path")
+	}
+
+	if config == nil {
+		config = api.DefaultConfig()
+	}
+
+	client, err := api.NewClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Nomad client: %w", err)
+	}
+
+	name := fmt.Sprintf("nomad(%s/%s)", config.Address, path)
+
+	return &NomadSource{
+		name:     name,
+		priority: priority,
+		client:   client,
+		path:     path,
+	}, nil
+}
+
+// Name returns the unique identifier for this source.
+func (n *NomadSource) Name() string {
+	return n.name
+}
+
+// Priority returns the precedence level (higher = higher priority).
+func (n *NomadSource) Priority() int {
+	return n.priority
+}
+
+// Fetch reads the Nomad Variable at <path> and returns variables whose names
+// appear in schema. Values are decoded using the schema type — string items are
+// returned as-is; all other types are JSON-decoded.
+//
+// Each item of the Nomad Variable maps to one pack variable.
+// Returns nil (not an error) when no Nomad Variable exists at the given path.
+func (n *NomadSource) Fetch(ctx context.Context, _ pack.ID, schema map[variables.ID]*variables.Variable) ([]*variables.Variable, error) {
+	variable, _, err := n.client.Variables().Read(n.path, (&api.QueryOptions{}).WithContext(ctx))
+	if err != nil {
+		if errors.Is(err, api.ErrVariablePathNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read Nomad variable at %s: %w", n.path, err)
+	}
+
+	vars := make([]*variables.Variable, 0, len(variable.Items))
+	for rawKey, str := range variable.Items {
+		schemaVar, inSchema := schema[variables.ID(rawKey)]
+		if !inSchema {
+			continue
+		}
+
+		// Empty values for string variables are valid and kept as "".
+		if str == "" && schemaVar.Type != cty.String {
+			return nil, fmt.Errorf("empty Nomad value for %s: a %s value is required", rawKey, schemaVar.Type.FriendlyName())
+		}
+
+		// Convert using the variable's constraint type. ConstraintType preserves
+		// optional() attributes.
+		expectedType := schemaVar.ConstraintType
+		if expectedType == cty.NilType {
+			expectedType = schemaVar.Type
+		}
+
+		value, err := n.convertValue([]byte(str), expectedType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert value for %s: %w", rawKey, err)
+		}
+
+		vars = append(vars, &variables.Variable{
+			Name:  variables.ID(rawKey),
+			Value: value,
+			Type:  value.Type(),
+		})
+	}
+
+	return vars, nil
+}
+
+// convertValue converts a raw Nomad Variable item value into a cty.Value of the
+// expected type.
+func (n *NomadSource) convertValue(data []byte, expectedType cty.Type) (cty.Value, error) {
+	if expectedType == cty.String {
+		return cty.StringVal(string(data)), nil
+	}
+
+	val, err := ctyjson.Unmarshal(data, expectedType)
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("decoding Nomad value as %s: %w", expectedType.FriendlyName(), err)
+	}
+
+	return val, nil
+}

--- a/internal/pkg/variable/source/nomad_source.go
+++ b/internal/pkg/variable/source/nomad_source.go
@@ -9,10 +9,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/nomad/api"
-
 	"github.com/hashicorp/nomad-pack/sdk/pack"
 	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
+	"github.com/hashicorp/nomad/api"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 )

--- a/internal/pkg/variable/source/nomad_source_integration_test.go
+++ b/internal/pkg/variable/source/nomad_source_integration_test.go
@@ -1,0 +1,218 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"testing"
+
+	"github.com/hashicorp/nomad-pack/sdk/pack"
+	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test/must"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func startTestNomad(t *testing.T) *testutil.TestServer {
+	t.Helper()
+
+	if _, err := exec.LookPath("nomad"); err != nil {
+		t.Fatalf("nomad binary not found on $PATH: %v", err)
+	}
+
+	srv := testutil.NewTestServer(t, func(c *testutil.TestServerConfig) {
+		if !testing.Verbose() {
+			c.Stdout = io.Discard
+			c.Stderr = io.Discard
+		}
+	})
+	t.Cleanup(srv.Stop)
+	return srv
+}
+
+func newNomadClient(t *testing.T, srv *testutil.TestServer) *api.Client {
+	t.Helper()
+	cfg := api.DefaultConfig()
+	cfg.Address = "http://" + srv.HTTPAddr
+	client, err := api.NewClient(cfg)
+	must.NoError(t, err)
+	return client
+}
+
+func writeNomadVar(t *testing.T, client *api.Client, path string, items map[string]string) {
+	t.Helper()
+	_, _, err := client.Variables().Create(&api.Variable{
+		Path:  path,
+		Items: items,
+	}, nil)
+	must.NoError(t, err)
+}
+
+func newNomadSourceForServer(t *testing.T, srv *testutil.TestServer, path string) *NomadSource {
+	t.Helper()
+	cfg := api.DefaultConfig()
+	cfg.Address = "http://" + srv.HTTPAddr
+	src, err := NewNomadSource(PriorityNomad, cfg, path)
+	must.NoError(t, err)
+	return src
+}
+
+func nomadVarsByName(vars []*variables.Variable) map[string]*variables.Variable {
+	out := make(map[string]*variables.Variable, len(vars))
+	for _, v := range vars {
+		out[string(v.Name)] = v
+	}
+	return out
+}
+
+func TestNomadSource_Fetch(t *testing.T) {
+	ci.Parallel(t)
+
+	srv := startTestNomad(t)
+	client := newNomadClient(t, srv)
+
+	packID := pack.ID("webapp")
+	schema := map[variables.ID]*variables.Variable{
+		"replicas": {Name: "replicas", Type: cty.Number},
+		"region":   {Name: "region", Type: cty.String},
+		"name":     {Name: "name", Type: cty.String},
+	}
+
+	t.Run("fetches typed variables from a variable", func(t *testing.T) {
+		writeNomadVar(t, client, "deploy/webapp", map[string]string{
+			"replicas": "3",
+			"region":   "us-west-2",
+		})
+
+		src := newNomadSourceForServer(t, srv, "deploy/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 2, vars)
+
+		got := nomadVarsByName(vars)
+		replicas, _ := got["replicas"].Value.AsBigFloat().Int64()
+		must.Eq(t, int64(3), replicas)
+		must.Eq(t, "us-west-2", got["region"].Value.AsString())
+	})
+
+	t.Run("items not in pack schema are ignored", func(t *testing.T) {
+		writeNomadVar(t, client, "staging/webapp", map[string]string{
+			"region":      "us-east-1",
+			"not_in_pack": "ignored",
+		})
+
+		src := newNomadSourceForServer(t, srv, "staging/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "region", string(vars[0].Name))
+	})
+
+	t.Run("empty value for non-string variable is an error", func(t *testing.T) {
+		writeNomadVar(t, client, "prod/webapp", map[string]string{
+			"replicas": "",
+			"region":   "us-west-1",
+		})
+
+		src := newNomadSourceForServer(t, srv, "prod/webapp")
+		_, err := src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "empty Nomad value")
+	})
+
+	t.Run("object with optional field missing is valid", func(t *testing.T) {
+		objSchema := map[variables.ID]*variables.Variable{
+			"svc": {
+				Name: "svc",
+				Type: cty.Object(map[string]cty.Type{
+					"name": cty.String,
+					"port": cty.Number,
+				}),
+				ConstraintType: cty.ObjectWithOptionalAttrs(
+					map[string]cty.Type{"name": cty.String, "port": cty.Number},
+					[]string{"port"},
+				),
+			},
+		}
+		writeNomadVar(t, client, "services/webapp", map[string]string{
+			"svc": `{"name":"api"}`,
+		})
+
+		src := newNomadSourceForServer(t, srv, "services/webapp")
+		vars, err := src.Fetch(t.Context(), packID, objSchema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "api", vars[0].Value.GetAttr("name").AsString())
+		must.True(t, vars[0].Value.GetAttr("port").IsNull())
+	})
+
+	t.Run("list variable is decoded from JSON", func(t *testing.T) {
+		listSchema := map[variables.ID]*variables.Variable{
+			"zones": {Name: "zones", Type: cty.List(cty.String)},
+		}
+		writeNomadVar(t, client, "config/webapp", map[string]string{
+			"zones": `["us-east-1a","us-east-1b"]`,
+		})
+
+		src := newNomadSourceForServer(t, srv, "config/webapp")
+		vars, err := src.Fetch(t.Context(), packID, listSchema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, 2, vars[0].Value.LengthInt())
+		must.Eq(t, "us-east-1a", vars[0].Value.Index(cty.NumberIntVal(0)).AsString())
+	})
+
+	t.Run("malformed JSON for non-string variable is an error", func(t *testing.T) {
+		writeNomadVar(t, client, "broken/webapp", map[string]string{
+			"replicas": "not-a-number",
+		})
+
+		src := newNomadSourceForServer(t, srv, "broken/webapp")
+		_, err := src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "decoding Nomad value")
+	})
+
+	t.Run("empty string value is kept for string variable", func(t *testing.T) {
+		writeNomadVar(t, client, "defaults/webapp", map[string]string{
+			"name": "",
+		})
+
+		src := newNomadSourceForServer(t, srv, "defaults/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "", vars[0].Value.AsString())
+	})
+
+	t.Run("variable not found returns empty result", func(t *testing.T) {
+		src := newNomadSourceForServer(t, srv, "missing/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 0, vars)
+	})
+
+	t.Run("variable with no matching items returns empty result", func(t *testing.T) {
+		writeNomadVar(t, client, "nomatch/webapp", map[string]string{
+			"not_in_pack": "ignored",
+		})
+
+		src := newNomadSourceForServer(t, srv, "nomatch/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 0, vars)
+	})
+
+	t.Run("nomad unavailable returns read error", func(t *testing.T) {
+		cfg := api.DefaultConfig()
+		cfg.Address = fmt.Sprintf("http://127.0.0.1:%d", ci.PortAllocator.One())
+		src, err := NewNomadSource(PriorityNomad, cfg, "any/path")
+		must.NoError(t, err)
+
+		_, err = src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "failed to read Nomad variable")
+	})
+}


### PR DESCRIPTION
**Description**

This PR implements Subtask 4 of Issue https://github.com/hashicorp/nomad-pack/issues/473 (External Variable Sources for nomad-pack). It adds support for fetching pack variables from Nomad Variables along with the integration tests coverage

E2E Testing:

<img width="1367" height="979" alt="image" src="https://github.com/user-attachments/assets/e90642af-370b-4f69-9d1a-13225af9a802" />


<img width="1043" height="663" alt="image" src="https://github.com/user-attachments/assets/7a8f0f39-7756-4c0f-9fb8-3c2b759e193d" />


<img width="1358" height="646" alt="image" src="https://github.com/user-attachments/assets/5ea46338-846e-45cf-8045-37036642a1be" />


**Reminders**

- [ ] Add `CHANGELOG.md` entry


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

