### PR TITLE
CI: group dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,6 +12,11 @@ updates:
       time: "09:00"
     labels:
       - "theme/dependencies"
+    groups:
+      go:
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
     directory: /
     labels:
@@ -21,3 +26,7 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "09:00"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Ref: https://hashicorp.atlassian.net/browse/NMD-1586

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

