### PR TITLE
add external variable sources for Consul KV, Vault KV v2, and Nomad Variables

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -24,13 +24,14 @@ jobs:
           go install gotest.tools/gotestsum@latest
           make test-certs
 
-      # install nomad
-      - name: Install Nomad
+      # install nomad and consul. consul is required by the Consul KV variable
+      # source integration tests; the tests fail hard if consul is not on $PATH.
+      - name: Install Nomad and Consul
         run : |
           sudo apt -y install wget gpg coreutils
           wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt update && sudo apt -y install nomad
+          sudo apt update && sudo apt -y install nomad consul
 
       # Run tests with nice formatting. Save the original log in /tmp/gotest.log
       - name: Run tests

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -24,8 +24,9 @@ jobs:
           go install gotest.tools/gotestsum@latest
           make test-certs
 
-      # install nomad, consul, and vault. consul is required by the Consul KV
-      # variable source integration tests and vault by the Vault KV variable
+      # install nomad, consul, and vault. nomad is required by the Nomad
+      # Variables variable source integration tests, consul by the Consul KV
+      # variable source integration tests, and vault by the Vault KV variable
       # source integration tests; the tests fail hard if they are not on $PATH.
       - name: Install Nomad, Consul, and Vault
         run : |

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -24,14 +24,15 @@ jobs:
           go install gotest.tools/gotestsum@latest
           make test-certs
 
-      # install nomad and consul. consul is required by the Consul KV variable
-      # source integration tests; the tests fail hard if consul is not on $PATH.
-      - name: Install Nomad and Consul
+      # install nomad, consul, and vault. consul is required by the Consul KV
+      # variable source integration tests and vault by the Vault KV variable
+      # source integration tests; the tests fail hard if they are not on $PATH.
+      - name: Install Nomad, Consul, and Vault
         run : |
           sudo apt -y install wget gpg coreutils
           wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt update && sudo apt -y install nomad consul
+          sudo apt update && sudo apt -y install nomad consul vault
 
       # Run tests with nice formatting. Save the original log in /tmp/gotest.log
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ IMPROVEMENTS:
 * cli: Fixed stale-job reconciliation so nomad-pack run no longer stops active parameterized/periodic child jobs [[GH-855](https://github.com/hashicorp/nomad-pack/pull/855)]
 * variable: Variables declaration now supports validation stanza [[GH-841](https://github.com/hashicorp/nomad-pack/pull/841)]
 * variable: Add support for `nomad_variable` blocks with automatic lifecycle management during pack deployment and destruction [[GH-409](https://github.com/hashicorp/nomad-pack/pull/853)]
+* variable: Add external variable sources via the `--var-source` flag for the `run`, `plan`, and `render` commands, reading values from Consul KV [[GH-898](https://github.com/hashicorp/nomad-pack/pull/898)], Vault KV v2 [[GH-903](https://github.com/hashicorp/nomad-pack/pull/903)], and Nomad Variables [[GH-905](https://github.com/hashicorp/nomad-pack/pull/905)]
 * variable: Fixed variable file overrides (last supplied wins) [[GH-851](https://github.com/hashicorp/nomad-pack/pull/851)]
 
 BUG FIXES:

--- a/docs/detailed-usage.md
+++ b/docs/detailed-usage.md
@@ -193,6 +193,57 @@ app_resources = {
 }
 ```
 
+#### External Variable Sources
+
+In addition to `--var` and `-f/--var-file`, the `run`, `plan`, and `render`
+commands can read variable values from an external system at render time using
+the `--var-source` flag. Three source types are supported: Consul KV, Vault KV
+v2, and Nomad Variables.
+
+A source is given as a URL whose scheme selects the source type. The flag may be
+provided more than once to read from several sources, including several of the
+same type:
+
+```
+nomad-pack run hello_world \
+  --var-source consul://localhost:8500/nomad-pack \
+  --var-source vault://localhost:8200/secret/nomad-pack \
+  --var-source nomad://localhost:4646/nomad-pack
+```
+
+The host is optional. Omit it to use the standard environment configuration for
+that tool, including its address and token:
+
+```
+nomad-pack run hello_world \
+  --var-source consul:///nomad-pack \
+  --var-source vault:///secret/nomad-pack \
+  --var-source nomad:///nomad-pack
+```
+
+Variables map onto each source differently. For Consul, each variable is read
+from its own key at `<path>/<variable-name>`. For Vault, all variables are
+fields of the secret at `<mount>/<path>`. For Nomad, all variables are items of
+the Nomad Variable at `<path>`. The path is used as-is, so include any per-pack
+grouping in it yourself.
+
+`NOMAD_ADDR` may point at a `unix://` socket, so Pack can run as a Nomad job and
+read variables over the task's API socket.
+
+##### Precedence
+
+Variable values are applied in order of precedence, highest first:
+
+1. `--var`
+2. `--var-source`
+3. `-f/--var-file`
+4. environment variables
+
+A higher-precedence value overrides any lower one. When more than one
+`--var-source` provides the same variable, Consul wins over Vault, and Vault
+over Nomad. Sources are read only when a variable needs resolving, so a command
+that does not use them makes no connection.
+
 To see the type and description of each variable, run the `info` command.
 
 ```

--- a/docs/detailed-usage.md
+++ b/docs/detailed-usage.md
@@ -224,25 +224,31 @@ nomad-pack run hello_world \
 Variables map onto each source differently. For Consul, each variable is read
 from its own key at `<path>/<variable-name>`. For Vault, all variables are
 fields of the secret at `<mount>/<path>`. For Nomad, all variables are items of
-the Nomad Variable at `<path>`. The path is used as-is, so include any per-pack
-grouping in it yourself.
+the Nomad Variable at `<path>`.
 
-`NOMAD_ADDR` may point at a `unix://` socket, so Pack can run as a Nomad job and
-read variables over the task's API socket.
+A host given in the URL is always a TCP `host:port`. To read over a `unix://`
+socket instead :
+
+```
+NOMAD_ADDR=unix:///secrets/api.sock \
+  nomad-pack run hello_world --var-source nomad:///nomad-pack
+```
 
 ##### Precedence
 
 Variable values are applied in order of precedence, highest first:
 
 1. `--var`
-2. `--var-source`
-3. `-f/--var-file`
-4. environment variables
+2. `-f/--var-file`
+3. environment variables
+4. `--var-source`
+5. pack variable defaults
 
-A higher-precedence value overrides any lower one. When more than one
-`--var-source` provides the same variable, Consul wins over Vault, and Vault
-over Nomad. Sources are read only when a variable needs resolving, so a command
-that does not use them makes no connection.
+A higher-precedence value overrides any lower one. Explicit local input always
+wins over an external source. When more than one `--var-source` provides the
+same variable, the one given later on the command line wins. Sources are read
+only when a variable needs resolving, so a command that does not use them makes
+no connection.
 
 To see the type and description of each variable, run the `info` command.
 

--- a/fixtures/v2/simple_raw_exec_v2/variables.hcl
+++ b/fixtures/v2/simple_raw_exec_v2/variables.hcl
@@ -46,8 +46,8 @@ nomad_variable "app_config" {
   path = "nomad/jobs/simple_raw_exec/config"
   items = {
     database_url = "postgres://localhost:5432/mydb"
-    api_key = "secret-api-key-123"
-    environment = "production"
+    api_key      = "secret-api-key-123"
+    environment  = "production"
   }
 }
 
@@ -55,6 +55,6 @@ nomad_variable "secrets" {
   path = "nomad/jobs/simple_raw_exec/secrets"
   items = {
     admin_password = "super-secret-password"
-    jwt_secret = "jwt-signing-key-xyz"
+    jwt_secret     = "jwt-signing-key-xyz"
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/hashicorp/consul/api v1.33.4
+	github.com/hashicorp/consul/sdk v0.17.2
 	github.com/hashicorp/go-getter v1.8.6
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1
@@ -193,7 +194,6 @@ require (
 	github.com/hashicorp/cap v0.12.0 // indirect
 	github.com/hashicorp/cli v1.1.7 // indirect
 	github.com/hashicorp/consul-template v0.41.4 // indirect
-	github.com/hashicorp/consul/sdk v0.17.2 // indirect
 	github.com/hashicorp/cronexpr v1.1.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.16 // indirect

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.23.0
 	github.com/hashicorp/nomad v1.11.3
 	github.com/hashicorp/nomad/api v0.0.0-20260304165455-489f8b9d1054
+	github.com/hashicorp/vault/api v1.22.0
 	github.com/kr/text v0.2.0
 	github.com/lab47/vterm v0.0.0-20211107042118-80c3d2849f9c
 	github.com/mattn/go-isatty v0.0.22
@@ -241,7 +242,6 @@ require (
 	github.com/hashicorp/raft-autopilot v0.3.0 // indirect
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1 // indirect
 	github.com/hashicorp/serf v0.10.2 // indirect
-	github.com/hashicorp/vault/api v1.22.0 // indirect
 	github.com/hashicorp/vault/api/auth/kubernetes v0.10.0 // indirect
 	github.com/hashicorp/vic v1.5.1-0.20241121050025-d1d58fa204f5 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.19.0
 	github.com/go-git/go-git/v5 v5.19.1
+	github.com/hashicorp/consul/api v1.33.4
 	github.com/hashicorp/go-getter v1.8.6
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1
@@ -192,7 +193,6 @@ require (
 	github.com/hashicorp/cap v0.12.0 // indirect
 	github.com/hashicorp/cli v1.1.7 // indirect
 	github.com/hashicorp/consul-template v0.41.4 // indirect
-	github.com/hashicorp/consul/api v1.33.4 // indirect
 	github.com/hashicorp/consul/sdk v0.17.2 // indirect
 	github.com/hashicorp/cronexpr v1.1.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -71,6 +71,10 @@ type baseCommand struct {
 	// for defined input variables
 	varFiles []string
 
+	// varSources is a list of external variable source URLs
+	// (e.g., consul:///path)
+	varSources []string
+
 	// allowUnsetVars suppresses errors from variables with nil values,
 	// i.e. those that are not set and have no default
 	allowUnsetVars bool
@@ -267,6 +271,31 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 			Shorthand: "f",
 		})
 
+		// --var-source performs remote reads (e.g. Consul KV) at render time, so
+		// it is only offered by commands that compute a fresh deployment
+		// (run/plan/render). Commands like stop operate on an already-deployed
+		// job and must not depend on a remote source still being reachable or
+		// its keys still existing.
+		if bit&flagSetExternalVarSources != 0 {
+			f.StringSliceVar(&flag.StringSliceVar{
+				Name:    "var-source",
+				Target:  &c.varSources,
+				Default: make([]string, 0),
+				Usage: `Specifies an external variable source as a URL, and may be
+						given more than once to read from several sources. Consul KV
+						is the only source currently supported, using the form
+						consul://<host>:<port>/<path>; for example,
+						consul://localhost:8500/nomad-pack. The host is optional: omit
+						it (consul:///<path>) to use the standard Consul environment
+						configuration, such as CONSUL_HTTP_ADDR and CONSUL_HTTP_TOKEN.
+						Each variable is read from <path>/<variable-name>, so include
+						any per-pack grouping in the path yourself. Variable sources
+						are applied in order of precedence, highest first: --var, then
+						--var-source, then --var-file, then environment variables. A
+						higher-precedence source overrides any lower one.`,
+			})
+		}
+
 		f.BoolVar(&flag.BoolVar{
 			Name:    "allow-unset-vars",
 			Target:  &c.allowUnsetVars,
@@ -435,10 +464,11 @@ func (c *baseCommand) helpUsageMessage() string {
 type flagSetBit uint
 
 const (
-	flagSetNone          flagSetBit = 1 << iota // nolint:deadcode,varcheck,unused
-	flagSetOperation                            // shared flags for operations (run, plan, etc)
-	flagSetNeedsApproval                        // adds the -y flag for commands that require approval to run
-	flagSetNomadClient                          // adds client config flags
+	flagSetNone               flagSetBit = 1 << iota // nolint:deadcode,varcheck,unused
+	flagSetOperation                                 // shared flags for operations (run, plan, etc)
+	flagSetNeedsApproval                             // adds the -y flag for commands that require approval to run
+	flagSetNomadClient                               // adds client config flags
+	flagSetExternalVarSources                        // adds --var-source; only for commands that compute a fresh deployment (run, plan, render)
 )
 
 var (

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -282,17 +282,22 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 				Target:  &c.varSources,
 				Default: make([]string, 0),
 				Usage: `Specifies an external variable source as a URL, and may be
-						given more than once to read from several sources. Consul KV
-						is the only source currently supported, using the form
+						given more than once to read from several sources. Two source
+						types are supported. Consul KV uses the form
 						consul://<host>:<port>/<path>; for example,
-						consul://localhost:8500/nomad-pack. The host is optional: omit
-						it (consul:///<path>) to use the standard Consul environment
-						configuration, such as CONSUL_HTTP_ADDR and CONSUL_HTTP_TOKEN.
-						Each variable is read from <path>/<variable-name>, so include
-						any per-pack grouping in the path yourself. Variable sources
-						are applied in order of precedence, highest first: --var, then
-						--var-source, then --var-file, then environment variables. A
-						higher-precedence source overrides any lower one.`,
+						consul://localhost:8500/nomad-pack. Vault KV v2 uses the form
+						vault://<host>:<port>/<mount>/<path>; for example,
+						vault://localhost:8200/secret/nomad-pack. The host is
+						optional: omit it (consul:///<path> or vault:///<mount>/<path>)
+						to use the standard Consul or Vault environment configuration,
+						such as CONSUL_HTTP_ADDR and CONSUL_HTTP_TOKEN, or VAULT_ADDR
+						and VAULT_TOKEN. For Consul each variable is read from
+						<path>/<variable-name>; for Vault each variable is a field of
+						the secret at <mount>/<path>. Include any per-pack grouping in
+						the path yourself. Variable sources are applied in order of
+						precedence, highest first: --var, then --var-source, then
+						--var-file, then environment variables. A higher-precedence
+						source overrides any lower one.`,
 			})
 		}
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -293,16 +293,17 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 						(consul:///<path>, vault:///<mount>/<path>, or nomad:///<path>)
 						to use the standard environment configuration for that tool,
 						such as CONSUL_HTTP_ADDR and CONSUL_HTTP_TOKEN, VAULT_ADDR and
-						VAULT_TOKEN, or NOMAD_ADDR and NOMAD_TOKEN. NOMAD_ADDR may point
-						at a unix:// socket, so Pack can run as a Nomad job and read
-						variables over the task's API socket. For Consul each variable
-						is read from <path>/<variable-name>; for Vault each variable is
-						a field of the secret at <mount>/<path>; for Nomad each variable
-						is an item of the Nomad Variable at <path>. Include
-						any per-pack grouping in the path yourself. Variable sources are
-						applied in order of precedence, highest first: --var, then
-						--var-source, then --var-file, then environment variables. A
-						higher-precedence source overrides any lower one.`,
+						VAULT_TOKEN, or NOMAD_ADDR and NOMAD_TOKEN. A host in the URL is
+						always a TCP host:port; to read over a unix:// socket instead,
+						such as a Nomad task's API socket, omit the host
+						(nomad:///<path>) and set NOMAD_ADDR to the socket. For Consul
+						each variable is read from <path>/<variable-name>; for Vault each
+						variable is a field of the secret at <mount>/<path>; for Nomad
+						each variable is an item of the Nomad Variable at <path>.
+						External sources rank below local input: values from --var,
+						--var-file, and the environment all override them. When more
+						than one --var-source provides the same variable, the one given
+						later on the command line wins.`,
 			})
 		}
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -282,22 +282,27 @@ func (c *baseCommand) flagSet(bit flagSetBit, f func(*flag.Sets)) *flag.Sets {
 				Target:  &c.varSources,
 				Default: make([]string, 0),
 				Usage: `Specifies an external variable source as a URL, and may be
-						given more than once to read from several sources. Two source
+						given more than once to read from several sources. Three source
 						types are supported. Consul KV uses the form
 						consul://<host>:<port>/<path>; for example,
 						consul://localhost:8500/nomad-pack. Vault KV v2 uses the form
 						vault://<host>:<port>/<mount>/<path>; for example,
-						vault://localhost:8200/secret/nomad-pack. The host is
-						optional: omit it (consul:///<path> or vault:///<mount>/<path>)
-						to use the standard Consul or Vault environment configuration,
-						such as CONSUL_HTTP_ADDR and CONSUL_HTTP_TOKEN, or VAULT_ADDR
-						and VAULT_TOKEN. For Consul each variable is read from
-						<path>/<variable-name>; for Vault each variable is a field of
-						the secret at <mount>/<path>. Include any per-pack grouping in
-						the path yourself. Variable sources are applied in order of
-						precedence, highest first: --var, then --var-source, then
-						--var-file, then environment variables. A higher-precedence
-						source overrides any lower one.`,
+						vault://localhost:8200/secret/nomad-pack. Nomad Variables use
+						the form nomad://<host>:<port>/<path>; for example,
+						nomad://localhost:4646/nomad-pack. The host is optional: omit it
+						(consul:///<path>, vault:///<mount>/<path>, or nomad:///<path>)
+						to use the standard environment configuration for that tool,
+						such as CONSUL_HTTP_ADDR and CONSUL_HTTP_TOKEN, VAULT_ADDR and
+						VAULT_TOKEN, or NOMAD_ADDR and NOMAD_TOKEN. NOMAD_ADDR may point
+						at a unix:// socket, so Pack can run as a Nomad job and read
+						variables over the task's API socket. For Consul each variable
+						is read from <path>/<variable-name>; for Vault each variable is
+						a field of the secret at <mount>/<path>; for Nomad each variable
+						is an item of the Nomad Variable at <path>. Include
+						any per-pack grouping in the path yourself. Variable sources are
+						applied in order of precedence, highest first: --var, then
+						--var-source, then --var-file, then environment variables. A
+						higher-precedence source overrides any lower one.`,
 			})
 		}
 

--- a/internal/cli/generate_varfile.go
+++ b/internal/cli/generate_varfile.go
@@ -142,7 +142,11 @@ func (c *generateVarFileCommand) Run(args []string) int {
 	// until something sets them, like the var file we're trying to create!)
 	c.allowUnsetVars = true
 
-	packManager := generatePackManager(c.baseCommand, nil, c.packConfig)
+	packManager, err := generatePackManager(c.baseCommand, nil, c.packConfig)
+	if err != nil {
+		c.ui.ErrorWithContext(err, "failed to generate pack manager", errorContext.GetAll()...)
+		return 1
+	}
 	renderOutput, err := renderVariableOverrideFile(packManager, c.ui, errorContext)
 	if err != nil {
 		return 1

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/nomad-pack/internal/pkg/manager"
 	"github.com/hashicorp/nomad-pack/internal/pkg/renderer"
 	"github.com/hashicorp/nomad-pack/internal/pkg/variable/parser"
+	"github.com/hashicorp/nomad-pack/internal/pkg/variable/source"
 	"github.com/hashicorp/nomad-pack/internal/runner"
 	"github.com/hashicorp/nomad-pack/internal/runner/job"
 	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
@@ -40,17 +41,28 @@ func initPackCommand(cfg *caching.PackConfig) (errorContext *errors.UIErrorConte
 }
 
 // generatePackManager is used to generate the pack manager for this Nomad Pack run.
-func generatePackManager(c *baseCommand, client *api.Client, packCfg *caching.PackConfig) *manager.PackManager {
+func generatePackManager(c *baseCommand, client *api.Client, packCfg *caching.PackConfig) (*manager.PackManager, error) {
+	// Parse external variable source configurations if provided.
+	var externalSourceConfigs []source.SourceConfig
+	if len(c.varSources) > 0 {
+		configs, err := parseVarSourceConfigs(c.varSources)
+		if err != nil {
+			return nil, err
+		}
+		externalSourceConfigs = configs
+	}
+
 	// TODO: Refactor to have manager use cache.
 	cfg := manager.Config{
-		Path:            packCfg.Path,
-		VariableFiles:   c.varFiles,
-		VariableCLIArgs: c.vars,
-		VariableEnvVars: c.envVars,
-		AllowUnsetVars:  c.allowUnsetVars,
-		UseParserV1:     c.useParserV1,
+		Path:                  packCfg.Path,
+		VariableFiles:         c.varFiles,
+		VariableCLIArgs:       c.vars,
+		VariableEnvVars:       c.envVars,
+		AllowUnsetVars:        c.allowUnsetVars,
+		UseParserV1:           c.useParserV1,
+		ExternalSourceConfigs: externalSourceConfigs,
 	}
-	return manager.NewPackManager(&cfg, client)
+	return manager.NewPackManager(&cfg, client), nil
 }
 
 // predictPackName is a complete.Predictor that suggests cached pack names.

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -54,7 +54,11 @@ func (c *PlanCommand) Run(args []string) int {
 		return c.exitCodeError
 	}
 
-	packManager := generatePackManager(c.baseCommand, client, c.packConfig)
+	packManager, err := generatePackManager(c.baseCommand, client, c.packConfig)
+	if err != nil {
+		c.ui.ErrorWithContext(err, "failed to generate pack manager", errorContext.GetAll()...)
+		return c.exitCodeError
+	}
 
 	// load pack
 	r, err := renderPack(
@@ -142,7 +146,7 @@ func (c *PlanCommand) Run(args []string) int {
 func (c *PlanCommand) Flags() *flag.Sets {
 	c.packConfig = &caching.PackConfig{}
 
-	return c.flagSet(flagSetOperation|flagSetNomadClient, func(set *flag.Sets) {
+	return c.flagSet(flagSetOperation|flagSetNomadClient|flagSetExternalVarSources, func(set *flag.Sets) {
 		f := set.NewSet("Plan Options")
 
 		c.jobConfig = &job.CLIConfig{

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -280,7 +280,11 @@ func (c *RenderCommand) Run(args []string) int {
 		c.ui.Error(err.Error())
 		return 1
 	}
-	packManager := generatePackManager(c.baseCommand, client, c.packConfig)
+	packManager, err := generatePackManager(c.baseCommand, client, c.packConfig)
+	if err != nil {
+		c.ui.ErrorWithContext(err, "failed to generate pack manager", errorContext.GetAll()...)
+		return 1
+	}
 
 	renderOutput, err := renderPack(
 		packManager,
@@ -344,7 +348,7 @@ func (c *RenderCommand) Run(args []string) int {
 }
 
 func (c *RenderCommand) Flags() *flag.Sets {
-	return c.flagSet(flagSetOperation|flagSetNeedsApproval, func(set *flag.Sets) {
+	return c.flagSet(flagSetOperation|flagSetNeedsApproval|flagSetExternalVarSources, func(set *flag.Sets) {
 		c.packConfig = &caching.PackConfig{}
 
 		f := set.NewSet("Render Options")

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -64,7 +64,11 @@ func (c *RunCommand) run() int {
 		return 1
 	}
 
-	packManager := generatePackManager(c.baseCommand, client, c.packConfig)
+	packManager, err := generatePackManager(c.baseCommand, client, c.packConfig)
+	if err != nil {
+		c.ui.ErrorWithContext(err, "failed to generate pack manager", errorContext.GetAll()...)
+		return 1
+	}
 
 	// Render the pack now, before creating the deployer. If we get an error
 	// we won't make it to the deployer.
@@ -191,7 +195,7 @@ func (c *RunCommand) run() int {
 
 // Flags defines the flag.Sets for the operation.
 func (c *RunCommand) Flags() *flag.Sets {
-	return c.flagSet(flagSetOperation|flagSetNomadClient, func(set *flag.Sets) {
+	return c.flagSet(flagSetOperation|flagSetNomadClient|flagSetExternalVarSources, func(set *flag.Sets) {
 		f := set.NewSet("Run Options")
 
 		c.packConfig = &caching.PackConfig{}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -81,7 +81,11 @@ func (c *StopCommand) Run(args []string) int {
 
 	var jobs []*api.Job
 
-	packManager := generatePackManager(c.baseCommand, client, c.packConfig)
+	packManager, err := generatePackManager(c.baseCommand, client, c.packConfig)
+	if err != nil {
+		c.ui.ErrorWithContext(err, "failed to generate pack manager", errorContext.GetAll()...)
+		return 1
+	}
 
 	var r *renderer.Rendered
 

--- a/internal/cli/varsource_config.go
+++ b/internal/cli/varsource_config.go
@@ -17,8 +17,10 @@ import (
 // variable parser.
 //
 // Supported URL formats:
-//   - consul:///path              (uses the Consul environment address)
-//   - consul://host:port/path     (uses the specified Consul address)
+//   - consul:///path                  (uses the Consul environment address)
+//   - consul://host:port/path         (uses the specified Consul address)
+//   - vault:///mount/path             (uses the Vault environment address)
+//   - vault://host:port/mount/path    (uses the specified Vault address)
 func parseVarSourceConfigs(urls []string) ([]source.SourceConfig, error) {
 	if len(urls) == 0 {
 		return nil, nil
@@ -50,8 +52,10 @@ func parseVarSourceConfig(urlStr string) (source.SourceConfig, error) {
 	switch u.Scheme {
 	case "consul":
 		return parseConsulSourceConfig(host, path)
+	case "vault":
+		return parseVaultSourceConfig(host, path)
 	default:
-		return nil, fmt.Errorf("unsupported scheme %q (supported: consul)", u.Scheme)
+		return nil, fmt.Errorf("unsupported scheme %q (supported: consul, vault)", u.Scheme)
 	}
 }
 
@@ -72,5 +76,28 @@ func parseConsulSourceConfig(host, path string) (source.SourceConfig, error) {
 		Priority: source.PriorityConsul,
 		Address:  host,
 		Path:     path,
+	}, nil
+}
+
+// parseVaultSourceConfig builds a Vault KV v2 source config from the host and
+// path of a vault:// URL. The first path segment is the KV v2 mount point and
+// the remainder is the secret path; all variables for the pack are stored as
+// fields of the single secret at <mount>/<path>. A non-empty host overrides the
+// Vault environment address; the rest of the Vault configuration, including the
+// token, comes from the standard Vault environment configuration (VAULT_ADDR,
+// VAULT_TOKEN, and so on) when the source is built.
+//   - vault:///secret/path/to/vars        -> host="",               mount="secret", path="path/to/vars"
+//   - vault://localhost:8200/secret/path  -> host="localhost:8200", mount="secret", path="path"
+func parseVaultSourceConfig(host, path string) (source.SourceConfig, error) {
+	mount, secretPath, ok := strings.Cut(path, "/")
+	if !ok || mount == "" || secretPath == "" {
+		return nil, fmt.Errorf("vault URL must include a mount and path (e.g., vault:///secret/nomad-pack)")
+	}
+
+	return source.VaultSourceConfig{
+		Priority: source.PriorityVault,
+		Address:  host,
+		Mount:    mount,
+		Path:     secretPath,
 	}, nil
 }

--- a/internal/cli/varsource_config.go
+++ b/internal/cli/varsource_config.go
@@ -21,6 +21,8 @@ import (
 //   - consul://host:port/path         (uses the specified Consul address)
 //   - vault:///mount/path             (uses the Vault environment address)
 //   - vault://host:port/mount/path    (uses the specified Vault address)
+//   - nomad:///path                   (uses the Nomad environment address)
+//   - nomad://host:port/path          (uses the specified Nomad address)
 func parseVarSourceConfigs(urls []string) ([]source.SourceConfig, error) {
 	if len(urls) == 0 {
 		return nil, nil
@@ -54,8 +56,10 @@ func parseVarSourceConfig(urlStr string) (source.SourceConfig, error) {
 		return parseConsulSourceConfig(host, path)
 	case "vault":
 		return parseVaultSourceConfig(host, path)
+	case "nomad":
+		return parseNomadSourceConfig(host, path)
 	default:
-		return nil, fmt.Errorf("unsupported scheme %q (supported: consul, vault)", u.Scheme)
+		return nil, fmt.Errorf("unsupported scheme %q (supported: consul, vault, nomad)", u.Scheme)
 	}
 }
 
@@ -99,5 +103,26 @@ func parseVaultSourceConfig(host, path string) (source.SourceConfig, error) {
 		Address:  host,
 		Mount:    mount,
 		Path:     secretPath,
+	}, nil
+}
+
+// parseNomadSourceConfig builds a Nomad Variables source config from the host
+// and path of a nomad:// URL. The path is the Nomad Variable path; all variables
+// for the pack are stored as items of the single Nomad Variable at <path>. A
+// non-empty host overrides the Nomad environment address; the rest of the Nomad
+// configuration, including the token and namespace, comes from the standard
+// Nomad environment configuration (NOMAD_ADDR, NOMAD_TOKEN, NOMAD_NAMESPACE, and
+// so on) when the source is built.
+//   - nomad:///path/to/vars        -> host="",               path="path/to/vars"
+//   - nomad://localhost:4646/path  -> host="localhost:4646", path="path"
+func parseNomadSourceConfig(host, path string) (source.SourceConfig, error) {
+	if path == "" {
+		return nil, fmt.Errorf("nomad URL must include a path (e.g., nomad:///nomad-pack)")
+	}
+
+	return source.NomadSourceConfig{
+		Priority: source.PriorityNomad,
+		Address:  host,
+		Path:     path,
 	}, nil
 }

--- a/internal/cli/varsource_config.go
+++ b/internal/cli/varsource_config.go
@@ -30,8 +30,12 @@ func parseVarSourceConfigs(urls []string) ([]source.SourceConfig, error) {
 
 	configs := make([]source.SourceConfig, 0, len(urls))
 
-	for _, urlStr := range urls {
-		cfg, err := parseVarSourceConfig(urlStr)
+	for i, urlStr := range urls {
+		// Each source's priority is its position on the command line, so a later
+		// --var-source overrides an earlier one for the same variable. The base
+		// keeps every external source below local input (env, files, CLI flags).
+		priority := source.PriorityExternalBase + i
+		cfg, err := parseVarSourceConfig(urlStr, priority)
 		if err != nil {
 			return nil, fmt.Errorf("var-source %q: %w", urlStr, err)
 		}
@@ -42,7 +46,8 @@ func parseVarSourceConfigs(urls []string) ([]source.SourceConfig, error) {
 }
 
 // parseVarSourceConfig parses a single variable source URL into a typed config.
-func parseVarSourceConfig(urlStr string) (source.SourceConfig, error) {
+// priority is the precedence assigned to the built source.
+func parseVarSourceConfig(urlStr string, priority int) (source.SourceConfig, error) {
 	u, err := url.Parse(urlStr)
 	if err != nil {
 		return nil, fmt.Errorf("invalid URL: %w", err)
@@ -53,11 +58,11 @@ func parseVarSourceConfig(urlStr string) (source.SourceConfig, error) {
 
 	switch u.Scheme {
 	case "consul":
-		return parseConsulSourceConfig(host, path)
+		return parseConsulSourceConfig(host, path, priority)
 	case "vault":
-		return parseVaultSourceConfig(host, path)
+		return parseVaultSourceConfig(host, path, priority)
 	case "nomad":
-		return parseNomadSourceConfig(host, path)
+		return parseNomadSourceConfig(host, path, priority)
 	default:
 		return nil, fmt.Errorf("unsupported scheme %q (supported: consul, vault, nomad)", u.Scheme)
 	}
@@ -71,13 +76,13 @@ func parseVarSourceConfig(urlStr string) (source.SourceConfig, error) {
 // when the source is built.
 //   - consul:///path/to/vars        -> host="",              path="path/to/vars"
 //   - consul://localhost:8500/path  -> host="localhost:8500", path="path"
-func parseConsulSourceConfig(host, path string) (source.SourceConfig, error) {
+func parseConsulSourceConfig(host, path string, priority int) (source.SourceConfig, error) {
 	if path == "" {
 		return nil, fmt.Errorf("consul URL must include a path (e.g., consul:///nomad-pack)")
 	}
 
 	return source.ConsulSourceConfig{
-		Priority: source.PriorityConsul,
+		Priority: priority,
 		Address:  host,
 		Path:     path,
 	}, nil
@@ -92,14 +97,14 @@ func parseConsulSourceConfig(host, path string) (source.SourceConfig, error) {
 // VAULT_TOKEN, and so on) when the source is built.
 //   - vault:///secret/path/to/vars        -> host="",               mount="secret", path="path/to/vars"
 //   - vault://localhost:8200/secret/path  -> host="localhost:8200", mount="secret", path="path"
-func parseVaultSourceConfig(host, path string) (source.SourceConfig, error) {
+func parseVaultSourceConfig(host, path string, priority int) (source.SourceConfig, error) {
 	mount, secretPath, ok := strings.Cut(path, "/")
 	if !ok || mount == "" || secretPath == "" {
 		return nil, fmt.Errorf("vault URL must include a mount and path (e.g., vault:///secret/nomad-pack)")
 	}
 
 	return source.VaultSourceConfig{
-		Priority: source.PriorityVault,
+		Priority: priority,
 		Address:  host,
 		Mount:    mount,
 		Path:     secretPath,
@@ -115,13 +120,13 @@ func parseVaultSourceConfig(host, path string) (source.SourceConfig, error) {
 // so on) when the source is built.
 //   - nomad:///path/to/vars        -> host="",               path="path/to/vars"
 //   - nomad://localhost:4646/path  -> host="localhost:4646", path="path"
-func parseNomadSourceConfig(host, path string) (source.SourceConfig, error) {
+func parseNomadSourceConfig(host, path string, priority int) (source.SourceConfig, error) {
 	if path == "" {
 		return nil, fmt.Errorf("nomad URL must include a path (e.g., nomad:///nomad-pack)")
 	}
 
 	return source.NomadSourceConfig{
-		Priority: source.PriorityNomad,
+		Priority: priority,
 		Address:  host,
 		Path:     path,
 	}, nil

--- a/internal/cli/varsource_config.go
+++ b/internal/cli/varsource_config.go
@@ -1,0 +1,76 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package cli
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/nomad-pack/internal/pkg/variable/source"
+)
+
+// parseVarSourceConfigs parses variable source URLs into typed source configs.
+// Only the configuration is parsed here; no remote connections are made. The
+// returned configs are built into live sources lazily, at render time, by the
+// variable parser.
+//
+// Supported URL formats:
+//   - consul:///path              (uses the Consul environment address)
+//   - consul://host:port/path     (uses the specified Consul address)
+func parseVarSourceConfigs(urls []string) ([]source.SourceConfig, error) {
+	if len(urls) == 0 {
+		return nil, nil
+	}
+
+	configs := make([]source.SourceConfig, 0, len(urls))
+
+	for _, urlStr := range urls {
+		cfg, err := parseVarSourceConfig(urlStr)
+		if err != nil {
+			return nil, fmt.Errorf("var-source %q: %w", urlStr, err)
+		}
+		configs = append(configs, cfg)
+	}
+
+	return configs, nil
+}
+
+// parseVarSourceConfig parses a single variable source URL into a typed config.
+func parseVarSourceConfig(urlStr string) (source.SourceConfig, error) {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+
+	host := u.Host
+	path := strings.Trim(u.Path, "/")
+
+	switch u.Scheme {
+	case "consul":
+		return parseConsulSourceConfig(host, path)
+	default:
+		return nil, fmt.Errorf("unsupported scheme %q (supported: consul)", u.Scheme)
+	}
+}
+
+// parseConsulSourceConfig builds a Consul KV source config from the host and
+// path of a consul:// URL. Each variable is read from <path>/<variable-name>.
+// A non-empty host overrides the Consul environment address; the rest of the
+// Consul configuration, including the ACL token, comes from the standard Consul
+// environment configuration (CONSUL_HTTP_ADDR, CONSUL_HTTP_TOKEN, and so on)
+// when the source is built.
+//   - consul:///path/to/vars        -> host="",              path="path/to/vars"
+//   - consul://localhost:8500/path  -> host="localhost:8500", path="path"
+func parseConsulSourceConfig(host, path string) (source.SourceConfig, error) {
+	if path == "" {
+		return nil, fmt.Errorf("consul URL must include a path (e.g., consul:///nomad-pack)")
+	}
+
+	return source.ConsulSourceConfig{
+		Priority: source.PriorityConsul,
+		Address:  host,
+		Path:     path,
+	}, nil
+}

--- a/internal/pkg/manager/manager.go
+++ b/internal/pkg/manager/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/nomad-pack/internal/pkg/renderer"
 	"github.com/hashicorp/nomad-pack/internal/pkg/variable/parser"
 	"github.com/hashicorp/nomad-pack/internal/pkg/variable/parser/config"
+	"github.com/hashicorp/nomad-pack/internal/pkg/variable/source"
 	"github.com/hashicorp/nomad-pack/sdk/pack"
 	"github.com/hashicorp/nomad/api"
 )
@@ -21,12 +22,13 @@ import (
 // Config contains all the user specified parameters needed to correctly run
 // the pack manager.
 type Config struct {
-	Path            string
-	VariableFiles   []string
-	VariableCLIArgs map[string]string
-	VariableEnvVars map[string]string
-	UseParserV1     bool
-	AllowUnsetVars  bool
+	Path                  string
+	VariableFiles         []string
+	VariableCLIArgs       map[string]string
+	VariableEnvVars       map[string]string
+	UseParserV1           bool
+	AllowUnsetVars        bool
+	ExternalSourceConfigs []source.SourceConfig // Lazily-built configs for external sources (Consul, Vault, Nomad)
 }
 
 // PackManager is responsible for loading, parsing, and rendering a Pack and
@@ -67,12 +69,13 @@ func (pm *PackManager) ProcessVariableFiles() (*parser.ParsedVariables, []*error
 	parentName, _, _ := strings.Cut(path.Base(pm.cfg.Path), "@")
 
 	pCfg := &config.ParserConfig{
-		Version:           config.V2,
-		ParentPack:        pm.loadedPack,
-		RootVariableFiles: loadedPack.RootVariableFiles(),
-		EnvOverrides:      pm.cfg.VariableEnvVars,
-		FileOverrides:     pm.cfg.VariableFiles,
-		FlagOverrides:     pm.cfg.VariableCLIArgs,
+		Version:               config.V2,
+		ParentPack:            pm.loadedPack,
+		RootVariableFiles:     loadedPack.RootVariableFiles(),
+		EnvOverrides:          pm.cfg.VariableEnvVars,
+		FileOverrides:         pm.cfg.VariableFiles,
+		FlagOverrides:         pm.cfg.VariableCLIArgs,
+		ExternalSourceConfigs: pm.cfg.ExternalSourceConfigs,
 	}
 
 	if pm.cfg.UseParserV1 {

--- a/internal/pkg/variable/parser/config/config.go
+++ b/internal/pkg/variable/parser/config/config.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"github.com/hashicorp/nomad-pack/internal/pkg/variable/source"
 	"github.com/hashicorp/nomad-pack/sdk/pack"
 )
 
@@ -46,6 +47,10 @@ type ParserConfig struct {
 	// FlagOverrides are key=value variables and take the highest precedence of
 	// all sources. If the same key is supplied twice, the last wins.
 	FlagOverrides map[string]string
+
+	// ExternalSourceConfigs are parsed, lazily-built configurations for
+	// external variable sources (Consul, Vault, Nomad).
+	ExternalSourceConfigs []source.SourceConfig
 
 	// IgnoreMissingVars determines whether we error or not on variable overrides
 	// that don't have corresponding vars in the pack.

--- a/internal/pkg/variable/parser/parser_v2.go
+++ b/internal/pkg/variable/parser/parser_v2.go
@@ -27,6 +27,13 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+const (
+	// externalSourceTimeout is the maximum time allowed for fetching variables
+	// from external sources (Consul, Vault, Nomad). This prevents hanging on
+	// slow or unresponsive external services.
+	externalSourceTimeout = 30 * time.Second
+)
+
 type ParserV2 struct {
 	fs  afero.Afero
 	cfg *config.ParserConfig
@@ -108,36 +115,36 @@ func (p *ParserV2) Parse() (*ParsedVariables, hcl.Diagnostics) {
 		return nil, diags
 	}
 
-	// Register sources with the registry (priority: env=10, file=20, cli=30)
-	if err := p.sourceRegistry.Register(source.NewEnvSource(10, p.envOverrideVars)); err != nil {
-		return nil, diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Failed to register environment source",
-			Detail:   err.Error(),
-		})
-	}
-	if err := p.sourceRegistry.Register(source.NewFileSource(20, p.fileOverrideVars)); err != nil {
-		return nil, diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Failed to register file source",
-			Detail:   err.Error(),
-		})
-	}
-	if err := p.sourceRegistry.Register(source.NewCLISource(30, p.flagOverrideVars)); err != nil {
-		return nil, diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Failed to register CLI source",
-			Detail:   err.Error(),
-		})
+	// Register sources with the registry in priority order
+	p.sourceRegistry.Register(source.NewEnvSource(source.PriorityEnv, p.envOverrideVars))
+	p.sourceRegistry.Register(source.NewFileSource(source.PriorityFile, p.fileOverrideVars))
+
+	// Create and register external sources (Consul, Vault, Nomad) from configs if provided.
+	// This is where we lazily build the actual sources from their parsed
+	// configs, avoiding remote connections for commands that never resolve.
+	for _, sc := range p.cfg.ExternalSourceConfigs {
+		src, err := sc.Build()
+		if err != nil {
+			return nil, diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Failed to create external source",
+				Detail:   err.Error(),
+			})
+		}
+
+		p.sourceRegistry.Register(src)
 	}
 
+	p.sourceRegistry.Register(source.NewCLISource(source.PriorityCLI, p.flagOverrideVars))
+
 	// Use context with timeout to prevent hanging on external sources
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), externalSourceTimeout)
 	defer cancel()
 
 	// Resolve and merge variables from all sources using the registry
-	for packName := range p.rootVars {
-		resolvedVars, resolveErr := p.sourceRegistry.Resolve(ctx, packName)
+	for packName, packSchema := range p.rootVars {
+		// Pass the pack's schema to enable schema-aware type conversion
+		resolvedVars, resolveErr := p.sourceRegistry.Resolve(ctx, packName, packSchema)
 		if resolveErr != nil {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,

--- a/internal/pkg/variable/parser/parser_v2.go
+++ b/internal/pkg/variable/parser/parser_v2.go
@@ -115,7 +115,7 @@ func (p *ParserV2) Parse() (*ParsedVariables, hcl.Diagnostics) {
 		return nil, diags
 	}
 
-	// Register sources with the registry in priority order
+	// Register all sources with the registry.
 	p.sourceRegistry.Register(source.NewEnvSource(source.PriorityEnv, p.envOverrideVars))
 	p.sourceRegistry.Register(source.NewFileSource(source.PriorityFile, p.fileOverrideVars))
 

--- a/internal/pkg/variable/source/base_source.go
+++ b/internal/pkg/variable/source/base_source.go
@@ -39,11 +39,9 @@ func (b *BaseSource) Priority() int {
 
 // Fetch retrieves variables for the given pack from the wrapped map.
 // Returns an empty slice if the pack is not found or vars is nil.
-func (b *BaseSource) Fetch(ctx context.Context, packID pack.ID) ([]*variables.Variable, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
+//
+// Unlike external sources, BaseSource does not filter by schema. External sources (e.g. Consul) do their own schema filtering.
+func (b *BaseSource) Fetch(ctx context.Context, packID pack.ID, schema map[variables.ID]*variables.Variable) ([]*variables.Variable, error) {
 	if b.vars == nil {
 		return make([]*variables.Variable, 0), nil
 	}

--- a/internal/pkg/variable/source/config.go
+++ b/internal/pkg/variable/source/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/consul/api"
+	nomadapi "github.com/hashicorp/nomad/api"
 	vaultapi "github.com/hashicorp/vault/api"
 )
 
@@ -84,4 +85,39 @@ func (v VaultSourceConfig) Build() (VariableSource, error) {
 	}
 
 	return NewVaultSource(v.Priority, apiCfg, v.Mount, v.Path)
+}
+
+// NomadSourceConfig holds the parsed configuration for a Nomad Variables
+// variable source.
+type NomadSourceConfig struct {
+	// Priority is the precedence level applied to the built source.
+	Priority int
+
+	// Address is the Nomad HTTP address. When empty, the address from the
+	// standard Nomad environment configuration is used.
+	Address string
+
+	// Path is the Nomad Variable path. All variables for the pack are stored as
+	// items of the single Nomad Variable at this path.
+	Path string
+}
+
+// Build implements SourceConfig by constructing a NomadSource. When no host is
+// supplied (the nomad:///path form), the address and the rest of the client
+// settings come from nomadapi.DefaultConfig(), so NOMAD_ADDR is honored as-is —
+// including a unix:// socket such as the Task API socket.
+func (n NomadSourceConfig) Build() (VariableSource, error) {
+	apiCfg := nomadapi.DefaultConfig()
+	if n.Address != "" {
+		// A host taken from the URL is always a TCP host:port. Nomad's API
+		// address must be a full URL, so default to http when it omits a scheme —
+		// matching Nomad's own default address (http://127.0.0.1:4646).
+		addr := n.Address
+		if !strings.Contains(addr, "://") {
+			addr = "http://" + addr
+		}
+		apiCfg.Address = addr
+	}
+
+	return NewNomadSource(n.Priority, apiCfg, n.Path)
 }

--- a/internal/pkg/variable/source/config.go
+++ b/internal/pkg/variable/source/config.go
@@ -4,7 +4,10 @@
 package source
 
 import (
+	"strings"
+
 	"github.com/hashicorp/consul/api"
+	vaultapi "github.com/hashicorp/vault/api"
 )
 
 // SourceConfig is a parsed, lazily-evaluated configuration for a variable
@@ -47,4 +50,38 @@ func (c ConsulSourceConfig) Build() (VariableSource, error) {
 	}
 
 	return NewConsulSource(c.Priority, apiCfg, c.Path)
+}
+
+// VaultSourceConfig holds the parsed configuration for a Vault KV v2 variable
+// source.
+type VaultSourceConfig struct {
+	// Priority is the precedence level applied to the built source.
+	Priority int
+
+	// Address is the Vault HTTP address. When empty, the address from the
+	// standard Vault environment configuration is used.
+	Address string
+
+	// Mount is the KV v2 engine mount point under which the secret lives.
+	Mount string
+
+	// Path is the secret path within the mount. All variables for the pack are
+	// stored as fields of the single secret at <Mount>/<Path>.
+	Path string
+}
+
+// Build implements SourceConfig by constructing a VaultSource.
+func (v VaultSourceConfig) Build() (VariableSource, error) {
+	apiCfg := vaultapi.DefaultConfig()
+	if v.Address != "" {
+		// Vault's API address must be a full URL (unlike Consul's host:port),
+		// so default to https when the URL omits a scheme.
+		addr := v.Address
+		if !strings.Contains(addr, "://") {
+			addr = "https://" + addr
+		}
+		apiCfg.Address = addr
+	}
+
+	return NewVaultSource(v.Priority, apiCfg, v.Mount, v.Path)
 }

--- a/internal/pkg/variable/source/config.go
+++ b/internal/pkg/variable/source/config.go
@@ -1,0 +1,50 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source
+
+import (
+	"github.com/hashicorp/consul/api"
+)
+
+// SourceConfig is a parsed, lazily-evaluated configuration for a variable
+// source. Parsing a config (for example from a --var-source URL) is kept
+// separate from Build, which constructs the concrete VariableSource. Build does
+// only local work, such as building API client structs; it opens no connection.
+// No network I/O happens until variables are actually fetched for rendering, so
+// callers can parse and validate source configuration up front for free.
+type SourceConfig interface {
+	// Build constructs the concrete VariableSource described by this config.
+	// Implementations may construct API clients here, but constructing a client
+	// must not open a connection; no remote reads happen until
+	// VariableSource.Fetch.
+	Build() (VariableSource, error)
+}
+
+// ConsulSourceConfig holds the parsed configuration for a Consul KV variable
+// source. It is a plain value type with no live connections, making it safe to
+// pass across package boundaries without import cycles.
+type ConsulSourceConfig struct {
+	// Priority is the precedence level applied to the built source.
+	Priority int
+
+	// Address is the Consul HTTP address. When empty, the address from the
+	// standard Consul environment configuration is used.
+	Address string
+
+	// Path is the Consul KV path under which variables are stored. Each
+	// variable is read from <Path>/<var-name>.
+	Path string
+}
+
+// Build implements SourceConfig by constructing a ConsulSource. It builds the
+// Consul API client struct but opens no connection and performs no remote
+// reads; those happen later in Fetch.
+func (c ConsulSourceConfig) Build() (VariableSource, error) {
+	apiCfg := api.DefaultConfig()
+	if c.Address != "" {
+		apiCfg.Address = c.Address
+	}
+
+	return NewConsulSource(c.Priority, apiCfg, c.Path)
+}

--- a/internal/pkg/variable/source/consul_source.go
+++ b/internal/pkg/variable/source/consul_source.go
@@ -15,9 +15,7 @@ import (
 )
 
 // ConsulSource fetches variables from Consul KV store. Each variable is read
-// from <path>/<variable-name>, where <path> is the user-supplied KV path.
-// Callers that want per-pack namespacing include it in the path
-// themselves (for example, consul:///myapp/config).
+// from <path>/<variable-name>, where <path> is the user-supplied KV path (for example, consul:///myapp/config).
 type ConsulSource struct {
 	name     string
 	priority int
@@ -94,7 +92,7 @@ func (c *ConsulSource) Fetch(ctx context.Context, _ pack.ID, schema map[variable
 	// c.path was trimmed of slashes when the source was built; re-add a single
 	// trailing slash to scope the KV list to keys under this path and to strip
 	// each key down to its variable name. The pack ID is intentionally unused —
-	// any per-pack grouping lives in the path itself.
+	// the KV path is taken as-is from the source URL.
 	path := c.path + "/"
 
 	// List all keys under this path

--- a/internal/pkg/variable/source/consul_source.go
+++ b/internal/pkg/variable/source/consul_source.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/nomad-pack/sdk/pack"
 	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
 	"github.com/zclconf/go-cty/cty"
-	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 // ConsulSource fetches variables from Consul KV store. Each variable is read
@@ -142,7 +141,7 @@ func (c *ConsulSource) Fetch(ctx context.Context, _ pack.ID, schema map[variable
 		}
 
 		// Convert value using schema-aware conversion
-		value, err := c.convertValueWithSchema(pair.Value, expectedType)
+		value, err := decodeValue("Consul", pair.Value, expectedType)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert value for %s: %w", varName, err)
 		}
@@ -155,20 +154,4 @@ func (c *ConsulSource) Fetch(ctx context.Context, _ pack.ID, schema map[variable
 	}
 
 	return vars, nil
-}
-
-// convertValueWithSchema converts raw Consul KV bytes into a cty.Value of the
-// expected type.
-func (c *ConsulSource) convertValueWithSchema(data []byte, expectedType cty.Type) (cty.Value, error) {
-	if expectedType == cty.String {
-		return cty.StringVal(string(data)), nil
-	}
-
-	// For every other type, let cty decode the JSON directly into the expected type.
-	val, err := ctyjson.Unmarshal(data, expectedType)
-	if err != nil {
-		return cty.NilVal, fmt.Errorf("decoding Consul value as %s: %w", expectedType.FriendlyName(), err)
-	}
-
-	return val, nil
 }

--- a/internal/pkg/variable/source/consul_source.go
+++ b/internal/pkg/variable/source/consul_source.go
@@ -1,0 +1,174 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/nomad-pack/sdk/pack"
+	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+// ConsulSource fetches variables from Consul KV store. Each variable is read
+// from <path>/<variable-name>, where <path> is the user-supplied KV path.
+// Callers that want per-pack namespacing include it in the path
+// themselves (for example, consul:///myapp/config).
+type ConsulSource struct {
+	name     string
+	priority int
+	client   *api.Client
+	path     string // KV path under which variables are stored
+}
+
+// NewConsulSource creates a new Consul KV variable source.
+// The config parameter can be nil to use default Consul configuration
+// (which reads from CONSUL_HTTP_ADDR and CONSUL_HTTP_TOKEN env vars).
+// The path parameter is the KV path where variables are stored; each variable
+// is read from <path>/<variable-name>. It must not be empty.
+func NewConsulSource(priority int, config *api.Config, path string) (*ConsulSource, error) {
+	// Variables are read from <path>/<variable-name>, so an empty path would
+	// list the entire KV store. Require an explicit path.
+	trimmedPath := strings.Trim(path, "/")
+	if trimmedPath == "" {
+		return nil, fmt.Errorf("consul source requires a non-empty KV path")
+	}
+
+	if config == nil {
+		config = api.DefaultConfig()
+	}
+
+	client, err := api.NewClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Consul client: %w", err)
+	}
+
+	// Make the name unique by including the address and path.
+	// This allows multiple Consul sources with different configurations
+	// and eliminates the possibility of duplicate names.
+	name := fmt.Sprintf("consul(%s:%s)", config.Address, trimmedPath)
+
+	return &ConsulSource{
+		name:     name,
+		priority: priority,
+		client:   client,
+		path:     trimmedPath,
+	}, nil
+}
+
+// Name returns the unique identifier for this source.
+func (c *ConsulSource) Name() string {
+	return c.name
+}
+
+// Priority returns the precedence level (higher = higher priority).
+func (c *ConsulSource) Priority() int {
+	return c.priority
+}
+
+// Fetch retrieves variables for the given pack from Consul KV. Each variable is
+// read from <path>/<variable-name> and decoded into the type the pack schema
+// declares for it.
+//
+// Type Conversion Rules:
+//   - If schema expects string: always return as string (even if valid JSON)
+//   - If schema expects number: decode the value as a JSON number
+//   - If schema expects bool: decode the value as a JSON boolean
+//   - If schema expects object/list: decode the value as JSON into that type
+//   - Variables not in schema are skipped (not returned)
+//
+// Edge Cases:
+//   - Returns nil (not error) if no keys found at path
+//   - Skips directory entries (keys ending with /)
+//   - Skips variables not defined in the pack schema
+//   - Returns an error for an empty value on a non-string variable; empty
+//     values for string variables are kept as ""
+//
+// The parser wraps Fetch in a timeout context, so a slow or unreachable Consul
+// fails the resolve instead of hanging.
+func (c *ConsulSource) Fetch(ctx context.Context, _ pack.ID, schema map[variables.ID]*variables.Variable) ([]*variables.Variable, error) {
+	// c.path was trimmed of slashes when the source was built; re-add a single
+	// trailing slash to scope the KV list to keys under this path and to strip
+	// each key down to its variable name. The pack ID is intentionally unused —
+	// any per-pack grouping lives in the path itself.
+	path := c.path + "/"
+
+	// List all keys under this path
+	opts := api.QueryOptions{RequireConsistent: true}
+	pairs, _, err := c.client.KV().List(path, (&opts).WithContext(ctx))
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Consul KV at %s: %w", path, err)
+	}
+
+	// If no keys found, return nil (not an error)
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+
+	vars := make([]*variables.Variable, 0, len(pairs))
+	for _, pair := range pairs {
+		// Skip directory entries (keys ending in /) before stripping the prefix
+		if strings.HasSuffix(pair.Key, "/") {
+			continue
+		}
+
+		varName := strings.TrimPrefix(pair.Key, path)
+
+		// Check if this variable exists in the schema
+		schemaVar, inSchema := schema[variables.ID(varName)]
+		if !inSchema {
+			// Skip variables not defined in the pack schema
+			continue
+		}
+
+		// A non-string variable has no meaningful empty form (there is no "empty"
+		// number or bool), so an empty value almost always means the Consul key
+		// was misconfigured. Empty values for string variables are valid and kept as "".
+		if len(pair.Value) == 0 && schemaVar.Type != cty.String {
+			return nil, fmt.Errorf("empty Consul value for %s at %s: a %s value is required", varName, pair.Key, schemaVar.Type.FriendlyName())
+		}
+
+		// Convert using the variable's constraint type. ConstraintType preserves
+		// optional() attributes.
+		expectedType := schemaVar.ConstraintType
+		if expectedType == cty.NilType {
+			expectedType = schemaVar.Type
+		}
+
+		// Convert value using schema-aware conversion
+		value, err := c.convertValueWithSchema(pair.Value, expectedType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert value for %s: %w", varName, err)
+		}
+
+		vars = append(vars, &variables.Variable{
+			Name:  variables.ID(varName),
+			Value: value,
+			Type:  value.Type(),
+		})
+	}
+
+	return vars, nil
+}
+
+// convertValueWithSchema converts raw Consul KV bytes into a cty.Value of the
+// expected type.
+func (c *ConsulSource) convertValueWithSchema(data []byte, expectedType cty.Type) (cty.Value, error) {
+	if expectedType == cty.String {
+		return cty.StringVal(string(data)), nil
+	}
+
+	// For every other type, let cty decode the JSON directly into the expected type.
+	val, err := ctyjson.Unmarshal(data, expectedType)
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("decoding Consul value as %s: %w", expectedType.FriendlyName(), err)
+	}
+
+	return val, nil
+}

--- a/internal/pkg/variable/source/consul_source_integration_test.go
+++ b/internal/pkg/variable/source/consul_source_integration_test.go
@@ -39,7 +39,7 @@ func newSourceForServer(t *testing.T, srv *consultest.TestServer, path string) *
 	t.Helper()
 	cfg := api.DefaultConfig()
 	cfg.Address = srv.HTTPAddr
-	src, err := NewConsulSource(PriorityConsul, cfg, path)
+	src, err := NewConsulSource(PriorityExternalBase, cfg, path)
 	must.NoError(t, err)
 	return src
 }
@@ -164,7 +164,7 @@ func TestConsulSource_Fetch(t *testing.T) {
 	t.Run("consul unavailable returns list error", func(t *testing.T) {
 		cfg := api.DefaultConfig()
 		cfg.Address = "127.0.0.1:19998"
-		src, err := NewConsulSource(PriorityConsul, cfg, "any/path")
+		src, err := NewConsulSource(PriorityExternalBase, cfg, "any/path")
 		must.NoError(t, err)
 		_, err = src.Fetch(t.Context(), packID, schema)
 		must.ErrorContains(t, err, "failed to list Consul KV")

--- a/internal/pkg/variable/source/consul_source_integration_test.go
+++ b/internal/pkg/variable/source/consul_source_integration_test.go
@@ -1,0 +1,193 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source
+
+import (
+	"io"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	consultest "github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/nomad-pack/sdk/pack"
+	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
+	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func startTestConsul(t *testing.T) *consultest.TestServer {
+	t.Helper()
+
+	srv, err := consultest.NewTestServerConfigT(t, func(c *consultest.TestServerConfig) {
+		c.Peering = nil
+		if !testing.Verbose() {
+			c.Stdout = io.Discard
+			c.Stderr = io.Discard
+		}
+	})
+	if err != nil {
+		t.Fatalf("failed to start Consul test server: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Stop() })
+
+	srv.WaitForLeader(t)
+	return srv
+}
+
+func newSourceForServer(t *testing.T, srv *consultest.TestServer, path string) *ConsulSource {
+	t.Helper()
+	cfg := api.DefaultConfig()
+	cfg.Address = srv.HTTPAddr
+	src, err := NewConsulSource(PriorityConsul, cfg, path)
+	must.NoError(t, err)
+	return src
+}
+
+func varsByName(vars []*variables.Variable) map[string]*variables.Variable {
+	out := make(map[string]*variables.Variable, len(vars))
+	for _, v := range vars {
+		out[string(v.Name)] = v
+	}
+	return out
+}
+
+func TestConsulSource_Fetch(t *testing.T) {
+	ci.Parallel(t)
+
+	srv := startTestConsul(t)
+
+	packID := pack.ID("webapp")
+	schema := map[variables.ID]*variables.Variable{
+		"replicas": {Name: "replicas", Type: cty.Number},
+		"region":   {Name: "region", Type: cty.String},
+		"name":     {Name: "name", Type: cty.String},
+	}
+
+	t.Run("fetches typed variables from KV path", func(t *testing.T) {
+		srv.SetKVString(t, "deploy/webapp/replicas", "3")
+		srv.SetKVString(t, "deploy/webapp/region", "us-west-2")
+
+		src := newSourceForServer(t, srv, "deploy/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 2, vars)
+
+		got := varsByName(vars)
+		replicas, _ := got["replicas"].Value.AsBigFloat().Int64()
+		must.Eq(t, int64(3), replicas)
+		must.Eq(t, "us-west-2", got["region"].Value.AsString())
+	})
+
+	t.Run("keys not in pack schema are ignored", func(t *testing.T) {
+		srv.SetKVString(t, "staging/webapp/region", "us-east-1")
+		srv.SetKVString(t, "staging/webapp/not_in_pack", "ignored")
+
+		src := newSourceForServer(t, srv, "staging/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "region", string(vars[0].Name))
+	})
+
+	t.Run("empty value for non-string variable is an error", func(t *testing.T) {
+		srv.SetKVString(t, "prod/webapp/replicas", "")
+		srv.SetKVString(t, "prod/webapp/region", "us-west-1")
+
+		src := newSourceForServer(t, srv, "prod/webapp")
+		_, err := src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "empty Consul value")
+	})
+
+	t.Run("object with optional field missing is valid", func(t *testing.T) {
+		objSchema := map[variables.ID]*variables.Variable{
+			"svc": {
+				Name: "svc",
+				Type: cty.Object(map[string]cty.Type{
+					"name": cty.String,
+					"port": cty.Number,
+				}),
+				ConstraintType: cty.ObjectWithOptionalAttrs(
+					map[string]cty.Type{"name": cty.String, "port": cty.Number},
+					[]string{"port"},
+				),
+			},
+		}
+		srv.SetKVString(t, "services/webapp/svc", `{"name":"api"}`)
+
+		src := newSourceForServer(t, srv, "services/webapp")
+		vars, err := src.Fetch(t.Context(), packID, objSchema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "api", vars[0].Value.GetAttr("name").AsString())
+		must.True(t, vars[0].Value.GetAttr("port").IsNull())
+	})
+
+	t.Run("bool variable is decoded from JSON", func(t *testing.T) {
+		boolSchema := map[variables.ID]*variables.Variable{
+			"enabled": {Name: "enabled", Type: cty.Bool},
+		}
+		srv.SetKVString(t, "config/webapp/enabled", "true")
+
+		src := newSourceForServer(t, srv, "config/webapp")
+		vars, err := src.Fetch(t.Context(), packID, boolSchema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.True(t, vars[0].Value.True())
+	})
+
+	t.Run("malformed JSON for non-string variable is an error", func(t *testing.T) {
+		srv.SetKVString(t, "broken/webapp/replicas", "not-a-number")
+
+		src := newSourceForServer(t, srv, "broken/webapp")
+		_, err := src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "decoding Consul value")
+	})
+
+	t.Run("empty string value is kept for string variable", func(t *testing.T) {
+		srv.SetKVString(t, "defaults/webapp/name", "")
+
+		src := newSourceForServer(t, srv, "defaults/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "", vars[0].Value.AsString())
+	})
+
+	t.Run("path with no keys returns empty result", func(t *testing.T) {
+		src := newSourceForServer(t, srv, "empty/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 0, vars)
+	})
+
+	t.Run("consul unavailable returns list error", func(t *testing.T) {
+		cfg := api.DefaultConfig()
+		cfg.Address = "127.0.0.1:19998"
+		src, err := NewConsulSource(PriorityConsul, cfg, "any/path")
+		must.NoError(t, err)
+		_, err = src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "failed to list Consul KV")
+	})
+
+	t.Run("path with surrounding slashes fetches correctly", func(t *testing.T) {
+		srv.SetKVString(t, "norm/webapp/region", "ap-southeast-1")
+
+		src := newSourceForServer(t, srv, "/norm/webapp/")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "ap-southeast-1", varsByName(vars)["region"].Value.AsString())
+	})
+
+	t.Run("keys with trailing slash are skipped", func(t *testing.T) {
+		srv.SetKVString(t, "nested/webapp/region", "us-east-1")
+		srv.SetKVString(t, "nested/webapp/subdir/", "ignored")
+
+		src := newSourceForServer(t, srv, "nested/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "region", string(vars[0].Name))
+	})
+}

--- a/internal/pkg/variable/source/convert.go
+++ b/internal/pkg/variable/source/convert.go
@@ -1,0 +1,29 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source
+
+import (
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+// decodeValue converts a raw external-source value into a cty.Value of the
+// expected type. String values are returned as-is; every other type is
+// JSON-decoded into expectedType. source names the backend (for example
+// "Consul") so callers share one decode path while keeping backend-specific
+// error messages.
+func decodeValue(source string, data []byte, expectedType cty.Type) (cty.Value, error) {
+	if expectedType == cty.String {
+		return cty.StringVal(string(data)), nil
+	}
+
+	val, err := ctyjson.Unmarshal(data, expectedType)
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("decoding %s value as %s: %w", source, expectedType.FriendlyName(), err)
+	}
+
+	return val, nil
+}

--- a/internal/pkg/variable/source/nomad_source.go
+++ b/internal/pkg/variable/source/nomad_source.go
@@ -1,0 +1,129 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad-pack/sdk/pack"
+	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
+	"github.com/hashicorp/nomad/api"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+// NomadSource fetches variables from a Nomad Variable. All variables for a pack
+// are stored as items of a single Nomad Variable at <path>.
+type NomadSource struct {
+	name     string
+	priority int
+	client   *api.Client
+	path     string // Nomad Variable path, e.g. "nomad-pack/myapp"
+}
+
+// NewNomadSource creates a new Nomad Variables source. config can be nil to use
+// the default Nomad configuration (reads NOMAD_ADDR, NOMAD_TOKEN, and
+// NOMAD_NAMESPACE from the environment). path is the Nomad Variable path whose
+// items become pack variables.
+func NewNomadSource(priority int, config *api.Config, path string) (*NomadSource, error) {
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return nil, fmt.Errorf("nomad source requires a non-empty variable path")
+	}
+
+	if config == nil {
+		config = api.DefaultConfig()
+	}
+
+	client, err := api.NewClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Nomad client: %w", err)
+	}
+
+	name := fmt.Sprintf("nomad(%s/%s)", config.Address, path)
+
+	return &NomadSource{
+		name:     name,
+		priority: priority,
+		client:   client,
+		path:     path,
+	}, nil
+}
+
+// Name returns the unique identifier for this source.
+func (n *NomadSource) Name() string {
+	return n.name
+}
+
+// Priority returns the precedence level (higher = higher priority).
+func (n *NomadSource) Priority() int {
+	return n.priority
+}
+
+// Fetch reads the Nomad Variable at <path> and returns variables whose names
+// appear in schema. Values are decoded using the schema type — string items are
+// returned as-is; all other types are JSON-decoded.
+//
+// Each item of the Nomad Variable maps to one pack variable.
+// Returns nil (not an error) when no Nomad Variable exists at the given path.
+func (n *NomadSource) Fetch(ctx context.Context, _ pack.ID, schema map[variables.ID]*variables.Variable) ([]*variables.Variable, error) {
+	variable, _, err := n.client.Variables().Read(n.path, (&api.QueryOptions{}).WithContext(ctx))
+	if err != nil {
+		if errors.Is(err, api.ErrVariablePathNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read Nomad variable at %s: %w", n.path, err)
+	}
+
+	vars := make([]*variables.Variable, 0, len(variable.Items))
+	for rawKey, str := range variable.Items {
+		schemaVar, inSchema := schema[variables.ID(rawKey)]
+		if !inSchema {
+			continue
+		}
+
+		// Empty values for string variables are valid and kept as "".
+		if str == "" && schemaVar.Type != cty.String {
+			return nil, fmt.Errorf("empty Nomad value for %s: a %s value is required", rawKey, schemaVar.Type.FriendlyName())
+		}
+
+		// Convert using the variable's constraint type. ConstraintType preserves
+		// optional() attributes.
+		expectedType := schemaVar.ConstraintType
+		if expectedType == cty.NilType {
+			expectedType = schemaVar.Type
+		}
+
+		value, err := n.convertValue([]byte(str), expectedType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert value for %s: %w", rawKey, err)
+		}
+
+		vars = append(vars, &variables.Variable{
+			Name:  variables.ID(rawKey),
+			Value: value,
+			Type:  value.Type(),
+		})
+	}
+
+	return vars, nil
+}
+
+// convertValue converts a raw Nomad Variable item value into a cty.Value of the
+// expected type.
+func (n *NomadSource) convertValue(data []byte, expectedType cty.Type) (cty.Value, error) {
+	if expectedType == cty.String {
+		return cty.StringVal(string(data)), nil
+	}
+
+	val, err := ctyjson.Unmarshal(data, expectedType)
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("decoding Nomad value as %s: %w", expectedType.FriendlyName(), err)
+	}
+
+	return val, nil
+}

--- a/internal/pkg/variable/source/nomad_source.go
+++ b/internal/pkg/variable/source/nomad_source.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
 	"github.com/hashicorp/nomad/api"
 	"github.com/zclconf/go-cty/cty"
-	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 // NomadSource fetches variables from a Nomad Variable. All variables for a pack
@@ -98,7 +97,7 @@ func (n *NomadSource) Fetch(ctx context.Context, _ pack.ID, schema map[variables
 			expectedType = schemaVar.Type
 		}
 
-		value, err := n.convertValue([]byte(str), expectedType)
+		value, err := decodeValue("Nomad", []byte(str), expectedType)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert value for %s: %w", rawKey, err)
 		}
@@ -111,19 +110,4 @@ func (n *NomadSource) Fetch(ctx context.Context, _ pack.ID, schema map[variables
 	}
 
 	return vars, nil
-}
-
-// convertValue converts a raw Nomad Variable item value into a cty.Value of the
-// expected type.
-func (n *NomadSource) convertValue(data []byte, expectedType cty.Type) (cty.Value, error) {
-	if expectedType == cty.String {
-		return cty.StringVal(string(data)), nil
-	}
-
-	val, err := ctyjson.Unmarshal(data, expectedType)
-	if err != nil {
-		return cty.NilVal, fmt.Errorf("decoding Nomad value as %s: %w", expectedType.FriendlyName(), err)
-	}
-
-	return val, nil
 }

--- a/internal/pkg/variable/source/nomad_source_integration_test.go
+++ b/internal/pkg/variable/source/nomad_source_integration_test.go
@@ -57,7 +57,7 @@ func newNomadSourceForServer(t *testing.T, srv *testutil.TestServer, path string
 	t.Helper()
 	cfg := api.DefaultConfig()
 	cfg.Address = "http://" + srv.HTTPAddr
-	src, err := NewNomadSource(PriorityNomad, cfg, path)
+	src, err := NewNomadSource(PriorityExternalBase, cfg, path)
 	must.NoError(t, err)
 	return src
 }
@@ -209,7 +209,7 @@ func TestNomadSource_Fetch(t *testing.T) {
 	t.Run("nomad unavailable returns read error", func(t *testing.T) {
 		cfg := api.DefaultConfig()
 		cfg.Address = fmt.Sprintf("http://127.0.0.1:%d", ci.PortAllocator.One())
-		src, err := NewNomadSource(PriorityNomad, cfg, "any/path")
+		src, err := NewNomadSource(PriorityExternalBase, cfg, "any/path")
 		must.NoError(t, err)
 
 		_, err = src.Fetch(t.Context(), packID, schema)

--- a/internal/pkg/variable/source/nomad_source_integration_test.go
+++ b/internal/pkg/variable/source/nomad_source_integration_test.go
@@ -1,0 +1,218 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"testing"
+
+	"github.com/hashicorp/nomad-pack/sdk/pack"
+	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test/must"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func startTestNomad(t *testing.T) *testutil.TestServer {
+	t.Helper()
+
+	if _, err := exec.LookPath("nomad"); err != nil {
+		t.Fatalf("nomad binary not found on $PATH: %v", err)
+	}
+
+	srv := testutil.NewTestServer(t, func(c *testutil.TestServerConfig) {
+		if !testing.Verbose() {
+			c.Stdout = io.Discard
+			c.Stderr = io.Discard
+		}
+	})
+	t.Cleanup(srv.Stop)
+	return srv
+}
+
+func newNomadClient(t *testing.T, srv *testutil.TestServer) *api.Client {
+	t.Helper()
+	cfg := api.DefaultConfig()
+	cfg.Address = "http://" + srv.HTTPAddr
+	client, err := api.NewClient(cfg)
+	must.NoError(t, err)
+	return client
+}
+
+func writeNomadVar(t *testing.T, client *api.Client, path string, items map[string]string) {
+	t.Helper()
+	_, _, err := client.Variables().Create(&api.Variable{
+		Path:  path,
+		Items: items,
+	}, nil)
+	must.NoError(t, err)
+}
+
+func newNomadSourceForServer(t *testing.T, srv *testutil.TestServer, path string) *NomadSource {
+	t.Helper()
+	cfg := api.DefaultConfig()
+	cfg.Address = "http://" + srv.HTTPAddr
+	src, err := NewNomadSource(PriorityNomad, cfg, path)
+	must.NoError(t, err)
+	return src
+}
+
+func nomadVarsByName(vars []*variables.Variable) map[string]*variables.Variable {
+	out := make(map[string]*variables.Variable, len(vars))
+	for _, v := range vars {
+		out[string(v.Name)] = v
+	}
+	return out
+}
+
+func TestNomadSource_Fetch(t *testing.T) {
+	ci.Parallel(t)
+
+	srv := startTestNomad(t)
+	client := newNomadClient(t, srv)
+
+	packID := pack.ID("webapp")
+	schema := map[variables.ID]*variables.Variable{
+		"replicas": {Name: "replicas", Type: cty.Number},
+		"region":   {Name: "region", Type: cty.String},
+		"name":     {Name: "name", Type: cty.String},
+	}
+
+	t.Run("fetches typed variables from a variable", func(t *testing.T) {
+		writeNomadVar(t, client, "deploy/webapp", map[string]string{
+			"replicas": "3",
+			"region":   "us-west-2",
+		})
+
+		src := newNomadSourceForServer(t, srv, "deploy/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 2, vars)
+
+		got := nomadVarsByName(vars)
+		replicas, _ := got["replicas"].Value.AsBigFloat().Int64()
+		must.Eq(t, int64(3), replicas)
+		must.Eq(t, "us-west-2", got["region"].Value.AsString())
+	})
+
+	t.Run("items not in pack schema are ignored", func(t *testing.T) {
+		writeNomadVar(t, client, "staging/webapp", map[string]string{
+			"region":      "us-east-1",
+			"not_in_pack": "ignored",
+		})
+
+		src := newNomadSourceForServer(t, srv, "staging/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "region", string(vars[0].Name))
+	})
+
+	t.Run("empty value for non-string variable is an error", func(t *testing.T) {
+		writeNomadVar(t, client, "prod/webapp", map[string]string{
+			"replicas": "",
+			"region":   "us-west-1",
+		})
+
+		src := newNomadSourceForServer(t, srv, "prod/webapp")
+		_, err := src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "empty Nomad value")
+	})
+
+	t.Run("object with optional field missing is valid", func(t *testing.T) {
+		objSchema := map[variables.ID]*variables.Variable{
+			"svc": {
+				Name: "svc",
+				Type: cty.Object(map[string]cty.Type{
+					"name": cty.String,
+					"port": cty.Number,
+				}),
+				ConstraintType: cty.ObjectWithOptionalAttrs(
+					map[string]cty.Type{"name": cty.String, "port": cty.Number},
+					[]string{"port"},
+				),
+			},
+		}
+		writeNomadVar(t, client, "services/webapp", map[string]string{
+			"svc": `{"name":"api"}`,
+		})
+
+		src := newNomadSourceForServer(t, srv, "services/webapp")
+		vars, err := src.Fetch(t.Context(), packID, objSchema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "api", vars[0].Value.GetAttr("name").AsString())
+		must.True(t, vars[0].Value.GetAttr("port").IsNull())
+	})
+
+	t.Run("list variable is decoded from JSON", func(t *testing.T) {
+		listSchema := map[variables.ID]*variables.Variable{
+			"zones": {Name: "zones", Type: cty.List(cty.String)},
+		}
+		writeNomadVar(t, client, "config/webapp", map[string]string{
+			"zones": `["us-east-1a","us-east-1b"]`,
+		})
+
+		src := newNomadSourceForServer(t, srv, "config/webapp")
+		vars, err := src.Fetch(t.Context(), packID, listSchema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, 2, vars[0].Value.LengthInt())
+		must.Eq(t, "us-east-1a", vars[0].Value.Index(cty.NumberIntVal(0)).AsString())
+	})
+
+	t.Run("malformed JSON for non-string variable is an error", func(t *testing.T) {
+		writeNomadVar(t, client, "broken/webapp", map[string]string{
+			"replicas": "not-a-number",
+		})
+
+		src := newNomadSourceForServer(t, srv, "broken/webapp")
+		_, err := src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "decoding Nomad value")
+	})
+
+	t.Run("empty string value is kept for string variable", func(t *testing.T) {
+		writeNomadVar(t, client, "defaults/webapp", map[string]string{
+			"name": "",
+		})
+
+		src := newNomadSourceForServer(t, srv, "defaults/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "", vars[0].Value.AsString())
+	})
+
+	t.Run("variable not found returns empty result", func(t *testing.T) {
+		src := newNomadSourceForServer(t, srv, "missing/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 0, vars)
+	})
+
+	t.Run("variable with no matching items returns empty result", func(t *testing.T) {
+		writeNomadVar(t, client, "nomatch/webapp", map[string]string{
+			"not_in_pack": "ignored",
+		})
+
+		src := newNomadSourceForServer(t, srv, "nomatch/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 0, vars)
+	})
+
+	t.Run("nomad unavailable returns read error", func(t *testing.T) {
+		cfg := api.DefaultConfig()
+		cfg.Address = fmt.Sprintf("http://127.0.0.1:%d", ci.PortAllocator.One())
+		src, err := NewNomadSource(PriorityNomad, cfg, "any/path")
+		must.NoError(t, err)
+
+		_, err = src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "failed to read Nomad variable")
+	})
+}

--- a/internal/pkg/variable/source/registry.go
+++ b/internal/pkg/variable/source/registry.go
@@ -29,7 +29,7 @@ import (
 //	registry.Register(source.NewEnvSource(10, envVars))
 //	registry.Register(source.NewFileSource(20, fileVars))
 //	registry.Register(source.NewCLISource(30, cliVars))
-//	vars, err := registry.Resolve(ctx, packID)
+//	vars, err := registry.Resolve(ctx, packID, schema)
 type Registry struct {
 	sources []VariableSource
 }
@@ -41,36 +41,25 @@ func NewRegistry() *Registry {
 	}
 }
 
-// Register adds a source to the registry. Returns an error if the source
-// has an empty name, or if a source with the same name is already registered.
+// Register adds a source to the registry.
 // Sources are automatically sorted by priority after registration.
-func (r *Registry) Register(source VariableSource) error {
-	if source.Name() == "" {
-		return fmt.Errorf("source name cannot be empty")
-	}
-
-	// Check for duplicate names
-	for _, existing := range r.sources {
-		if existing.Name() == source.Name() {
-			return fmt.Errorf("source with name %q already registered", source.Name())
-		}
-	}
-
+// Source names are expected to be unique (enforced by source constructors).
+func (r *Registry) Register(source VariableSource) {
 	r.sources = append(r.sources, source)
 
 	// Sort by priority immediately after adding (lower first, so higher priority overwrites)
 	slices.SortFunc(r.sources, func(a, b VariableSource) int {
 		return cmp.Compare(a.Priority(), b.Priority())
 	})
-
-	return nil
 }
 
 // Resolve fetches and merges variables from all registered sources.
 // Sources are processed in priority order (lowest to highest), with
 // higher priority sources overwriting variables from lower priority sources.
+// The schema parameter provides the expected type for each variable, allowing
+// sources to perform schema-aware type conversion.
 // Returns an error if context is cancelled or if any source fails to fetch.
-func (r *Registry) Resolve(ctx context.Context, packID pack.ID) ([]*variables.Variable, error) {
+func (r *Registry) Resolve(ctx context.Context, packID pack.ID, schema map[variables.ID]*variables.Variable) ([]*variables.Variable, error) {
 	// Check context before starting
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("context cancelled before resolution: %w", err)
@@ -87,7 +76,7 @@ func (r *Registry) Resolve(ctx context.Context, packID pack.ID) ([]*variables.Va
 			return nil, fmt.Errorf("context cancelled during resolution: %w", err)
 		}
 
-		vars, err := source.Fetch(ctx, packID)
+		vars, err := source.Fetch(ctx, packID, schema)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch from %s: %w", source.Name(), err)
 		}

--- a/internal/pkg/variable/source/registry_test.go
+++ b/internal/pkg/variable/source/registry_test.go
@@ -37,7 +37,7 @@ func TestRegistry_Resolve(t *testing.T) {
 				{Name: "replicas", Value: cty.NumberIntVal(3)},
 			},
 		}
-		registry.Register(NewBaseSource("consul", PriorityConsul, consulVars))
+		registry.Register(NewBaseSource("consul", PriorityExternalBase, consulVars))
 
 		// CLI has higher priority
 		cliVars := map[pack.ID][]*variables.Variable{
@@ -80,7 +80,7 @@ func TestRegistry_Resolve(t *testing.T) {
 		consulVars := map[pack.ID][]*variables.Variable{
 			packID: {{Name: "app_name", Value: cty.StringVal("prod-app")}},
 		}
-		registry.Register(NewBaseSource("consul", PriorityConsul, consulVars))
+		registry.Register(NewBaseSource("consul", PriorityExternalBase, consulVars))
 
 		result, err := registry.Resolve(t.Context(), packID, schema)
 		must.NoError(t, err)

--- a/internal/pkg/variable/source/registry_test.go
+++ b/internal/pkg/variable/source/registry_test.go
@@ -14,59 +14,100 @@ import (
 )
 
 func TestRegistry_Resolve(t *testing.T) {
-	packID := pack.ID("test")
+	packID := pack.ID("webapp")
 
-	testCases := []struct {
-		name     string
-		sources  []VariableSource
-		expected cty.Value
-	}{
-		{
-			name: "priority resolution",
-			sources: []VariableSource{
-				NewBaseSource("low", 1, map[pack.ID][]*variables.Variable{
-					packID: {{Name: "var", Value: cty.StringVal("low")}},
-				}),
-				NewBaseSource("high", 10, map[pack.ID][]*variables.Variable{
-					packID: {{Name: "var", Value: cty.StringVal("high")}},
-				}),
-			},
-			expected: cty.StringVal("high"),
+	schema := map[variables.ID]*variables.Variable{
+		"app_name": {
+			Name: "app_name",
+			Type: cty.String,
+		},
+		"replicas": {
+			Name: "replicas",
+			Type: cty.Number,
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			registry := NewRegistry()
-			for _, s := range tc.sources {
-				must.NoError(t, registry.Register(s))
-			}
-
-			result, err := registry.Resolve(t.Context(), packID)
-			must.NoError(t, err)
-			must.Len(t, 1, result)
-			must.True(t, tc.expected.Equals(result[0].Value).True())
-		})
-	}
-
-	t.Run("empty registry", func(t *testing.T) {
+	t.Run("cli overrides consul", func(t *testing.T) {
 		registry := NewRegistry()
-		result, err := registry.Resolve(t.Context(), pack.ID("test"))
+
+		// Consul has lower priority
+		consulVars := map[pack.ID][]*variables.Variable{
+			packID: {
+				{Name: "app_name", Value: cty.StringVal("consul-app")},
+				{Name: "replicas", Value: cty.NumberIntVal(3)},
+			},
+		}
+		registry.Register(NewBaseSource("consul", PriorityConsul, consulVars))
+
+		// CLI has higher priority
+		cliVars := map[pack.ID][]*variables.Variable{
+			packID: {
+				{Name: "app_name", Value: cty.StringVal("cli-app")},
+			},
+		}
+		registry.Register(NewBaseSource("cli", PriorityCLI, cliVars))
+
+		result, err := registry.Resolve(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 2, result)
+
+		// CLI value should win for app_name
+		var appName, replicas *variables.Variable
+		for _, v := range result {
+			switch v.Name {
+			case "app_name":
+				appName = v
+			case "replicas":
+				replicas = v
+			}
+		}
+
+		must.Eq(t, "cli-app", appName.Value.AsString())
+		replicasInt, _ := replicas.Value.AsBigFloat().Int64()
+		must.Eq(t, int64(3), replicasInt)
+	})
+
+	t.Run("multiple sources merge correctly", func(t *testing.T) {
+		registry := NewRegistry()
+
+		// File source provides base config
+		fileVars := map[pack.ID][]*variables.Variable{
+			packID: {{Name: "replicas", Value: cty.NumberIntVal(1)}},
+		}
+		registry.Register(NewBaseSource("file", PriorityFile, fileVars))
+
+		// Consul provides app name
+		consulVars := map[pack.ID][]*variables.Variable{
+			packID: {{Name: "app_name", Value: cty.StringVal("prod-app")}},
+		}
+		registry.Register(NewBaseSource("consul", PriorityConsul, consulVars))
+
+		result, err := registry.Resolve(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 2, result)
+	})
+
+	t.Run("no variables for pack", func(t *testing.T) {
+		registry := NewRegistry()
+		registry.Register(NewBaseSource("empty", PriorityFile, nil))
+
+		result, err := registry.Resolve(t.Context(), pack.ID("nonexistent"), schema)
 		must.NoError(t, err)
 		must.Len(t, 0, result)
 	})
 
-	t.Run("context cancellation", func(t *testing.T) {
+	t.Run("cancelled context fails fast", func(t *testing.T) {
 		registry := NewRegistry()
-		s := NewBaseSource("test", 1, map[pack.ID][]*variables.Variable{
-			pack.ID("test"): {{Name: "var", Value: cty.StringVal("val")}},
-		})
-		must.NoError(t, registry.Register(s))
+		vars := map[pack.ID][]*variables.Variable{
+			packID: {{Name: "app_name", Value: cty.StringVal("test")}},
+		}
+		registry.Register(NewBaseSource("test", PriorityFile, vars))
 
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+		cancel() // Cancel immediately
 
-		_, err := registry.Resolve(ctx, pack.ID("test"))
-		must.Error(t, err)
+		_, err := registry.Resolve(ctx, packID, schema)
+		must.ErrorContains(t, err, "context canceled")
 	})
 }

--- a/internal/pkg/variable/source/source.go
+++ b/internal/pkg/variable/source/source.go
@@ -13,20 +13,23 @@ import (
 // Priority constants define the precedence order for variable sources.
 // Higher values take precedence over lower values when variables conflict.
 //
-// Priority Order (lowest to highest):
-//   - Environment variables (10)
-//   - Variable files (20)
-//   - Nomad Variables (23)
-//   - Vault KV (24)
-//   - Consul KV (25)
-//   - CLI flags (30)
+// Precedence order (lowest to highest):
+//   - Pack defaults
+//   - External sources (--var-source), in command-line order
+//   - Environment variables
+//   - Variable files (-f/--var-file)
+//   - CLI flags (--var)
+//
+// External sources rank below all local input: anything passed with --var,
+// --var-file, or the environment overrides a value read from Consul, Vault, or
+// Nomad. Each external source is assigned PriorityExternalBase plus its position
+// on the command line, so when two sources supply the same variable the one
+// given later wins.
 const (
-	PriorityEnv    = 10
-	PriorityFile   = 20
-	PriorityNomad  = 23
-	PriorityVault  = 24
-	PriorityConsul = 25
-	PriorityCLI    = 30
+	PriorityExternalBase = 10
+	PriorityEnv          = 1000
+	PriorityFile         = 2000
+	PriorityCLI          = 3000
 )
 
 // VariableSource represents a source of variables (CLI, file, env, external)

--- a/internal/pkg/variable/source/source.go
+++ b/internal/pkg/variable/source/source.go
@@ -10,6 +10,25 @@ import (
 	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
 )
 
+// Priority constants define the precedence order for variable sources.
+// Higher values take precedence over lower values when variables conflict.
+//
+// Priority Order (lowest to highest):
+//   - Environment variables (10)
+//   - Variable files (20)
+//   - Nomad Variables (23)
+//   - Vault KV (24)
+//   - Consul KV (25)
+//   - CLI flags (30)
+const (
+	PriorityEnv    = 10
+	PriorityFile   = 20
+	PriorityNomad  = 23
+	PriorityVault  = 24
+	PriorityConsul = 25
+	PriorityCLI    = 30
+)
+
 // VariableSource represents a source of variables (CLI, file, env, external)
 type VariableSource interface {
 	// Name returns the unique identifier for this source
@@ -18,6 +37,7 @@ type VariableSource interface {
 	// Priority returns the precedence level (higher = higher priority)
 	Priority() int
 
-	// Fetch retrieves variables for the given pack
-	Fetch(ctx context.Context, packID pack.ID) ([]*variables.Variable, error)
+	// Fetch retrieves variables for the given pack.
+	// If a variable is not in the schema, it will be skipped (not returned).
+	Fetch(ctx context.Context, packID pack.ID, schema map[variables.ID]*variables.Variable) ([]*variables.Variable, error)
 }

--- a/internal/pkg/variable/source/vault_source.go
+++ b/internal/pkg/variable/source/vault_source.go
@@ -16,9 +16,7 @@ import (
 )
 
 // VaultSource fetches variables from a Vault KV v2 secret. All variables for a
-// pack are stored as fields of a single secret at <mount>/<path>. Callers
-// include any per-pack namespacing in the path themselves
-// (for example, mount="secret", path="myapp/config").
+// pack are stored as fields of a single secret at <mount>/<path> (for example, mount="secret", path="myapp/config").
 type VaultSource struct {
 	name     string
 	priority int

--- a/internal/pkg/variable/source/vault_source.go
+++ b/internal/pkg/variable/source/vault_source.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/zclconf/go-cty/cty"
-	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 // VaultSource fetches variables from a Vault KV v2 secret. All variables for a
@@ -122,7 +121,7 @@ func (v *VaultSource) Fetch(ctx context.Context, _ pack.ID, schema map[variables
 			expectedType = schemaVar.Type
 		}
 
-		value, err := v.convertValue([]byte(str), expectedType)
+		value, err := decodeValue("Vault", []byte(str), expectedType)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert value for %s: %w", rawKey, err)
 		}
@@ -135,20 +134,4 @@ func (v *VaultSource) Fetch(ctx context.Context, _ pack.ID, schema map[variables
 	}
 
 	return vars, nil
-}
-
-// convertValue converts a raw Vault string value into a cty.Value of the
-// expected type.
-func (v *VaultSource) convertValue(data []byte, expectedType cty.Type) (cty.Value, error) {
-	if expectedType == cty.String {
-		return cty.StringVal(string(data)), nil
-	}
-
-	// For every other type, let cty decode the JSON directly into the expected type.
-	val, err := ctyjson.Unmarshal(data, expectedType)
-	if err != nil {
-		return cty.NilVal, fmt.Errorf("decoding Vault value as %s: %w", expectedType.FriendlyName(), err)
-	}
-
-	return val, nil
 }

--- a/internal/pkg/variable/source/vault_source.go
+++ b/internal/pkg/variable/source/vault_source.go
@@ -1,0 +1,154 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/nomad-pack/sdk/pack"
+	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+// VaultSource fetches variables from a Vault KV v2 secret. All variables for a
+// pack are stored as fields of a single secret at <mount>/<path>. Callers
+// include any per-pack namespacing in the path themselves
+// (for example, mount="secret", path="myapp/config").
+type VaultSource struct {
+	name     string
+	priority int
+	client   *vaultapi.Client
+	mount    string // KV v2 mount point, e.g. "secret"
+	path     string // secret path within the mount, e.g. "myapp/config"
+}
+
+// NewVaultSource creates a new Vault KV v2 variable source.
+// config can be nil to use the default Vault configuration
+// (reads VAULT_ADDR and VAULT_TOKEN from the environment).
+// mount is the KV v2 engine mount point; path is the secret path within it.
+func NewVaultSource(priority int, config *vaultapi.Config, mount, path string) (*VaultSource, error) {
+	mount = strings.Trim(mount, "/")
+	if mount == "" {
+		return nil, fmt.Errorf("vault source requires a non-empty mount point")
+	}
+
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return nil, fmt.Errorf("vault source requires a non-empty secret path")
+	}
+
+	if config == nil {
+		config = vaultapi.DefaultConfig()
+	}
+
+	client, err := vaultapi.NewClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Vault client: %w", err)
+	}
+
+	name := fmt.Sprintf("vault(%s/%s/%s)", config.Address, mount, path)
+
+	return &VaultSource{
+		name:     name,
+		priority: priority,
+		client:   client,
+		mount:    mount,
+		path:     path,
+	}, nil
+}
+
+// Name returns the unique identifier for this source.
+func (v *VaultSource) Name() string {
+	return v.name
+}
+
+// Priority returns the precedence level (higher = higher priority).
+func (v *VaultSource) Priority() int {
+	return v.priority
+}
+
+// Fetch reads the Vault KV v2 secret at <mount>/<path> and returns variables
+// whose names appear in schema. Values are decoded using the schema type —
+// string fields are returned as-is; all other types are JSON-decoded.
+//
+// Each field of the secret maps to one pack variable. Fields not present in
+// the schema are silently skipped. An empty value for a non-string variable
+// is an error; empty strings are valid for string variables.
+//
+// Returns nil (not an error) when the secret does not exist at the given path
+// or when the latest version has been deleted.
+func (v *VaultSource) Fetch(ctx context.Context, _ pack.ID, schema map[variables.ID]*variables.Variable) ([]*variables.Variable, error) {
+	secret, err := v.client.KVv2(v.mount).Get(ctx, v.path)
+	if err != nil {
+		if errors.Is(err, vaultapi.ErrSecretNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read Vault secret at %s/%s: %w", v.mount, v.path, err)
+	}
+
+	// A deleted secret has nil Data.
+	if secret.Data == nil {
+		return nil, nil
+	}
+
+	vars := make([]*variables.Variable, 0, len(secret.Data))
+	for rawKey, rawVal := range secret.Data {
+		schemaVar, inSchema := schema[variables.ID(rawKey)]
+		if !inSchema {
+			continue
+		}
+
+		// Vault KV stores all values as strings.
+		str, ok := rawVal.(string)
+		if !ok {
+			return nil, fmt.Errorf("field %s is not a string (got %T)", rawKey, rawVal)
+		}
+
+		// Empty values for string variables are valid and kept as "".
+		if str == "" && schemaVar.Type != cty.String {
+			return nil, fmt.Errorf("empty Vault value for %s: a %s value is required", rawKey, schemaVar.Type.FriendlyName())
+		}
+
+		// Convert using the variable's constraint type. ConstraintType preserves
+		// optional() attributes.
+		expectedType := schemaVar.ConstraintType
+		if expectedType == cty.NilType {
+			expectedType = schemaVar.Type
+		}
+
+		value, err := v.convertValue([]byte(str), expectedType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert value for %s: %w", rawKey, err)
+		}
+
+		vars = append(vars, &variables.Variable{
+			Name:  variables.ID(rawKey),
+			Value: value,
+			Type:  value.Type(),
+		})
+	}
+
+	return vars, nil
+}
+
+// convertValue converts a raw Vault string value into a cty.Value of the
+// expected type.
+func (v *VaultSource) convertValue(data []byte, expectedType cty.Type) (cty.Value, error) {
+	if expectedType == cty.String {
+		return cty.StringVal(string(data)), nil
+	}
+
+	// For every other type, let cty decode the JSON directly into the expected type.
+	val, err := ctyjson.Unmarshal(data, expectedType)
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("decoding Vault value as %s: %w", expectedType.FriendlyName(), err)
+	}
+
+	return val, nil
+}

--- a/internal/pkg/variable/source/vault_source_integration_test.go
+++ b/internal/pkg/variable/source/vault_source_integration_test.go
@@ -1,0 +1,270 @@
+// Copyright IBM Corp. 2023, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad-pack/sdk/pack"
+	"github.com/hashicorp/nomad-pack/sdk/pack/variables"
+	"github.com/hashicorp/nomad/ci"
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/shoenig/test/must"
+	"github.com/zclconf/go-cty/cty"
+)
+
+const devRootToken = "root"
+
+func startTestVault(t *testing.T) string {
+	t.Helper()
+
+	port := ci.PortAllocator.One()
+	listen := fmt.Sprintf("127.0.0.1:%d", port)
+	addr := "http://" + listen
+
+	cmd := exec.Command("vault", "server", "-dev",
+		"-dev-root-token-id="+devRootToken,
+		"-dev-listen-address="+listen,
+	)
+	if !testing.Verbose() {
+		cmd.Stdout = io.Discard
+		cmd.Stderr = io.Discard
+	}
+	must.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	waitForVault(t, addr)
+	return addr
+}
+
+func waitForVault(t *testing.T, addr string) {
+	t.Helper()
+
+	cfg := vaultapi.DefaultConfig()
+	cfg.Address = addr
+	client, err := vaultapi.NewClient(cfg)
+	must.NoError(t, err)
+
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		health, err := client.Sys().Health()
+		if err == nil && health.Initialized && !health.Sealed {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatal("vault dev server did not become ready within 20s")
+}
+
+func newVaultClient(t *testing.T, addr string) *vaultapi.Client {
+	t.Helper()
+	cfg := vaultapi.DefaultConfig()
+	cfg.Address = addr
+	client, err := vaultapi.NewClient(cfg)
+	must.NoError(t, err)
+	client.SetToken(devRootToken)
+	return client
+}
+
+func writeSecret(t *testing.T, client *vaultapi.Client, path string, data map[string]any) {
+	t.Helper()
+	_, err := client.KVv2("secret").Put(t.Context(), path, data)
+	must.NoError(t, err)
+}
+
+func newVaultSourceForServer(t *testing.T, addr, mount, path string) *VaultSource {
+	t.Helper()
+	cfg := vaultapi.DefaultConfig()
+	cfg.Address = addr
+	src, err := NewVaultSource(PriorityVault, cfg, mount, path)
+	must.NoError(t, err)
+	src.client.SetToken(devRootToken)
+	return src
+}
+
+func vaultVarsByName(vars []*variables.Variable) map[string]*variables.Variable {
+	out := make(map[string]*variables.Variable, len(vars))
+	for _, v := range vars {
+		out[string(v.Name)] = v
+	}
+	return out
+}
+
+func TestVaultSource_Fetch(t *testing.T) {
+	ci.Parallel(t)
+
+	addr := startTestVault(t)
+	client := newVaultClient(t, addr)
+
+	packID := pack.ID("webapp")
+	schema := map[variables.ID]*variables.Variable{
+		"replicas": {Name: "replicas", Type: cty.Number},
+		"region":   {Name: "region", Type: cty.String},
+		"name":     {Name: "name", Type: cty.String},
+	}
+
+	t.Run("fetches typed variables from secret", func(t *testing.T) {
+		writeSecret(t, client, "deploy/webapp", map[string]any{
+			"replicas": "3",
+			"region":   "us-west-2",
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "deploy/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 2, vars)
+
+		got := vaultVarsByName(vars)
+		replicas, _ := got["replicas"].Value.AsBigFloat().Int64()
+		must.Eq(t, int64(3), replicas)
+		must.Eq(t, "us-west-2", got["region"].Value.AsString())
+	})
+
+	t.Run("fields not in pack schema are ignored", func(t *testing.T) {
+		writeSecret(t, client, "staging/webapp", map[string]any{
+			"region":      "us-east-1",
+			"not_in_pack": "ignored",
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "staging/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "region", string(vars[0].Name))
+	})
+
+	t.Run("empty value for non-string variable is an error", func(t *testing.T) {
+		writeSecret(t, client, "prod/webapp", map[string]any{
+			"replicas": "",
+			"region":   "us-west-1",
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "prod/webapp")
+		_, err := src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "empty Vault value")
+	})
+
+	t.Run("object with optional field missing is valid", func(t *testing.T) {
+		objSchema := map[variables.ID]*variables.Variable{
+			"svc": {
+				Name: "svc",
+				Type: cty.Object(map[string]cty.Type{
+					"name": cty.String,
+					"port": cty.Number,
+				}),
+				ConstraintType: cty.ObjectWithOptionalAttrs(
+					map[string]cty.Type{"name": cty.String, "port": cty.Number},
+					[]string{"port"},
+				),
+			},
+		}
+		writeSecret(t, client, "services/webapp", map[string]any{
+			"svc": `{"name":"api"}`,
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "services/webapp")
+		vars, err := src.Fetch(t.Context(), packID, objSchema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "api", vars[0].Value.GetAttr("name").AsString())
+		must.True(t, vars[0].Value.GetAttr("port").IsNull())
+	})
+
+	t.Run("bool variable is decoded from JSON", func(t *testing.T) {
+		boolSchema := map[variables.ID]*variables.Variable{
+			"enabled": {Name: "enabled", Type: cty.Bool},
+		}
+		writeSecret(t, client, "config/webapp", map[string]any{
+			"enabled": "true",
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "config/webapp")
+		vars, err := src.Fetch(t.Context(), packID, boolSchema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.True(t, vars[0].Value.True())
+	})
+
+	t.Run("malformed JSON for non-string variable is an error", func(t *testing.T) {
+		writeSecret(t, client, "broken/webapp", map[string]any{
+			"replicas": "not-a-number",
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "broken/webapp")
+		_, err := src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "decoding Vault value")
+	})
+
+	t.Run("empty string value is kept for string variable", func(t *testing.T) {
+		writeSecret(t, client, "defaults/webapp", map[string]any{
+			"name": "",
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "defaults/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "", vars[0].Value.AsString())
+	})
+
+	t.Run("secret not found returns empty result", func(t *testing.T) {
+		src := newVaultSourceForServer(t, addr, "secret", "empty/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 0, vars)
+	})
+
+	t.Run("non-string field value is an error", func(t *testing.T) {
+		// replicas is stored as a JSON number rather than a string.
+		writeSecret(t, client, "typed/webapp", map[string]any{
+			"replicas": 3,
+		})
+
+		src := newVaultSourceForServer(t, addr, "secret", "typed/webapp")
+		_, err := src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "is not a string")
+	})
+
+	t.Run("deleted secret returns empty result", func(t *testing.T) {
+		writeSecret(t, client, "deleted/webapp", map[string]any{
+			"region": "us-west-2",
+		})
+		must.NoError(t, client.KVv2("secret").Delete(t.Context(), "deleted/webapp"))
+
+		src := newVaultSourceForServer(t, addr, "secret", "deleted/webapp")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 0, vars)
+	})
+
+	t.Run("vault unavailable returns read error", func(t *testing.T) {
+		cfg := vaultapi.DefaultConfig()
+		cfg.Address = fmt.Sprintf("http://127.0.0.1:%d", ci.PortAllocator.One())
+		src, err := NewVaultSource(PriorityVault, cfg, "secret", "any/path")
+		must.NoError(t, err)
+		src.client.SetToken(devRootToken)
+
+		_, err = src.Fetch(t.Context(), packID, schema)
+		must.ErrorContains(t, err, "failed to read Vault secret")
+	})
+
+	t.Run("mount and path with surrounding slashes fetch correctly", func(t *testing.T) {
+		writeSecret(t, client, "norm/webapp", map[string]any{
+			"region": "ap-southeast-1",
+		})
+
+		src := newVaultSourceForServer(t, addr, "/secret/", "/norm/webapp/")
+		vars, err := src.Fetch(t.Context(), packID, schema)
+		must.NoError(t, err)
+		must.Len(t, 1, vars)
+		must.Eq(t, "ap-southeast-1", vaultVarsByName(vars)["region"].Value.AsString())
+	})
+}

--- a/internal/pkg/variable/source/vault_source_integration_test.go
+++ b/internal/pkg/variable/source/vault_source_integration_test.go
@@ -84,7 +84,7 @@ func newVaultSourceForServer(t *testing.T, addr, mount, path string) *VaultSourc
 	t.Helper()
 	cfg := vaultapi.DefaultConfig()
 	cfg.Address = addr
-	src, err := NewVaultSource(PriorityVault, cfg, mount, path)
+	src, err := NewVaultSource(PriorityExternalBase, cfg, mount, path)
 	must.NoError(t, err)
 	src.client.SetToken(devRootToken)
 	return src
@@ -248,7 +248,7 @@ func TestVaultSource_Fetch(t *testing.T) {
 	t.Run("vault unavailable returns read error", func(t *testing.T) {
 		cfg := vaultapi.DefaultConfig()
 		cfg.Address = fmt.Sprintf("http://127.0.0.1:%d", ci.PortAllocator.One())
-		src, err := NewVaultSource(PriorityVault, cfg, "secret", "any/path")
+		src, err := NewVaultSource(PriorityExternalBase, cfg, "secret", "any/path")
 		must.NoError(t, err)
 		src.client.SetToken(devRootToken)
 


### PR DESCRIPTION
**Description**

This PR implements Issue https://github.com/hashicorp/nomad-pack/issues/473 (External Variable Sources for nomad-pack). It adds support for fetching pack variables from Consul, Vault and Nomad Variables along with the integration tests coverage

# E2E Testing:

1) The system support multiple variable sources simultaneously within a single execution (e.g., CLI + Consul KV + Nomad Variables + Vault).

<details><summary>Multiple sources in a single execution (CLI + Consul + Vault + Nomad)</summary>

```bash
consul kv put multisrc/from_consul from-consul
vault kv put secret/multisrc from_vault=from-vault
nomad var put -force multisrc from_nomad=from-nomad

nomad-pack render multisrc \
  --var from_cli=from-cli \
  --var-source consul:///multisrc \
  --var-source vault:///secret/multisrc \
  --var-source nomad:///multisrc
```

```hcl
job "multisrc" {
  meta {
    from_cli    = "from-cli"
    from_consul = "from-consul"
    from_vault  = "from-vault"
    from_nomad  = "from-nomad"
  }
}
```
</details>

2) Variable resolution performed through a single unified resolution flow, not separate per-source implementations.

<details><summary>Single unified resolution flow (same command, only the scheme changes)</summary>

```bash
nomad-pack render multisrc --var-source consul:///multisrc
nomad-pack render multisrc --var-source vault:///secret/multisrc
nomad-pack render multisrc --var-source nomad:///multisrc
```

```hcl
from_consul = "from-consul"  from_vault = "DEFAULT"      from_nomad = "DEFAULT"
from_consul = "DEFAULT"      from_vault = "from-vault"   from_nomad = "DEFAULT"
from_consul = "DEFAULT"      from_vault = "DEFAULT"      from_nomad = "from-nomad"
```
</details>

3) If a variable exists in multiple sources:
The defined precedence rules apply consistently across all sources.

<details><summary>Precedence applied consistently (Consul > Vault > Nomad)</summary>

```bash
consul kv put multisrc/shared shared-from-consul
vault  kv put secret/multisrc shared=shared-from-vault
nomad var put -force multisrc shared=shared-from-nomad

nomad-pack render multisrc --var-source consul:///multisrc --var-source vault:///secret/multisrc --var-source nomad:///multisrc | grep shared
```
```
shared = "shared-from-consul"
```
```bash
consul kv delete multisrc/shared
```
```
shared = "shared-from-vault"
```
```bash
vault kv delete secret/multisrc
```
```
shared = "shared-from-nomad"
```
</details>



**Reminders**

- [x] Add `CHANGELOG.md` entry


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

